### PR TITLE
fix: resolve Copier template variable escaping in git-cliff and issue templates

### DIFF
--- a/template/.git-cliff.toml.jinja
+++ b/template/.git-cliff.toml.jinja
@@ -33,10 +33,10 @@ This **{{ release_type }} release** includes {{ commits | length }} commit{%- if
 
 ### {{ group | striptags | trim | upper_first }}
 {%- for commit in commits %}
-- {{ commit.message | upper_first }}{%- if commit.github.pr_number %} ([#{{ commit.github.pr_number }}](https://github.com/{{ github_username }}/{{ project_slug }}/pull/{{ commit.github.pr_number }})){%- endif %}{%- if commit.github.username %} by @{{ commit.github.username }}{%- endif %}
+- {{ commit.message | upper_first }}{%- if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/{% endraw %}{{ github_username }}/{{ project_slug }}{% raw %}/pull/{{ commit.remote.pr_number }})){%- endif %}{%- if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}
 {%- endfor %}
 {%- endfor %}
-{%- set new_contributors = commits | filter(attribute="github.username") | map(attribute="github.username") | unique %}
+{%- set new_contributors = commits | filter(attribute="remote.username") | map(attribute="remote.username") | unique %}
 {%- if new_contributors | length > 0 %}
 
 ### Contributors

--- a/template/.github/ISSUE_TEMPLATE/config.yml.jinja
+++ b/template/.github/ISSUE_TEMPLATE/config.yml.jinja
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question or Discussion
-    url: https://github.com/{% raw %}{{ github_username }}/{{ package_name }}{% endraw %}/discussions
+    url: https://github.com/{{ github_username }}/{{ package_name }}/discussions
     about: Please use GitHub Discussions for questions and general discussions
   - name: Documentation
-    url: https://{% raw %}{{ github_username }}{% endraw %}.github.io/{% raw %}{{ package_name }}{% endraw %}/
+    url: https://{{ github_username }}.github.io/{{ package_name }}/
     about: Check the documentation for guides and API references

--- a/template/.github/ISSUE_TEMPLATE/feature_request.yml.jinja
+++ b/template/.github/ISSUE_TEMPLATE/feature_request.yml.jinja
@@ -28,7 +28,7 @@ body:
       description: Show how you'd like to use this feature (optional)
       render: python
       placeholder: |
-        from {% raw %}{{ package_name }}{% endraw %} import new_feature
+        from {{ package_name }} import new_feature
         result = new_feature()
 
   - type: textarea


### PR DESCRIPTION
## Description

Generated projects have unresolved Copier template variables (`{{ github_username }}`, `{{ project_slug }}`, `{{ package_name }}`) in their `.git-cliff.toml` and GitHub issue template files. This causes the changelog GitHub Action to fail with:

```
ERROR git_cliff > Template render error:
Variable `github_username` not found in context while rendering 'body'
```

Additionally, `commit.github` is deprecated in git-cliff and will be removed in a future version.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

When a project is generated from this Copier template and a tag is pushed, the changelog workflow fails because git-cliff encounters literal `{{ github_username }}` in its Tera template instead of the actual substituted value.

**Root cause:** The `{% raw %}` blocks in `.git-cliff.toml.jinja` (needed to protect git-cliff's Tera syntax from Copier) also prevent Copier from substituting its own variables (`github_username`, `project_slug`). Similarly, `config.yml.jinja` and `feature_request.yml.jinja` unnecessarily wrap Copier variables in `{% raw %}` blocks even though these files contain no Tera syntax.

### Files changed

1. **`template/.git-cliff.toml.jinja`**:
   - Break out of `{% raw %}` around `{{ github_username }}/{{ project_slug }}` so Copier substitutes them while keeping git-cliff's Tera syntax protected
   - Migrate deprecated `commit.github` → `commit.remote`

2. **`template/.github/ISSUE_TEMPLATE/config.yml.jinja`**:
   - Remove unnecessary `{% raw %}` blocks around Copier variables

3. **`template/.github/ISSUE_TEMPLATE/feature_request.yml.jinja`**:
   - Remove unnecessary `{% raw %}` block around `{{ package_name }}`

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] All new and existing tests passed
- [x] My changes generate no new warnings