### PR TITLE
feat: add PR title validation and improve git-cliff configuration

### DIFF
--- a/.git-cliff.toml
+++ b/.git-cliff.toml
@@ -78,7 +78,7 @@ commit_parsers = [
   { message = "^refactor", group = "<!-- 4 -->Refactoring" },
   { message = "^style", group = "<!-- 5 -->Styling" },
   { message = "^test", group = "<!-- 6 -->Testing" },
-  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,46 @@
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title follows conventional commit format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (must match git-cliff config)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Require a scope for certain types (optional)
+          requireScope: false
+          # Validate the subject is not empty
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # Validate the entire PR title (not just the subject)
+          validateSingleCommit: false
+          # Ignore merge commits
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -33,7 +33,9 @@ my-package/
 │   │   └── config.yml
 │   ├── workflows/
 │   │   ├── tests.yml
-│   │   ├── release.yml
+│   │   ├── pr-title.yml
+│   │   ├── changelog.yml
+│   │   ├── publish-release.yml
 │   │   └── nightly.yml
 │   ├── dependabot.yml
 │   └── pull_request_template.md
@@ -75,6 +77,14 @@ Runs on every push and pull request:
 - Matrix of 15 combinations
 - **Uploads coverage to Codecov** (requires `CODECOV_TOKEN` secret)
 - **Uploads test results to Codecov**
+
+### pr-title.yml - Pull Request Title Validation
+
+Runs on pull requests to main:
+- Validates PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
+- Required types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- Ensures consistency with changelog generation (git-cliff)
+- Helps maintain clean commit history
 
 ### changelog.yml - Automated Changelog
 

--- a/template/.git-cliff.toml.jinja
+++ b/template/.git-cliff.toml.jinja
@@ -78,7 +78,7 @@ commit_parsers = [
   { message = "^refactor", group = "<!-- 4 -->Refactoring" },
   { message = "^style", group = "<!-- 5 -->Styling" },
   { message = "^test", group = "<!-- 6 -->Testing" },
-  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(release\\)", skip = true },
   { message = "^chore\\(deps.*\\)", skip = true },
   { message = "^chore\\(pr\\)", skip = true },
   { message = "^chore\\(pull\\)", skip = true },

--- a/template/.github/workflows/pr-title.yml.jinja
+++ b/template/.github/workflows/pr-title.yml.jinja
@@ -1,0 +1,47 @@
+{% if include_github_actions %}name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  validate-pr-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title follows conventional commit format
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        with:
+          # Configure which types are allowed (must match git-cliff config)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Require a scope for certain types (optional)
+          requireScope: false
+          # Validate the subject is not empty
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # Validate the entire PR title (not just the subject)
+          validateSingleCommit: false
+          # Ignore merge commits
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+{% endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -167,6 +167,16 @@ def test_github_workflows(copie):
     # Check for ty
     assert "ty" in content, "ty not found in tests workflow"
 
+    # Check PR title validation workflow
+    pr_title_workflow = result.project_dir / ".github" / "workflows" / "pr-title.yml"
+    assert pr_title_workflow.is_file(), "PR title validation workflow not found"
+
+    pr_title_content = pr_title_workflow.read_text()
+    assert "amannn/action-semantic-pull-request" in pr_title_content
+    assert "feat" in pr_title_content
+    assert "fix" in pr_title_content
+    assert "docs" in pr_title_content
+
 
 def test_release_workflow(copie):
     """Test that release workflow includes changelog automation."""
@@ -224,6 +234,11 @@ def test_git_cliff_configuration(copie):
 
     # Check for Keep a Changelog format
     assert "Keep a Changelog" in content, "Keep a Changelog format not mentioned"
+
+    # Check that chore(release) commits are skipped
+    assert 'message = "^chore\\\\(release\\\\)", skip = true' in content, (
+        "chore(release) commits should be skipped in changelog"
+    )
 
 
 def test_different_licenses(copie):


### PR DESCRIPTION
## Description

This PR adds automated PR title validation and improves the git-cliff configuration to better handle release commits. The changes ensure that all PRs to main follow conventional commit syntax and that release-related commits are properly excluded from changelogs.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

To maintain code quality and consistency, we need to enforce conventional commit syntax on PR titles. This ensures that:
1. All merged PRs follow the same format (feat:, fix:, docs:, etc.)
2. Changelogs can be automatically generated from commit history
3. The commit history remains clean and semantic

Additionally, the git-cliff configuration needed improvement to exclude ALL `chore(release)` commits, not just those with "prepare for" in the message.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

**Test results:**
- All 12 tests pass successfully
- Verified PR title workflow is generated in both root and template
- Verified git-cliff configuration correctly skips `chore(release)` commits
- Tested generated project includes the new workflow file

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have updated the CHANGELOG.md with my changes
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Screenshots (if applicable)

N/A - Workflow and configuration changes

## Additional Notes

**Changes include:**

1. **PR Title Validation Workflow** (`.github/workflows/pr-title.yml` and `template/.github/workflows/pr-title.yml.jinja`)
   - Uses `amannn/action-semantic-pull-request@v5`
   - Validates PR titles follow conventional commit format
   - Supported types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
   - Requires non-empty subject
   - Can be bypassed with `bot` or `ignore-semantic-pull-request` labels

2. **Git-cliff Configuration Update** (`.git-cliff.toml` line 81 and `template/.git-cliff.toml.jinja`)
   - Changed from: `{ message = "^chore\\(release\\): prepare for", skip = true }`
   - Changed to: `{ message = "^chore\\(release\\)", skip = true }`
   - Now skips ALL `chore(release)` commits in changelog generation

3. **Test Coverage**
   - Updated `tests/test_template.py` to verify PR title workflow creation
   - Added assertion to verify git-cliff skips `chore(release)` commits

4. **Documentation**
   - Updated `docs/reference.md` with PR title validation workflow information