### PR TITLE
fix: Remove license classifier from template

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -14,10 +14,8 @@ requires-python = ">={{ python_version }}"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: {{ license.replace('-', ' ') }} License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: {{ python_version }}",
-
 ]
 dependencies = [
 


### PR DESCRIPTION
Remove license classifier from pyproject.toml.jinja

## Description

Classifiers in `pyproject.toml.jinja` cause install failure.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have updated the CHANGELOG.md with my changes
- [ ] My changes generate no new warnings
- [ ] I have checked that my changes don't break the template generation
