### PR TITLE
fix(docs): update issue template config to point to ReadTheDocs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/stateful-y/python-package-copier/discussions
     about: Please use GitHub Discussions for questions and general discussions
   - name: Documentation
-    url: https://stateful-y.github.io/python-package-copier/
+    url: https://python-package-copier.readthedocs.io/
     about: Check the documentation for guides and references


### PR DESCRIPTION
## Description

Updates the issue template configuration to point the documentation link to ReadTheDocs instead of GitHub Pages, ensuring consistency with the project's documentation hosting.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The project uses ReadTheDocs for documentation hosting, but the issue template configuration was pointing to the GitHub Pages URL.

## How Has This Been Tested?

- [ ] Tested locally with `uv run pytest`
- [ ] Tested template generation with `copier copy . /tmp/test-project`
- [ ] Verified generated project works as expected
- [ ] Added/updated tests
- [ ] All tests pass
- [x] Manual verification of the URL update

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation