### PR TITLE
feat: add manual approval notification step for PyPI publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,11 +99,11 @@ This **minor release** includes 7 commits.
 ### Miscellaneous Tasks
 - Standardize test command naming across nox, justfile, and CI  ([#55](https://github.com/stateful-y/python-package-copier/pull/55)) by @gtauzin
 
-### Contributors
+`### Contributors
 
 Thanks to all contributors for this release:
 - @gtauzin
-
+`
 ## [0.6.0] - 2026-02-03
 
 This **minor release** includes 4 commits.

--- a/docs/pages/reference.md
+++ b/docs/pages/reference.md
@@ -130,6 +130,24 @@ graph LR
 
 **Required environment protection**: `pypi` environment with required reviewers configured
 
+#### Configuring Manual Approval for PyPI
+
+To enable the manual approval gate before PyPI publishing, configure GitHub environment protection rules:
+
+1. Navigate to repository **Settings → Environments**
+2. Create or select the `pypi` environment
+3. Enable **Required reviewers** under *Deployment protection rules*
+4. Add one or more reviewers who must approve before PyPI publication
+5. (Optional) Enable **Wait timer** to delay deployment after approval
+
+When a release is ready:
+- The workflow will pause at the "Wait for approval" step
+- Designated reviewers receive a notification
+- Reviewers can inspect the GitHub Release and artifacts before approving
+- Once approved, the package is automatically published to PyPI
+
+**Note**: Environment protection rules require **public repositories** or **GitHub Pro/Team/Enterprise** plans.
+
 ### tests.yml - Continuous Integration
 
 Runs on every push and pull request:

--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -26,9 +26,9 @@ jobs:
       - name: Find release tag
         id: find_tag
         run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0")
+          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
           PR_TITLE="{% raw %}${{ github.event.pull_request.title }}{% endraw %}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"

--- a/template/CHANGELOG.md.jinja
+++ b/template/CHANGELOG.md.jinja
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-This file is automatically updated by git-cliff when releases are created.
-
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
## Description

Enhances PyPI publishing workflow with explicit manual approval notification step and comprehensive documentation for configuring GitHub environment protection rules.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Improves visibility and control over PyPI releases by adding a clear notification step that informs users when manual approval is required. Also provides complete setup instructions for configuring required reviewers in GitHub environment settings.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [ ] Tested template generation with `copier copy . /tmp/test-project`
- [ ] Verified generated project works as expected
- [ ] Added/updated tests
- [x] All tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation