### PR TITLE
fix: use PAT token for release workflow PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
@@ -45,7 +45,7 @@ jobs:
       - name: Create Pull Request for CHANGELOG
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           commit-message: "chore(release): update CHANGELOG.md for ${{ steps.changelog.outputs.version }}"
           title: "chore(release): update CHANGELOG.md for ${{ steps.changelog.outputs.version }}"
           body: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,6 +114,28 @@ The pre-commit hook will validate your commit messages automatically.
 
 Releases are automated via GitHub Actions. Here's how it works:
 
+### Initial Setup (One-time)
+
+Before you can create releases, you need to set up a Personal Access Token:
+
+1. **Create a Fine-grained Personal Access Token**:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+   - Click "Generate new token"
+   - Configure:
+     - **Token name**: `RELEASE_AUTOMATION_TOKEN`
+     - **Expiration**: 90 days or longer
+     - **Repository access**: Only select repositories → Choose this repository
+     - **Permissions**:
+       - Contents: Read and write
+       - Pull requests: Read and write
+       - Workflows: Read and write
+
+2. **Add token as repository secret**:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `PAT_TOKEN`
+   - Value: Paste your generated token
+
 ### Creating a Release
 
 1. **Ensure all changes follow conventional commits** - The changelog is auto-generated from commit messages

--- a/template/.github/workflows/release.yml.jinja
+++ b/template/.github/workflows/release.yml.jinja
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          token: {% raw %}${{ secrets.PAT_TOKEN }}{% endraw %}
 
       - name: Install git-cliff
         uses: taiki-e/install-action@v2
@@ -48,7 +48,7 @@ jobs:
       - name: Create Pull Request for CHANGELOG
         uses: peter-evans/create-pull-request@v7
         with:
-          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          token: {% raw %}${{ secrets.PAT_TOKEN }}{% endraw %}
           commit-message: "chore(release): update CHANGELOG.md for {% raw %}${{ steps.changelog.outputs.version }}{% endraw %}"
           title: "chore(release): update CHANGELOG.md for {% raw %}${{ steps.changelog.outputs.version }}{% endraw %}"
           body: |

--- a/template/docs/contributing.md.jinja
+++ b/template/docs/contributing.md.jinja
@@ -206,6 +206,28 @@ The pre-commit hook will validate your commit messages and prevent commits that 
 
 Releases are fully automated through GitHub Actions when a new tag is pushed.
 
+### Initial Setup (One-time)
+
+Before you can create releases, you need to set up a Personal Access Token:
+
+1. **Create a Fine-grained Personal Access Token**:
+   - Go to GitHub Settings → Developer settings → Personal access tokens → Fine-grained tokens
+   - Click "Generate new token"
+   - Configure:
+     - **Token name**: `RELEASE_AUTOMATION_TOKEN`
+     - **Expiration**: 90 days or longer
+     - **Repository access**: Only select repositories → Choose this repository
+     - **Permissions**:
+       - Contents: Read and write
+       - Pull requests: Read and write
+       - Workflows: Read and write
+
+2. **Add token as repository secret**:
+   - Go to repository Settings → Secrets and variables → Actions
+   - Click "New repository secret"
+   - Name: `PAT_TOKEN`
+   - Value: Paste your generated token
+
 ### How It Works
 
 1. **Tag a release:**


### PR DESCRIPTION
## Description

Fixes the release workflow by using a Personal Access Token (PAT) instead of the default `GITHUB_TOKEN` for creating pull requests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

The release workflow failed with:
```
Error: GitHub Actions is not permitted to create or approve pull requests.
```

GitHub's default `GITHUB_TOKEN` has limitations:
- Cannot create PRs that trigger other workflows
- Cannot bypass branch protection rules requiring PR reviews

## Changes Made

### Workflows: Replace GITHUB_TOKEN with PAT_TOKEN
- `.github/workflows/release.yml`
- `template/.github/workflows/release.yml.jinja`

### Documentation: Added PAT setup instructions
- `docs/contributing.md`
- `template/docs/contributing.md.jinja`

## Setup Required After Merge

1. Create Fine-grained PAT with Contents (R/W), Pull requests (R/W), Workflows (R/W)
2. Add as repository secret named `PAT_TOKEN`

## Additional Notes

This completes the series of release workflow fixes (PRs #6, #8, #9, and this one).