### PR TITLE
Exclude _version.py from ruff and coverage reports

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -62,6 +62,7 @@ line-length = 120
 target-version = "py{{ python_version.replace('.', '') }}"
 src = ["src", "tests"]
 show-fixes = true
+exclude = ["src/{{ package_name }}/_version.py"]
 
 [tool.ruff.format]
 preview = true
@@ -127,6 +128,7 @@ plugins = ["covdefaults"]
 omit = [
     "*/tests/*",
     "*/__pycache__/*",
+    "*/_version.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Description

`_version.py` is automatically created by hatchling and should not be covered by test or linted/formatted.