### PR TITLE
chore: gitignore openspec/ in generated projects

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -77,6 +77,9 @@ examples/__marimo__/
 # Ruff
 .ruff_cache/
 
+# OpenSpec (local working artifacts, not tracked)
+openspec/
+
 # build
 src/{{ package_name }}/_version.py
 


### PR DESCRIPTION
## Description

Generated projects gitignore `openspec/` so OpenSpec change bundles stay local working artifacts.

## Type of Change

- [x] Other (please describe): generated-project `.gitignore`

## Motivation and Context

OpenSpec bundles are local planning artifacts, not repo content. Ignoring them in the template keeps every generated (and `copier update`d) repo consistent. Follow-up to #128.

## How Has This Been Tested?

- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected

## Checklist

- [x] My code follows the code style of this project
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Applied to the two current generated repos (`kedro-dagster`, `kedro-azureml-pipeline`) in their respective PRs.
