### PR TITLE
fix: add base branch to PR creation for detached HEAD state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
 
             This PR was automatically created by the release workflow.
           branch: changelog-${{ steps.changelog.outputs.version }}
+          base: main
           delete-branch: true
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: |

--- a/template/.github/workflows/release.yml.jinja
+++ b/template/.github/workflows/release.yml.jinja
@@ -58,6 +58,7 @@ jobs:
 
             This PR was automatically created by the release workflow.
           branch: changelog-{% raw %}${{ steps.changelog.outputs.version }}{% endraw %}
+          base: main
           delete-branch: true
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: |


### PR DESCRIPTION
## Description

Fixes the release workflow failure caused by running in detached HEAD state when triggered by tag pushes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When a tag is pushed (e.g., `v0.2.0`), the workflow checks out that specific tag, putting Git in a detached HEAD state. The `peter-evans/create-pull-request` action failed with:

```
Error: When the repository is checked out on a commit instead of a branch, 
the 'base' input must be supplied.
```

## Changes Made

Added `base: main` parameter to the `Create Pull Request for CHANGELOG` step in:
- `.github/workflows/release.yml` - Template repository workflow
- `template/.github/workflows/release.yml.jinja` - Generated projects workflow

This explicitly tells the action to create the PR targeting the `main` branch, even when running from a tag checkout.

## How Has This Been Tested?

- [x] Workflow syntax validated
- [x] Pre-commit hooks pass
- [x] Changes applied to both template repo and generated project workflows
- [ ] Will be validated when tag is pushed again after PR merge

## Checklist

- [x] My code follows the code style of this project
- [x] Changes applied to both template and generated project workflows
- [x] All new and existing tests passed

## Additional Notes

This is a continuation of the fix from PR #8. Together they ensure:
1. PR #8: CHANGELOG updates respect branch protection rules
2. This PR: Workflow works correctly when triggered by tags

After merging, the release workflow will successfully create PRs for CHANGELOG updates when tags are pushed.