### PR TITLE
feat(template): resolve and link API cross-references in generated docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
 ]
 tests = [
     "copier>=9.11",
+    # hooks tests drive on_page_content, and _process_api_page_content imports
+    # mkdocs.structure.toc, so mkdocs must be importable from the test env.
+    "mkdocs>=1.6",
     "pytest>=8.3",
     "pytest-cov>=7.0",
     "pytest-mock>=3.14",

--- a/template/.claude/skills/diataxis-notebook-writer/SKILL.md
+++ b/template/.claude/skills/diataxis-notebook-writer/SKILL.md
@@ -27,9 +27,31 @@ __gallery__ = {
     "title": "How to Stop Optimization Early with Callbacks",  # goal-oriented for how-to
     "description": "Stop unneeded work early by adding Optuna callbacks to your search.",
     "category": "how-to",  # "tutorial" or "how-to"
-    "companion": "pages/how-to/use-callbacks.md",  # optional: path to companion doc page
+    "companion": "pages/how-to/use-callbacks.md",  # optional: doc page this notebook accompanies
+    "api_references": ["OptunaSearchCV"],  # optional: symbols this notebook demonstrates
 }
 ```
+
+**`companion`** renders this notebook as a card on the named doc page. The page
+must contain the `<!-- COMPANION_NOTEBOOKS -->` placeholder where the cards
+should appear. Leading/trailing slashes and a `.md` suffix are all accepted.
+
+**`api_references`** controls which API pages list this notebook.
+
+- **Omit it** and the symbols are inferred from the notebook's imports. This is
+  the default and it always works, so a notebook is never invisible for lack of
+  metadata.
+- **Declare it** to say which symbols the notebook *demonstrates*, as opposed to
+  the ones it merely imports as scaffolding (a train/test split helper, a
+  plotting call). Inference cannot tell those apart, so declaring is more
+  precise — worth doing once a gallery grows enough that the widely used helpers
+  collect long, meaningless card lists.
+- **Declare it empty** (`"api_references": []`) to keep the notebook off every
+  API page. An empty list means "nowhere"; omitting the key means "infer".
+
+Names that resolve to nothing are ignored rather than failing the build. Each
+API page shows a bounded number of cards, with a link to the full gallery past
+that point.
 
 **Title conventions:**
 - Tutorial: descriptive noun phrase - "OptunaSearchCV Quickstart"

--- a/template/.claude/skills/update-from-template/SKILL.md
+++ b/template/.claude/skills/update-from-template/SKILL.md
@@ -106,11 +106,16 @@ Read [references/conflict-resolution.md](references/conflict-resolution.md) for 
 
 For each `.rej` file, determine the base file's tier from Step 2:
 
+**A `.rej` does NOT mean the file is untouched.** `git apply --reject` applies every hunk
+that applies cleanly and rejects only the rest, so a conflicted file is already *partially*
+updated. Deleting the `.rej` keeps those applied hunks — which is wrong for any tier that
+was supposed to reject them.
+
 | Tier | Action |
 |------|--------|
-| **Tier 1** (template-managed) | Read `.rej`, apply changes to local file (template wins). Delete `.rej`. |
-| **Tier 2** (merge-required) | Read both local file and `.rej`. Merge: accept template improvements, preserve local additions. Delete `.rej`. |
-| **Tier 3** (local-owned) | Delete `.rej` without applying. |
+| **Tier 1** (template-managed) | Read `.rej`, apply its hunks to the local file (template wins). Delete `.rej`. |
+| **Tier 2** (merge-required) | `git diff HEAD -- <file>` first, to see which hunks already landed. Then merge: accept template improvements, restore any local content those hunks removed. Delete `.rej`. |
+| **Tier 3** (local-owned) | `git checkout HEAD -- <file>` to undo the hunks that already applied, then `rm <file>.rej`. Deleting the `.rej` alone leaves the template's changes in a file the project owns. |
 
 #### 5b: Handle files modified without conflict
 

--- a/template/.claude/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.claude/skills/update-from-template/references/conflict-resolution.md
@@ -23,11 +23,17 @@ How to resolve conflicts produced by `copier update --conflict rej` for each fil
 | Mode | Behavior | AI suitability |
 |------|----------|----------------|
 | `--conflict inline` | Inserts `<<<<<<<`/`=======`/`>>>>>>>` markers into files | Harder to parse — markers interleave with file content |
-| `--conflict rej` | Keeps local file intact, writes rejected template hunks to `<file>.rej` | Easier — local file is clean, `.rej` shows what template wanted |
+| `--conflict rej` | Applies the hunks that apply, writes the rest to `<file>.rej` | Easier to parse — the `.rej` is a plain diff, not markers interleaved with content |
 
 Use `--conflict rej`. This produces:
-- The **local file** unchanged (what the project currently has)
-- A **`.rej` file** containing the diff hunks that copier couldn't apply (what the template wanted to change)
+- The **local file** with every hunk that applied cleanly already written to it — *not* the
+  untouched original. `git apply --reject` is all-or-nothing per hunk, not per file.
+- A **`.rej` file** containing only the hunks that could not be applied.
+
+That distinction is load-bearing. For a Tier 3 file, deleting the `.rej` does not restore
+the project's version: the hunks that applied are still there. Use
+`git checkout HEAD -- <file>` to undo them. Check with `git diff HEAD -- <file>` whenever a
+`.rej` exists — a non-empty diff means the file was partially updated.
 
 ---
 

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -141,6 +141,8 @@ This ensures the skill only spends effort merging files that actually have local
 - **Preserve local**: Custom `nav` entries (pages added beyond template defaults), extra plugins, custom theme overrides
 - **Strategy**: Parse by top-level YAML keys. Template-owned keys get updated. Local additions (new nav items, extra watch paths) are preserved. The `nav` key requires special attention — keep custom entries that don't exist in the template nav.
 - **`markdown_extensions` → `pymdownx.snippets` merges sub-key-wise**: accept the template's `base_path` and `check_paths`, but preserve any local sub-key such as `auto_append`. Taking the template's dict wholesale silently drops a local `auto_append`, and the pages relying on it then render without the appended content — with no error.
+- **`plugins` → `mkdocstrings` → `handlers.python.inventories` is a UNION, not a replacement**: the template ships only the Python inventory, and a project adds its own dependencies' inventories to the same list. Accepting the template's list wholesale drops them, and every cross-reference into those projects silently stops resolving — signatures and `See Also` entries render as plain text with no warning. Keep every local entry and add the template's if missing.
+- **`plugins` → `mkdocstrings` → `handlers.python.options` merges key-wise**: accept template additions, preserve local option overrides.
 
 ### noxfile.py
 

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -46,6 +46,7 @@ docs/assets/logo_light.png
 docs/assets/made_by_stateful-y.png
 docs/assets/README.md
 docs/hooks.py
+docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
 docs/material/overrides/api-index.html
@@ -97,6 +98,10 @@ tests/**                           # All test files
 examples/**                        # conditional: include_examples
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
+docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
+docs/pages/how-to/index.md             # template ships a skeleton, but a
+docs/pages/reference/index.md          # project's own landing page is better
+docs/pages/explanation/index.md        # and must never be overwritten
 docs/pages/tutorials/examples.md    # conditional: include_examples
 docs/examples/**                   # conditional: include_examples
 ```
@@ -135,6 +140,7 @@ This ensures the skill only spends effort merging files that actually have local
 - **Accept from template**: Theme configuration, plugin list, markdown extensions, extra CSS/JS references
 - **Preserve local**: Custom `nav` entries (pages added beyond template defaults), extra plugins, custom theme overrides
 - **Strategy**: Parse by top-level YAML keys. Template-owned keys get updated. Local additions (new nav items, extra watch paths) are preserved. The `nav` key requires special attention — keep custom entries that don't exist in the template nav.
+- **`markdown_extensions` → `pymdownx.snippets` merges sub-key-wise**: accept the template's `base_path` and `check_paths`, but preserve any local sub-key such as `auto_append`. Taking the template's dict wholesale silently drops a local `auto_append`, and the pages relying on it then render without the appended content — with no error.
 
 ### noxfile.py
 

--- a/template/.github/skills/diataxis-notebook-writer/SKILL.md
+++ b/template/.github/skills/diataxis-notebook-writer/SKILL.md
@@ -27,9 +27,31 @@ __gallery__ = {
     "title": "How to Stop Optimization Early with Callbacks",  # goal-oriented for how-to
     "description": "Stop unneeded work early by adding Optuna callbacks to your search.",
     "category": "how-to",  # "tutorial" or "how-to"
-    "companion": "pages/how-to/use-callbacks.md",  # optional: path to companion doc page
+    "companion": "pages/how-to/use-callbacks.md",  # optional: doc page this notebook accompanies
+    "api_references": ["OptunaSearchCV"],  # optional: symbols this notebook demonstrates
 }
 ```
+
+**`companion`** renders this notebook as a card on the named doc page. The page
+must contain the `<!-- COMPANION_NOTEBOOKS -->` placeholder where the cards
+should appear. Leading/trailing slashes and a `.md` suffix are all accepted.
+
+**`api_references`** controls which API pages list this notebook.
+
+- **Omit it** and the symbols are inferred from the notebook's imports. This is
+  the default and it always works, so a notebook is never invisible for lack of
+  metadata.
+- **Declare it** to say which symbols the notebook *demonstrates*, as opposed to
+  the ones it merely imports as scaffolding (a train/test split helper, a
+  plotting call). Inference cannot tell those apart, so declaring is more
+  precise — worth doing once a gallery grows enough that the widely used helpers
+  collect long, meaningless card lists.
+- **Declare it empty** (`"api_references": []`) to keep the notebook off every
+  API page. An empty list means "nowhere"; omitting the key means "infer".
+
+Names that resolve to nothing are ignored rather than failing the build. Each
+API page shows a bounded number of cards, with a link to the full gallery past
+that point.
 
 **Title conventions:**
 - Tutorial: descriptive noun phrase - "OptunaSearchCV Quickstart"

--- a/template/.github/skills/update-from-template/SKILL.md
+++ b/template/.github/skills/update-from-template/SKILL.md
@@ -106,11 +106,16 @@ Read [references/conflict-resolution.md](references/conflict-resolution.md) for 
 
 For each `.rej` file, determine the base file's tier from Step 2:
 
+**A `.rej` does NOT mean the file is untouched.** `git apply --reject` applies every hunk
+that applies cleanly and rejects only the rest, so a conflicted file is already *partially*
+updated. Deleting the `.rej` keeps those applied hunks — which is wrong for any tier that
+was supposed to reject them.
+
 | Tier | Action |
 |------|--------|
-| **Tier 1** (template-managed) | Read `.rej`, apply changes to local file (template wins). Delete `.rej`. |
-| **Tier 2** (merge-required) | Read both local file and `.rej`. Merge: accept template improvements, preserve local additions. Delete `.rej`. |
-| **Tier 3** (local-owned) | Delete `.rej` without applying. |
+| **Tier 1** (template-managed) | Read `.rej`, apply its hunks to the local file (template wins). Delete `.rej`. |
+| **Tier 2** (merge-required) | `git diff HEAD -- <file>` first, to see which hunks already landed. Then merge: accept template improvements, restore any local content those hunks removed. Delete `.rej`. |
+| **Tier 3** (local-owned) | `git checkout HEAD -- <file>` to undo the hunks that already applied, then `rm <file>.rej`. Deleting the `.rej` alone leaves the template's changes in a file the project owns. |
 
 #### 5b: Handle files modified without conflict
 

--- a/template/.github/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.github/skills/update-from-template/references/conflict-resolution.md
@@ -23,11 +23,17 @@ How to resolve conflicts produced by `copier update --conflict rej` for each fil
 | Mode | Behavior | AI suitability |
 |------|----------|----------------|
 | `--conflict inline` | Inserts `<<<<<<<`/`=======`/`>>>>>>>` markers into files | Harder to parse — markers interleave with file content |
-| `--conflict rej` | Keeps local file intact, writes rejected template hunks to `<file>.rej` | Easier — local file is clean, `.rej` shows what template wanted |
+| `--conflict rej` | Applies the hunks that apply, writes the rest to `<file>.rej` | Easier to parse — the `.rej` is a plain diff, not markers interleaved with content |
 
 Use `--conflict rej`. This produces:
-- The **local file** unchanged (what the project currently has)
-- A **`.rej` file** containing the diff hunks that copier couldn't apply (what the template wanted to change)
+- The **local file** with every hunk that applied cleanly already written to it — *not* the
+  untouched original. `git apply --reject` is all-or-nothing per hunk, not per file.
+- A **`.rej` file** containing only the hunks that could not be applied.
+
+That distinction is load-bearing. For a Tier 3 file, deleting the `.rej` does not restore
+the project's version: the hunks that applied are still there. Use
+`git checkout HEAD -- <file>` to undo them. Check with `git diff HEAD -- <file>` whenever a
+`.rej` exists — a non-empty diff means the file was partially updated.
 
 ---
 

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -141,6 +141,8 @@ This ensures the skill only spends effort merging files that actually have local
 - **Preserve local**: Custom `nav` entries (pages added beyond template defaults), extra plugins, custom theme overrides
 - **Strategy**: Parse by top-level YAML keys. Template-owned keys get updated. Local additions (new nav items, extra watch paths) are preserved. The `nav` key requires special attention — keep custom entries that don't exist in the template nav.
 - **`markdown_extensions` → `pymdownx.snippets` merges sub-key-wise**: accept the template's `base_path` and `check_paths`, but preserve any local sub-key such as `auto_append`. Taking the template's dict wholesale silently drops a local `auto_append`, and the pages relying on it then render without the appended content — with no error.
+- **`plugins` → `mkdocstrings` → `handlers.python.inventories` is a UNION, not a replacement**: the template ships only the Python inventory, and a project adds its own dependencies' inventories to the same list. Accepting the template's list wholesale drops them, and every cross-reference into those projects silently stops resolving — signatures and `See Also` entries render as plain text with no warning. Keep every local entry and add the template's if missing.
+- **`plugins` → `mkdocstrings` → `handlers.python.options` merges key-wise**: accept template additions, preserve local option overrides.
 
 ### noxfile.py
 

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -46,6 +46,7 @@ docs/assets/logo_light.png
 docs/assets/made_by_stateful-y.png
 docs/assets/README.md
 docs/hooks.py
+docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
 docs/material/overrides/api-index.html
@@ -97,6 +98,10 @@ tests/**                           # All test files
 examples/**                        # conditional: include_examples
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
+docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
+docs/pages/how-to/index.md             # template ships a skeleton, but a
+docs/pages/reference/index.md          # project's own landing page is better
+docs/pages/explanation/index.md        # and must never be overwritten
 docs/pages/tutorials/examples.md    # conditional: include_examples
 docs/examples/**                   # conditional: include_examples
 ```
@@ -135,6 +140,7 @@ This ensures the skill only spends effort merging files that actually have local
 - **Accept from template**: Theme configuration, plugin list, markdown extensions, extra CSS/JS references
 - **Preserve local**: Custom `nav` entries (pages added beyond template defaults), extra plugins, custom theme overrides
 - **Strategy**: Parse by top-level YAML keys. Template-owned keys get updated. Local additions (new nav items, extra watch paths) are preserved. The `nav` key requires special attention — keep custom entries that don't exist in the template nav.
+- **`markdown_extensions` → `pymdownx.snippets` merges sub-key-wise**: accept the template's `base_path` and `check_paths`, but preserve any local sub-key such as `auto_append`. Taking the template's dict wholesale silently drops a local `auto_append`, and the pages relying on it then render without the appended content — with no error.
 
 ### noxfile.py
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -10,7 +10,15 @@ import subprocess
 {% endif %}from html.parser import HTMLParser
 from pathlib import Path
 
+# Module-level caches. MkDocs loads hooks as plugin instances and does not
+# reload the module between builds, so these live for the whole process --
+# under `mkdocs serve` an unreset cache serves stale content for the rest of the
+# session. Every cache is cleared per build by on_config() below.
+#
+# Naming is load-bearing: the reset and its test discover caches by the
+# `_CACHE` suffix, so a cache named otherwise escapes both, silently.
 _SUBMODULE_CACHE = None
+_API_NAME_LOOKUP_CACHE = None
 
 
 def _get_submodules(project_root):
@@ -88,6 +96,165 @@ def _get_module_members(py_file):
             functions.append({"name": node.name, "doc": doc.strip().split("\n")[0]})
 
     return {"classes": classes, "functions": functions}
+
+
+def _get_dunder_all(tree):
+    """Return the set of names listed in ``__all__``, or None if absent."""
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "__all__":
+                if not isinstance(node.value, ast.List | ast.Tuple):
+                    return None
+                return {e.value for e in node.value.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)}
+    return None
+
+
+def _iter_reexport_nodes(tree):
+    """Yield ``ImportFrom`` nodes that re-export names from a package.
+
+    Covers top-level imports and imports guarded by a top-level ``try`` block,
+    which is the conventional way to expose an optional extra::
+
+        try:
+            from mypkg.neural._impl import Forecaster
+        except ImportError as err:
+            raise ImportError("install mypkg[neural]") from err
+
+    Only the ``try`` body is walked: names in an ``except`` handler are the
+    fallback path, not the package's advertised API.
+    """
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ImportFrom):
+            yield node
+        elif isinstance(node, ast.Try):
+            for inner in node.body:
+                if isinstance(inner, ast.ImportFrom):
+                    yield inner
+
+
+def _resolve_import_from(node, init_file, pkg_dir):
+    """Map an ``ImportFrom`` node to the file that declares its names.
+
+    Handles relative imports (``from .naive import X``) and absolute imports
+    rooted at this package (``from mypkg.stats._base import X``).  Returns
+    None for imports that leave the package, which is what keeps incidental
+    third-party imports (``from pathlib import Path``) out of the API.
+    """
+    if node.level:
+        base = init_file.parent
+        for _ in range(node.level - 1):
+            base = base.parent
+        parts = node.module.split(".") if node.module else []
+    else:
+        if not node.module:
+            return None
+        parts = node.module.split(".")
+        if parts[0] != pkg_dir.name:
+            return None
+        base = pkg_dir
+        parts = parts[1:]
+
+    target = base
+    for part in parts:
+        target = target / part
+    for candidate in (target.with_suffix(".py"), target / "__init__.py"):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _get_reexported_members(init_file, pkg_dir):
+    """Discover members a package exposes by re-export from its submodules.
+
+    A re-exporting ``__init__.py`` declares no classes or functions of its own,
+    so an AST scan of that file alone finds nothing.  This resolves each
+    ``ImportFrom`` binding to its declaring module and lifts the name's kind
+    and docstring from there.
+
+    ``__all__`` acts as a *filter*, not an authority: a name is exposed only if
+    it is listed there (when present) *and* resolves to a class or function in
+    its declaring module.  Constants and other exports are excluded, because
+    only classes and functions get generated pages.
+    """
+    try:
+        tree = ast.parse(init_file.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return {"classes": [], "functions": []}
+
+    exported = _get_dunder_all(tree)
+    classes = []
+    functions = []
+    seen = set()
+
+    for node in _iter_reexport_nodes(tree):
+        decl_file = _resolve_import_from(node, init_file, pkg_dir)
+        if decl_file is None:
+            continue
+        decl_members = None
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            exposed = alias.asname or alias.name
+            if exposed.startswith("_") or exposed in seen:
+                continue
+            if exported is not None and exposed not in exported:
+                continue
+            if decl_members is None:
+                decl_members = _get_module_members(decl_file)
+            for bucket, entries in (("classes", decl_members["classes"]), ("functions", decl_members["functions"])):
+                match = next((e for e in entries if e["name"] == alias.name), None)
+                if match is None:
+                    continue
+                (classes if bucket == "classes" else functions).append({"name": exposed, "doc": match["doc"]})
+                seen.add(exposed)
+                break
+
+    return {"classes": classes, "functions": functions}
+
+
+def _get_public_members(mod_file, pkg_dir):
+    """Public classes and functions of a module, including re-exported ones."""
+    if not mod_file.exists():
+        return {"classes": [], "functions": []}
+    members = _get_module_members(mod_file)
+    if mod_file.name == "__init__.py":
+        reexported = _get_reexported_members(mod_file, pkg_dir)
+        declared = {e["name"] for e in members["classes"] + members["functions"]}
+        for key in ("classes", "functions"):
+            members[key].extend(e for e in reexported[key] if e["name"] not in declared)
+    return members
+
+
+def _get_api_name_lookup(project_root):
+    """Map a symbol's short name to the qualified name of its API page (cached).
+
+    Shared by See Also resolution and example-notebook cross-referencing so the
+    two cannot disagree about what a symbol is called.  Built by static
+    analysis only — the package is never imported.
+
+    A short name claimed by two different modules is omitted rather than
+    resolved arbitrarily: consumers turn this straight into a URL, and a wrong
+    link is worse than no link.
+    """
+    global _API_NAME_LOOKUP_CACHE  # noqa: PLW0603
+    if _API_NAME_LOOKUP_CACHE is not None:
+        return _API_NAME_LOOKUP_CACHE
+
+    pkg_dir = project_root / "src" / "{{ package_name }}"
+    candidates = {}
+    for mod in _get_submodules(project_root):
+        mod_file = pkg_dir / f"{mod['module_name']}.py"
+        if not mod_file.exists():
+            mod_file = pkg_dir / mod["module_name"] / "__init__.py"
+        members = _get_public_members(mod_file, pkg_dir)
+        for entry in members["classes"] + members["functions"]:
+            qualified = f"{{ package_name }}.{mod['module_name']}.{entry['name']}"
+            candidates.setdefault(entry["name"], set()).add(qualified)
+
+    _API_NAME_LOOKUP_CACHE = {name: next(iter(quals)) for name, quals in candidates.items() if len(quals) == 1}
+    return _API_NAME_LOOKUP_CACHE
 
 
 def _build_members_tables(package_name, module_name, members):
@@ -179,7 +346,7 @@ def _generate_api_pages(project_root):
         if not mod_file.exists():
             mod_file = pkg_dir / mod["module_name"] / "__init__.py"
 
-        members = _get_module_members(mod_file) if mod_file.exists() else {"classes": [], "functions": []}
+        members = _get_public_members(mod_file, pkg_dir)
 
         # Generate submodule overview page with tables
         members_tables = _build_members_tables(
@@ -313,6 +480,17 @@ def _build_api_table_html(project_root):
 
 
 _GALLERY_CACHE = None
+_COMPANION_INDEX_CACHE = None
+
+# Max example cards on a single API page.  Most symbols are well under this
+# (a typical notebook demonstrates a handful of things); the cap exists for the
+# widely used helpers, where an uncapped list runs to dozens of cards and stops
+# being scannable.  The overflow link keeps the rest reachable.
+#
+# The `_CACHE` suffix on cache globals above is load-bearing: the per-build
+# reset's registration test discovers caches by that suffix, so a cache named
+# otherwise escapes it silently.
+_API_EXAMPLES_CAP = 6
 
 
 def _get_gallery_items(project_root):
@@ -356,10 +534,19 @@ def _get_gallery_items(project_root):
         view_path = f"/examples/{stem}/"
         open_path = f"/examples/{stem}/edit/"
 
+        # api_references: absent (None) means "infer from imports"; an empty
+        # list means "this notebook belongs on no API page" -- a deliberate
+        # statement, not a default.
+        api_references = gallery.get("api_references")
+        if api_references is not None and not isinstance(api_references, list):
+            api_references = None
+
         items.append({
             "title": gallery.get("title", stem.replace("_", " ").title()),
             "description": gallery.get("description", ""),
             "category": gallery.get("category", ""),
+            "api_references": api_references,
+            "companion": gallery.get("companion"),
             "view_path": view_path,
             "open_path": open_path,
             "stem": stem,
@@ -427,6 +614,39 @@ def _build_gallery_cards(items):
 _NOTEBOOK_API_USAGE_CACHE = None
 
 
+def _normalize_companion_path(path):
+    """Normalize a companion path so authored variants compare equal.
+
+    ``companion`` is hand-written, so it turns up as ``/pages/how-to/x/``,
+    ``pages/how-to/x`` and ``pages/how-to/x.md``.  All three mean the same
+    page; normalizing beats making the author guess the one true spelling.
+    """
+    return str(path).strip("/").removesuffix(".md").removesuffix("/index")
+
+
+def _get_companion_index(project_root):
+    """Reverse map: normalized doc page path -> notebooks naming it (cached)."""
+    global _COMPANION_INDEX_CACHE  # noqa: PLW0603
+    if _COMPANION_INDEX_CACHE is not None:
+        return _COMPANION_INDEX_CACHE
+
+    index: dict[str, list[dict]] = {}
+    for item in _get_gallery_items(project_root):
+        companion = item.get("companion")
+        if companion:
+            index.setdefault(_normalize_companion_path(companion), []).append(item)
+    _COMPANION_INDEX_CACHE = index
+    return _COMPANION_INDEX_CACHE
+
+
+def _build_companion_cards_html(project_root, page_src_uri):
+    """Build cards for notebooks declaring this page as their companion."""
+    items = _get_companion_index(project_root).get(_normalize_companion_path(page_src_uri), [])
+    if not items:
+        return ""
+    return _build_gallery_cards(sorted(items, key=lambda item: item["title"]))
+
+
 def _get_notebook_api_usage(project_root):
     """Build reverse map: qualified API name → list of gallery items that use it.
 
@@ -438,22 +658,7 @@ def _get_notebook_api_usage(project_root):
     if _NOTEBOOK_API_USAGE_CACHE is not None:
         return _NOTEBOOK_API_USAGE_CACHE
 
-    pkg_dir = project_root / "src" / "{{ package_name }}"
-    modules = _get_submodules(project_root)
-
-    # Build short name → qualified lookup from discovered module members
-    name_to_qualified: dict[str, str] = {}
-    for mod in modules:
-        mod_file = pkg_dir / f"{mod['module_name']}.py"
-        if not mod_file.exists():
-            mod_file = pkg_dir / mod["module_name"] / "__init__.py"
-        if not mod_file.exists():
-            continue
-        members = _get_module_members(mod_file)
-        for cls in members["classes"]:
-            name_to_qualified[cls["name"]] = f"{{ package_name }}.{mod['module_name']}.{cls['name']}"
-        for func in members["functions"]:
-            name_to_qualified[func["name"]] = f"{{ package_name }}.{mod['module_name']}.{func['name']}"
+    name_to_qualified = _get_api_name_lookup(project_root)
 
     gallery_items = _get_gallery_items(project_root)
     stem_to_item = {item["stem"]: item for item in gallery_items}
@@ -475,18 +680,28 @@ def _get_notebook_api_usage(project_root):
         if item is None:
             continue
 
-        try:
-            source = notebook.read_text(encoding="utf-8")
-            tree = ast.parse(source)
-        except (SyntaxError, UnicodeDecodeError):
-            continue
+        # Declared api_references win; import scanning is the fallback.
+        # Import scanning cannot tell a symbol a notebook *demonstrates* from
+        # one it merely uses as scaffolding, so an author saying which is which
+        # beats inference.  But a notebook that says nothing must still work --
+        # a fresh project has no metadata, and the feature has to be visible
+        # before anyone opts in.
+        declared = item.get("api_references")
+        if declared is not None:
+            imported_names = set(declared)
+        else:
+            try:
+                source = notebook.read_text(encoding="utf-8")
+                tree = ast.parse(source)
+            except (SyntaxError, UnicodeDecodeError):
+                continue
 
-        # Extract names imported from {{ package_name }}.*
-        imported_names: set[str] = set()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("{{ package_name }}"):
-                for alias in node.names:
-                    imported_names.add(alias.name)
+            # Extract names imported from {{ package_name }}.*
+            imported_names = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("{{ package_name }}"):
+                    for alias in node.names:
+                        imported_names.add(alias.name)
 
         for imp_name in imported_names:
             qualified = name_to_qualified.get(imp_name)
@@ -513,7 +728,19 @@ def _build_api_examples_html(project_root, qualified_name):
             seen.add(item["stem"])
             unique_items.append(item)
 
-    return "## Examples\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(unique_items)
+    # Bound the list.  A widely used helper accumulates a card per notebook,
+    # so the most-used symbols get the longest and least useful lists -- the
+    # failure is inversely proportional to usefulness.  Curation alone does not
+    # fix this: a genuinely central class really is used by dozens of
+    # notebooks.  Sort by title so the selection is stable across builds.
+    unique_items.sort(key=lambda item: item["title"])
+    total = len(unique_items)
+    shown = unique_items[:_API_EXAMPLES_CAP]
+
+    html = "## Examples\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(shown)
+    if total > _API_EXAMPLES_CAP:
+        html += f"\n[See all {total} examples in the gallery](/pages/examples/)\n"
+    return html
 {%- endif %}
 
 
@@ -623,6 +850,92 @@ _DETAIL_SECTION_SLUGS = {
     "see-also": ("see-also", "See Also"),
     "references": ("references", "References"),
 }
+
+
+_SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>', re.DOTALL)
+_SEE_ALSO_ENTRY_RE = re.compile(r"(?:<code>[^<]+</code>|[A-Za-z_][\w.]*)\s*:")
+
+
+def _resolve_see_also_url(name, page, config):
+    """Resolve a See Also entry naming a project symbol to a URL, or None.
+
+    A dotted name whose leading segment is not this package is external and is
+    not resolved here -- see ``_external_autoref`` for why.
+
+    Classifying by leading segment is the only rule that works: the project
+    lookup is keyed by *short* name, so a dotted external name always misses it,
+    and stripping the qualifier first would let ``sklearn.linear_model.Ridge``
+    collide with a project symbol called ``Ridge``.
+    """
+    package = "{{ package_name }}"
+    if "." in name and name.split(".", 1)[0] != package:
+        return None
+
+    short_name = name.rsplit(".", 1)[-1]
+    project_root = Path(__file__).parent.parent
+    qualified = _get_api_name_lookup(project_root).get(short_name)
+    return f"../{qualified}/" if qualified is not None else None
+
+
+def _external_autoref(name, title):
+    """Defer an external name to autorefs, which resolves it later.
+
+    External names cannot be resolved here: mkdocstrings registers downloaded
+    inventories into the autorefs URL map, but autorefs applies them in its
+    ``on_env`` hook -- after ``on_page_content`` runs.  Asking for the URL now
+    raises ``KeyError`` even when the inventory is configured.
+
+    So emit autorefs' own markup and let it resolve at the right time.  The
+    ``optional`` attribute is what keeps an unresolvable name quiet: autorefs
+    logs it at debug level and renders the title as plain text, rather than
+    recording it as an unmapped reference and warning (which would fail a
+    ``--strict`` build for a docstring that names something undocumented).
+
+    Only dotted names get here.  A bare name is not offered to autorefs: it
+    could resolve to an unrelated symbol that happens to share the name in some
+    configured inventory, and a wrong link is worse than no link.
+    """
+    return f'<autoref optional identifier="{name}">{title}</autoref>'
+
+
+def _link_entry(name, title, colon, entry, page, config):
+    """Render one See Also entry: project link, deferred external ref, or as-is."""
+    url = _resolve_see_also_url(name, page, config)
+    if url:
+        return f'<a href="{url}">{title}</a>{colon}'
+    if "." in name and name.split(".", 1)[0] != "{{ package_name }}":
+        return _external_autoref(name, title) + colon
+    return entry
+
+
+def _linkify_see_also(html, page, config):
+    """Turn names in a rendered See Also section into links.
+
+    Must run while the ``<details class="see-also">`` container still exists --
+    see the ordering comment in ``on_page_content``.  Unresolvable names are
+    left untouched: a docstring may reference a private helper or a concept,
+    and none of those are build errors.
+    """
+
+    def _process_block(block_match):
+        def _process_paragraph(p_match):
+            def _linkify_entry(entry_match):
+                entry = entry_match.group(0)
+                code_match = re.match(r"<code>([^<]+)</code>(\s*:)", entry)
+                if code_match:
+                    name, colon = code_match.group(1), code_match.group(2)
+                    return _link_entry(name, f"<code>{name}</code>", colon, entry, page, config)
+                plain_match = re.match(r"([A-Za-z_][\w.]*?)(\s*:)", entry)
+                if plain_match:
+                    name, colon = plain_match.group(1), plain_match.group(2)
+                    return _link_entry(name, name, colon, entry, page, config)
+                return entry
+
+            return "<p>" + _SEE_ALSO_ENTRY_RE.sub(_linkify_entry, p_match.group(1)) + "</p>"
+
+        return re.sub(r"<p>(.*?)</p>", _process_paragraph, block_match.group(0), flags=re.DOTALL)
+
+    return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
 def _make_section_heading(slug, title, level=3):
@@ -909,12 +1222,41 @@ def _process_api_page_content(html, page, config):
     return html
 
 
+def on_config(config):
+    """Clear per-build caches.
+
+    `on_config` is the first event on every build, including each rebuild in a
+    `mkdocs serve` session -- which is the lifetime these caches need.
+
+    Deliberately not `on_startup`: that runs once per `mkdocs` invocation, so a
+    reset there fires when the caches are already empty and never again, and
+    `mkdocs serve` keeps serving the first build's content.
+    """
+    global _SUBMODULE_CACHE, _API_NAME_LOOKUP_CACHE, _GIT_REF_CACHE  # noqa: PLW0603
+    _SUBMODULE_CACHE = None
+    _API_NAME_LOOKUP_CACHE = None
+    _GIT_REF_CACHE = None
+{%- if include_examples %}
+    global _GALLERY_CACHE, _COMPANION_INDEX_CACHE, _NOTEBOOK_API_USAGE_CACHE  # noqa: PLW0603
+    _GALLERY_CACHE = None
+    _COMPANION_INDEX_CACHE = None
+    _NOTEBOOK_API_USAGE_CACHE = None
+{%- endif %}
+    return config
+
+
 def on_page_content(html, page, config, files):
     """Post-process HTML: API page TOC and content restructuring."""
     src = page.file.src_path
 
     # Process generated API member pages (per-class/function detail pages)
     if src.startswith("pages/api/generated/"):
+        # ORDER IS LOAD-BEARING: mkdocstrings emits See Also as a
+        # <details class="see-also"> block, and _process_api_page_content
+        # dissolves that block for class-level docstrings.  Linkifying after it
+        # silently does nothing for class-level See Also sections -- the
+        # majority of them -- while appearing to work for method-level ones.
+        html = _linkify_see_also(html, page, config)
         html = _process_api_page_content(html, page, config)
 
     if src == "pages/reference/api.md":
@@ -968,6 +1310,15 @@ def on_page_markdown(markdown, page, config, files):
     if "<!-- GALLERY -->" in markdown:
         gallery_html = _build_gallery_html(project_root)
         markdown = markdown.replace("<!-- GALLERY -->", gallery_html)
+
+    # COMPANION_NOTEBOOKS placeholder → cards for notebooks naming this page.
+    # Substituted here, before the URL rewrites below, so companion cards go
+    # through the same [View]/[Open in marimo] resolution as gallery cards.
+    # Emitting resolved HTML directly would bypass those markdown-syntax
+    # rewrites and ship unresolved links.
+    if "<!-- COMPANION_NOTEBOOKS -->" in markdown:
+        companion_html = _build_companion_cards_html(project_root, page.file.src_path)
+        markdown = markdown.replace("<!-- COMPANION_NOTEBOOKS -->", companion_html)
 
     # Resolve [Open in marimo] placeholder URLs → full marimo.app playground URLs
     markdown = re.sub(

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -207,7 +207,9 @@ def _get_reexported_members(init_file, pkg_dir):
                 match = next((e for e in entries if e["name"] == alias.name), None)
                 if match is None:
                     continue
-                (classes if bucket == "classes" else functions).append({"name": exposed, "doc": match["doc"]})
+                (classes if bucket == "classes" else functions).append(
+                    {"name": exposed, "doc": match["doc"], "origin": str(decl_file), "reexported": True}
+                )
                 seen.add(exposed)
                 break
 
@@ -215,10 +217,19 @@ def _get_reexported_members(init_file, pkg_dir):
 
 
 def _get_public_members(mod_file, pkg_dir):
-    """Public classes and functions of a module, including re-exported ones."""
+    """Public classes and functions of a module, including re-exported ones.
+
+    Each entry carries *origin* (the file that declares the symbol) and
+    *reexported*, so the name lookup can tell one symbol reachable by two paths
+    from two different symbols that happen to share a short name.
+    """
     if not mod_file.exists():
         return {"classes": [], "functions": []}
     members = _get_module_members(mod_file)
+    for key in ("classes", "functions"):
+        for entry in members[key]:
+            entry.setdefault("origin", str(mod_file))
+            entry.setdefault("reexported", False)
     if mod_file.name == "__init__.py":
         reexported = _get_reexported_members(mod_file, pkg_dir)
         declared = {e["name"] for e in members["classes"] + members["functions"]}
@@ -234,9 +245,13 @@ def _get_api_name_lookup(project_root):
     two cannot disagree about what a symbol is called.  Built by static
     analysis only — the package is never imported.
 
-    A short name claimed by two different modules is omitted rather than
-    resolved arbitrarily: consumers turn this straight into a URL, and a wrong
-    link is worse than no link.
+    When one symbol is reachable by two paths -- declared in a module and
+    re-exported by a package -- the published path wins: that is the name users
+    write, and the one whose page they expect.
+
+    When a short name identifies two genuinely different symbols, it is omitted
+    rather than resolved arbitrarily: consumers turn this straight into a URL,
+    and a wrong link is worse than no link.
     """
     global _API_NAME_LOOKUP_CACHE  # noqa: PLW0603
     if _API_NAME_LOOKUP_CACHE is not None:
@@ -251,9 +266,21 @@ def _get_api_name_lookup(project_root):
         members = _get_public_members(mod_file, pkg_dir)
         for entry in members["classes"] + members["functions"]:
             qualified = f"{{ package_name }}.{mod['module_name']}.{entry['name']}"
-            candidates.setdefault(entry["name"], set()).add(qualified)
+            candidates.setdefault(entry["name"], []).append(
+                {"qualified": qualified, "origin": entry.get("origin"), "reexported": entry.get("reexported", False)}
+            )
 
-    _API_NAME_LOOKUP_CACHE = {name: next(iter(quals)) for name, quals in candidates.items() if len(quals) == 1}
+    lookup = {}
+    for name, cands in candidates.items():
+        if len({c["origin"] for c in cands}) > 1:
+            continue  # genuinely different symbols share this short name
+        published = sorted(c["qualified"] for c in cands if c["reexported"])
+        if published:
+            lookup[name] = published[0]
+        elif len(cands) == 1:
+            lookup[name] = cands[0]["qualified"]
+
+    _API_NAME_LOOKUP_CACHE = lookup
     return _API_NAME_LOOKUP_CACHE
 
 
@@ -481,6 +508,7 @@ def _build_api_table_html(project_root):
 
 _GALLERY_CACHE = None
 _COMPANION_INDEX_CACHE = None
+_GALLERY_PAGE_CACHE = None
 
 # Max example cards on a single API page.  Most symbols are well under this
 # (a typical notebook demonstrates a handful of things); the cap exists for the
@@ -614,6 +642,32 @@ def _build_gallery_cards(items):
 _NOTEBOOK_API_USAGE_CACHE = None
 
 
+def _get_gallery_page_url(project_root):
+    """URL of the page hosting the gallery, or None if there is not one.
+
+    The gallery page is whichever page carries the ``<!-- GALLERY -->``
+    placeholder -- found by looking, because that page is local-owned and a
+    project is free to move it.  A hardcoded path is wrong the moment someone
+    reorganises their docs, and produces a 404 with no build error.
+    """
+    global _GALLERY_PAGE_CACHE  # noqa: PLW0603
+    if _GALLERY_PAGE_CACHE is not None:
+        return _GALLERY_PAGE_CACHE or None
+
+    docs_dir = project_root / "docs"
+    _GALLERY_PAGE_CACHE = ""
+    if docs_dir.exists():
+        for md in sorted(docs_dir.rglob("*.md")):
+            try:
+                if "<!-- GALLERY -->" in md.read_text(encoding="utf-8"):
+                    rel = md.relative_to(docs_dir).with_suffix("")
+                    _GALLERY_PAGE_CACHE = "/" + "/".join(rel.parts) + "/"
+                    break
+            except (OSError, UnicodeDecodeError):
+                continue
+    return _GALLERY_PAGE_CACHE or None
+
+
 def _normalize_companion_path(path):
     """Normalize a companion path so authored variants compare equal.
 
@@ -738,8 +792,9 @@ def _build_api_examples_html(project_root, qualified_name):
     shown = unique_items[:_API_EXAMPLES_CAP]
 
     html = "## Examples\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(shown)
-    if total > _API_EXAMPLES_CAP:
-        html += f"\n[See all {total} examples in the gallery](/pages/examples/)\n"
+    gallery_url = _get_gallery_page_url(project_root)
+    if total > _API_EXAMPLES_CAP and gallery_url:
+        html += f"\n[See all {total} examples in the gallery]({gallery_url})\n"
     return html
 {%- endif %}
 
@@ -918,22 +973,31 @@ def _linkify_see_also(html, page, config):
     """
 
     def _process_block(block_match):
-        def _process_paragraph(p_match):
-            def _linkify_entry(entry_match):
-                entry = entry_match.group(0)
-                code_match = re.match(r"<code>([^<]+)</code>(\s*:)", entry)
-                if code_match:
-                    name, colon = code_match.group(1), code_match.group(2)
-                    return _link_entry(name, f"<code>{name}</code>", colon, entry, page, config)
-                plain_match = re.match(r"([A-Za-z_][\w.]*?)(\s*:)", entry)
-                if plain_match:
-                    name, colon = plain_match.group(1), plain_match.group(2)
-                    return _link_entry(name, name, colon, entry, page, config)
-                return entry
+        def _linkify_entry(entry_match):
+            entry = entry_match.group(0)
+            code_match = re.match(r"<code>([^<]+)</code>(\s*:)", entry)
+            if code_match:
+                name, colon = code_match.group(1), code_match.group(2)
+                return _link_entry(name, f"<code>{name}</code>", colon, entry, page, config)
+            plain_match = re.match(r"([A-Za-z_][\w.]*?)(\s*:)", entry)
+            if plain_match:
+                name, colon = plain_match.group(1), plain_match.group(2)
+                return _link_entry(name, name, colon, entry, page, config)
+            return entry
 
-            return "<p>" + _SEE_ALSO_ENTRY_RE.sub(_linkify_entry, p_match.group(1)) + "</p>"
+        def _process_container(container_match):
+            tag, inner = container_match.group(1), container_match.group(2)
+            # Skip content that is already a link or an autoref: an author who
+            # wrote an explicit `[Name][target]` cross-reference has said what
+            # they mean, and autorefs resolves it later.
+            if "<a " in inner or "<autoref" in inner:
+                return container_match.group(0)
+            return f"<{tag}>{_SEE_ALSO_ENTRY_RE.sub(_linkify_entry, inner)}</{tag}>"
 
-        return re.sub(r"<p>(.*?)</p>", _process_paragraph, block_match.group(0), flags=re.DOTALL)
+        # numpydoc renders See Also entries as a paragraph; an author may also
+        # write them as a markdown list, which renders as <li> instead. Both are
+        # ordinary numpydoc, so both get linked.
+        return re.sub(r"<(p|li)>(.*?)</\1>", _process_container, block_match.group(0), flags=re.DOTALL)
 
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
@@ -1237,10 +1301,11 @@ def on_config(config):
     _API_NAME_LOOKUP_CACHE = None
     _GIT_REF_CACHE = None
 {%- if include_examples %}
-    global _GALLERY_CACHE, _COMPANION_INDEX_CACHE, _NOTEBOOK_API_USAGE_CACHE  # noqa: PLW0603
+    global _GALLERY_CACHE, _COMPANION_INDEX_CACHE, _NOTEBOOK_API_USAGE_CACHE, _GALLERY_PAGE_CACHE  # noqa: PLW0603
     _GALLERY_CACHE = None
     _COMPANION_INDEX_CACHE = None
     _NOTEBOOK_API_USAGE_CACHE = None
+    _GALLERY_PAGE_CACHE = None
 {%- endif %}
     return config
 
@@ -1329,6 +1394,10 @@ def on_page_markdown(markdown, page, config, files):
 
     # Rewrite [View] to relative paths pointing to local HTML exports
     markdown = re.sub(r"\]\(/examples/", f"]({prefix}examples/", markdown)
+
+    # Absolute doc-page links (e.g. the gallery overflow link) resolve to the
+    # current page's depth, the same way [View] does.
+    markdown = re.sub(r"\]\(/pages/", f"]({prefix}pages/", markdown)
 {% else %}
     # Strip EXAMPLES_FOR placeholders when examples are disabled
     markdown = re.sub(r"<!-- EXAMPLES_FOR:[\w.]+ -->\n?", "", markdown)

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -427,7 +427,7 @@ def _build_api_table_html(project_root):
         if not mod_file.exists():
             continue
 
-        members = _get_module_members(mod_file)
+        members = _get_public_members(mod_file, pkg_dir)
         module_label = f"{{ package_name }}.{mod['module_name']}"
         module_href = f"../api/{mod['module_name']}/"
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -698,7 +698,11 @@ def _build_companion_cards_html(project_root, page_src_uri):
     items = _get_companion_index(project_root).get(_normalize_companion_path(page_src_uri), [])
     if not items:
         return ""
-    return _build_gallery_cards(sorted(items, key=lambda item: item["title"]))
+    # The heading is emitted here rather than written into the page, so a page
+    # whose companions were removed renders nothing at all instead of a heading
+    # with an empty section under it.
+    cards = _build_gallery_cards(sorted(items, key=lambda item: item["title"]))
+    return f"## Try it interactively\n\n{cards}"
 
 
 def _get_notebook_api_usage(project_root):
@@ -915,7 +919,7 @@ _SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>
 _SEE_ALSO_ENTRY_RE = re.compile(r"^(\s*)(<code>[^<]+</code>|[A-Za-z_][\w.]*)(\s*:)")
 
 
-def _resolve_see_also_url(name, page, config):
+def _resolve_see_also_url(name):
     """Resolve a See Also entry naming a project symbol to a URL, or None.
 
     A dotted name whose leading segment is not this package is external and is
@@ -957,9 +961,9 @@ def _external_autoref(name, title):
     return f'<autoref optional identifier="{name}">{title}</autoref>'
 
 
-def _link_entry(name, title, colon, entry, page, config):
+def _link_entry(name, title, colon, entry):
     """Render one See Also entry: project link, deferred external ref, or as-is."""
-    url = _resolve_see_also_url(name, page, config)
+    url = _resolve_see_also_url(name)
     if url:
         return f'<a href="{url}">{title}</a>{colon}'
     if "." in name and name.split(".", 1)[0] != "{{ package_name }}":
@@ -967,7 +971,7 @@ def _link_entry(name, title, colon, entry, page, config):
     return entry
 
 
-def _linkify_see_also(html, page, config):
+def _linkify_see_also(html):
     """Turn the names in a rendered See Also section into links.
 
     Must run while the ``<details class="see-also">`` container still exists --
@@ -986,7 +990,7 @@ def _linkify_see_also(html, page, config):
             code_match = re.fullmatch(r"<code>([^<]+)</code>", token)
             name = code_match.group(1) if code_match else token
             title = f"<code>{name}</code>" if code_match else name
-            return lead + _link_entry(name, title, colon, token + colon, page, config) + rest
+            return lead + _link_entry(name, title, colon, token + colon) + rest
 
         def _process_container(container_match):
             tag, inner = container_match.group(1), container_match.group(2)
@@ -1323,7 +1327,7 @@ def on_page_content(html, page, config, files):
         # dissolves that block for class-level docstrings.  Linkifying after it
         # silently does nothing for class-level See Also sections -- the
         # majority of them -- while appearing to work for method-level ones.
-        html = _linkify_see_also(html, page, config)
+        html = _linkify_see_also(html)
         html = _process_api_page_content(html, page, config)
 
     if src == "pages/reference/api.md":

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -908,7 +908,11 @@ _DETAIL_SECTION_SLUGS = {
 
 
 _SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>', re.DOTALL)
-_SEE_ALSO_ENTRY_RE = re.compile(r"(?:<code>[^<]+</code>|[A-Za-z_][\w.]*)\s*:")
+# An entry's name sits at the START of its line -- mkdocstrings renders one entry
+# per line inside the paragraph. Anchoring here is what keeps a colon-terminated
+# word in an entry's DESCRIPTION ("Target : Note: see below") from being treated
+# as another entry and linked.
+_SEE_ALSO_ENTRY_RE = re.compile(r"^(\s*)(<code>[^<]+</code>|[A-Za-z_][\w.]*)(\s*:)")
 
 
 def _resolve_see_also_url(name, page, config):
@@ -964,7 +968,7 @@ def _link_entry(name, title, colon, entry, page, config):
 
 
 def _linkify_see_also(html, page, config):
-    """Turn names in a rendered See Also section into links.
+    """Turn the names in a rendered See Also section into links.
 
     Must run while the ``<details class="see-also">`` container still exists --
     see the ordering comment in ``on_page_content``.  Unresolvable names are
@@ -973,29 +977,27 @@ def _linkify_see_also(html, page, config):
     """
 
     def _process_block(block_match):
-        def _linkify_entry(entry_match):
-            entry = entry_match.group(0)
-            code_match = re.match(r"<code>([^<]+)</code>(\s*:)", entry)
-            if code_match:
-                name, colon = code_match.group(1), code_match.group(2)
-                return _link_entry(name, f"<code>{name}</code>", colon, entry, page, config)
-            plain_match = re.match(r"([A-Za-z_][\w.]*?)(\s*:)", entry)
-            if plain_match:
-                name, colon = plain_match.group(1), plain_match.group(2)
-                return _link_entry(name, name, colon, entry, page, config)
-            return entry
+        def _linkify_line(line):
+            entry_match = _SEE_ALSO_ENTRY_RE.match(line)
+            if not entry_match:
+                return line
+            lead, token, colon = entry_match.groups()
+            rest = line[entry_match.end() :]
+            code_match = re.fullmatch(r"<code>([^<]+)</code>", token)
+            name = code_match.group(1) if code_match else token
+            title = f"<code>{name}</code>" if code_match else name
+            return lead + _link_entry(name, title, colon, token + colon, page, config) + rest
 
         def _process_container(container_match):
             tag, inner = container_match.group(1), container_match.group(2)
-            # Skip content that is already a link or an autoref: an author who
-            # wrote an explicit `[Name][target]` cross-reference has said what
-            # they mean, and autorefs resolves it later.
+            # Leave an author's explicit [Name][target] reference alone: they have
+            # said what they mean, and autorefs resolves it later.
             if "<a " in inner or "<autoref" in inner:
                 return container_match.group(0)
-            return f"<{tag}>{_SEE_ALSO_ENTRY_RE.sub(_linkify_entry, inner)}</{tag}>"
+            return f"<{tag}>" + "\n".join(_linkify_line(line) for line in inner.split("\n")) + f"</{tag}>"
 
-        # numpydoc renders See Also entries as a paragraph; an author may also
-        # write them as a markdown list, which renders as <li> instead. Both are
+        # numpydoc renders See Also entries as a paragraph, one per line; an author
+        # may also write them as a markdown list, which renders as <li>. Both are
         # ordinary numpydoc, so both get linked.
         return re.sub(r"<(p|li)>(.*?)</\1>", _process_container, block_match.group(0), flags=re.DOTALL)
 

--- a/template/docs/pages/explanation/index.md.jinja
+++ b/template/docs/pages/explanation/index.md.jinja
@@ -1,0 +1,7 @@
+# Explanation
+
+Understanding-oriented discussion of how {{ project_name }} works and why it is
+built the way it is. Read these when you want context and background rather
+than instructions.
+
+For what things do rather than why, see [Reference](../reference/index.md).

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -371,7 +371,24 @@ uvx interrogate src
 
 **`See Also` format:**
 
-Use standard numpydoc format with short backtick names. The `mkdocs-autorefs` plugin automatically links backtick references (e.g., `` `ClassName` ``) to the corresponding API pages in rendered documentation. This means plain backtick-wrapped names in docstrings become clickable links in the docs site without any special syntax.
+Use standard numpydoc format with short names:
+
+```python
+See Also
+--------
+OtherClass : One-line description of how it relates.
+other_function : Another related object.
+```
+
+Names are linked to their API pages automatically, whether or not you wrap them
+in backticks. Names that cannot be resolved — a private helper, or a concept
+rather than an API object — are left as plain text rather than failing the
+build, so you can reference anything that reads well.
+
+Fully qualified names work too (`{{ package_name }}.module.OtherClass`), and
+resolve to the same page as the short form. A name from another project (for
+example `sklearn.linear_model.Ridge`) links to that project's documentation
+when its inventory is configured in `mkdocs.yml`.
 
 For hyperlinks, always use Markdown syntax: `[text](url)`.
 

--- a/template/docs/pages/how-to/index.md.jinja
+++ b/template/docs/pages/how-to/index.md.jinja
@@ -1,0 +1,8 @@
+# How-to Guides
+
+Task-oriented recipes for getting a specific job done with {{ project_name }}.
+These assume you already know the basics and want to accomplish something
+concrete.
+
+If you are still finding your feet, start with the
+[Tutorials](../tutorials/index.md).

--- a/template/docs/pages/how-to/troubleshooting.md.jinja
+++ b/template/docs/pages/how-to/troubleshooting.md.jinja
@@ -19,3 +19,18 @@ Solutions to common problems when using {{ project_name }}.
 
 - [Open an issue on GitHub](https://github.com/{{ github_username }}/{{ project_slug }}/issues/new)
 - [Start a discussion](https://github.com/{{ github_username }}/{{ project_slug }}/discussions)
+
+## Docs build fails with a snippet-not-found error after a template update
+
+**Problem:** After updating from the template, `just build` fails with an error
+naming a file that a `--8<--` include cannot find.
+
+**Cause:** The docs build now sets `check_paths: true` for `pymdownx.snippets`.
+Previously a missing include was dropped silently, so the page rendered without
+the included content and looked deliberate. The error is surfacing an include
+that was already broken, not a new one.
+
+**Fix:** Either point the include at a file that exists, or remove the include
+(and the page, if the include was all it contained). Include paths resolve
+relative to `docs/` first, then the repository root — so `--8<-- "CHANGELOG.md"`
+finds the changelog at the top of the repo.

--- a/template/docs/pages/reference/changelog.md.jinja
+++ b/template/docs/pages/reference/changelog.md.jinja
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/template/docs/pages/reference/index.md.jinja
+++ b/template/docs/pages/reference/index.md.jinja
@@ -1,0 +1,8 @@
+# Reference
+
+Information-oriented description of what {{ project_name }} provides: the API,
+its behaviour, and its release history. Reference material is for looking
+things up, not for learning — it describes the machinery and stays out of your
+way.
+
+For the reasoning behind the design, see [Explanation](../explanation/index.md).

--- a/template/docs/pages/tutorials/getting-started.md.jinja
+++ b/template/docs/pages/tutorials/getting-started.md.jinja
@@ -73,3 +73,8 @@ Run locally:
 {% if include_examples %}- **Explore examples**: Check out the [Examples](examples.md) for interactive notebooks
 {% endif %}- **Dive into the API**: Browse the [API Reference](../reference/api.md) for detailed documentation
 - **Get help**: Visit [GitHub Discussions](https://github.com/{{ github_username }}/{{ project_slug }}/discussions) or [open an issue](https://github.com/{{ github_username }}/{{ project_slug }}/issues)
+
+{% if include_examples %}## Try it interactively
+
+<!-- COMPANION_NOTEBOOKS -->
+{% endif %}

--- a/template/docs/pages/tutorials/getting-started.md.jinja
+++ b/template/docs/pages/tutorials/getting-started.md.jinja
@@ -74,7 +74,5 @@ Run locally:
 {% endif %}- **Dive into the API**: Browse the [API Reference](../reference/api.md) for detailed documentation
 - **Get help**: Visit [GitHub Discussions](https://github.com/{{ github_username }}/{{ project_slug }}/discussions) or [open an issue](https://github.com/{{ github_username }}/{{ project_slug }}/issues)
 
-{% if include_examples %}## Try it interactively
-
-<!-- COMPANION_NOTEBOOKS -->
+{% if include_examples %}<!-- COMPANION_NOTEBOOKS -->
 {% endif %}

--- a/template/docs/pages/tutorials/index.md.jinja
+++ b/template/docs/pages/tutorials/index.md.jinja
@@ -1,0 +1,8 @@
+# Tutorials
+
+Learning-oriented guides that teach {{ project_name }} by walking you through
+hands-on steps. Start here if you are new: a tutorial's job is to give you a
+first success, not to cover every option.
+
+Once you know your way around, the [How-to Guides](../how-to/index.md) show you
+how to solve specific problems.

--- a/template/docs/stylesheets/{% if include_examples %}gallery.css{% endif %}
+++ b/template/docs/stylesheets/{% if include_examples %}gallery.css{% endif %}
@@ -13,3 +13,28 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Companion notebook cards: rendered on docs pages via the
+   <!-- COMPANION_NOTEBOOKS --> placeholder.  Uses the same grid as the
+   gallery so a companion card and a gallery card read as one system. */
+
+.md-typeset .companion-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0.5rem 0 0;
+}
+
+.md-typeset .companion-card {
+  flex: 1 1 calc(50% - 0.75rem);
+  min-width: 12rem;
+  padding: 0.8rem;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.2rem;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .md-typeset .companion-card {
+    flex: 1 1 100%;
+  }
+}

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -71,7 +71,16 @@ markdown_extensions:
   - pymdownx.magiclink
   - pymdownx.mark
   - pymdownx.smartsymbols
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      # Ordered: docs-relative includes win, but a page can still reach the
+      # repo root (e.g. CHANGELOG.md).  Do not narrow this to [docs] -- a
+      # project may legitimately include a file from src/ or the repo root.
+      base_path:
+        - docs
+        - .
+      # Without this a missing include is dropped silently, rendering a page
+      # that looks deliberate and is empty.
+      check_paths: true
   - pymdownx.superfences:
       custom_fences:
         - class: mermaid
@@ -125,6 +134,11 @@ plugins:
       handlers:
         python:
           paths: [src]
+          inventories:
+            # Resolves standard-library types in signatures and See Also
+            # entries.  Add your dependencies' inventories here too, e.g.
+            #   - https://numpy.org/doc/stable/objects.inv
+            - https://docs.python.org/3/objects.inv
           options:
             docstring_style: numpy
             show_source: true
@@ -139,15 +153,20 @@ plugins:
 nav:
   - Home: index.md
   - Tutorials:
+    - pages/tutorials/index.md
     - Getting Started: pages/tutorials/getting-started.md
 {% if include_examples %}    - Examples: pages/tutorials/examples.md
 {% endif %}  - How-to Guides:
+    - pages/how-to/index.md
     - Configuration: pages/how-to/configure.md
     - Troubleshooting: pages/how-to/troubleshooting.md
     - Contributing: pages/how-to/contribute.md
   - Reference:
+    - pages/reference/index.md
     - API: pages/reference/api.md
+    - Changelog: pages/reference/changelog.md
   - Explanation:
+    - pages/explanation/index.md
     - Concepts: pages/explanation/concepts.md
 
 extra:

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -177,5 +177,8 @@ extra:
 watch:
   - mkdocs.yml
   - docs
+  # The API pages are generated from the package source, so a source edit must
+  # trigger a rebuild -- otherwise adding a class shows nothing until restart.
+  - src
 {% if include_examples %}  - examples
 {% endif -%}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -213,6 +213,11 @@ exclude = ["CHANGELOG.md", "site", "htmlcov", ".nox", ".venv", "openspec"]
 ".github/PULL_REQUEST_TEMPLATE.md" = ["MD041"]  # PR template starts with checklist
 ".github/skills/**" = ["MD007"]  # Nested lists in skill files use variable indent
 "README.md" = ["MD041"]  # README starts with logo, not heading
+# The page is a bare `--8<--` include; the included CHANGELOG.md supplies the
+# H1. Adding one here would render two H1s and, because Material's ToC takes
+# first.children when the first heading is level 1, an empty ToC on the one
+# page that most needs one.
+"docs/pages/reference/changelog.md" = ["MD041"]
 "docs/index.md" = ["MD041"]  # Landing page starts with logo, not heading
 "CONTRIBUTING.md" = ["MD057"]  # Relative link to docs/ is valid at project level
 {% if include_actions %}

--- a/template/{% if include_examples %}examples{% endif %}/hello.py.jinja
+++ b/template/{% if include_examples %}examples{% endif %}/hello.py.jinja
@@ -13,6 +13,14 @@ __gallery__ = {
     "title": "Hello {{ project_name }}",
     "description": "Interactive scatter plot demonstrating {{ project_name }} with marimo notebooks.",
     "category": "tutorial",
+    # Renders this notebook as a card on the named docs page, which must carry
+    # the <!-- COMPANION_NOTEBOOKS --> placeholder.
+    "companion": "pages/tutorials/getting-started.md",
+    # You can also add:
+    #   "api_references": ["MyClass", "my_function"]
+    # to say which symbols this notebook demonstrates.  Without it, the symbols
+    # are inferred from the notebook's imports -- which also picks up
+    # scaffolding, so declaring is more precise once a gallery grows.
 }
 app = marimo.App(width="medium")
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1447,11 +1447,6 @@ def test_claude_skills_not_gitignored(copie_session_default):
     )
 
 
-# ---------------------------------------------------------------------------
-# API name lookup and re-export resolution
-# ---------------------------------------------------------------------------
-
-
 def _load_hooks(project_dir, unique_suffix):
     """Import a generated docs/hooks.py under a unique module name.
 
@@ -1603,11 +1598,6 @@ def test_api_name_lookup_shared_with_notebook_usage(copie_session_default):
     assert "name_to_qualified = _get_api_name_lookup(project_root)" in hooks_source, (
         "_get_notebook_api_usage must consume the shared lookup, not derive a second map"
     )
-
-
-# ---------------------------------------------------------------------------
-# See Also linkification
-# ---------------------------------------------------------------------------
 
 
 class _FakeFile:
@@ -1795,11 +1785,6 @@ def test_see_also_qualified_name_matches_bare_form(copie_session_minimal):
     )
 
 
-# ---------------------------------------------------------------------------
-# Example gallery linking: api_references override and companion cards
-# ---------------------------------------------------------------------------
-
-
 def _write_notebook(project_dir, stem, gallery_body, imports=""):
     nb = project_dir / "examples" / f"{stem}.py"
     nb.parent.mkdir(parents=True, exist_ok=True)
@@ -1983,11 +1968,6 @@ def test_gallery_features_absent_without_examples(copie_session_minimal):
         assert symbol not in hooks_source, f"{symbol} leaked into a project generated without examples"
 
 
-# ---------------------------------------------------------------------------
-# Docs site wiring: snippets, inventories, quadrant indexes, changelog
-# ---------------------------------------------------------------------------
-
-
 def _mkdocs_config(project_dir):
     import yaml
 
@@ -2092,11 +2072,6 @@ def test_quadrant_indexes_are_local_owned(copie_session_default):
 
     for quadrant in ("tutorials", "how-to", "reference", "explanation"):
         assert f"docs/pages/{quadrant}/index.md" in tier3, f"{quadrant}/index.md not listed as local-owned"
-
-
-# ---------------------------------------------------------------------------
-# Per-build cache reset
-# ---------------------------------------------------------------------------
 
 
 def _cache_names(hooks_module):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,5 +1,6 @@
 """Tests for the copier template."""
 
+import os
 import re
 
 import pytest
@@ -1444,3 +1445,738 @@ def test_claude_skills_not_gitignored(copie_session_default):
     assert not re.search(r"^\.claude/$", gitignore, re.MULTILINE), (
         "'.claude/' excludes the directory and makes '!.claude/skills/' unreachable"
     )
+
+
+# ---------------------------------------------------------------------------
+# API name lookup and re-export resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_hooks(project_dir, unique_suffix):
+    """Import a generated docs/hooks.py under a unique module name.
+
+    The module name must be unique per project: importing two differently
+    generated hooks modules under one name makes ``sys.modules`` return the
+    first, so the second variant is never actually exercised and the test
+    passes while asserting nothing.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(f"generated_hooks_{unique_suffix}", project_dir / "docs" / "hooks.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_reexport_package(project_dir, package_name):
+    """Lay down a package whose public API is exposed entirely by re-export."""
+    pkg = project_dir / "src" / package_name
+    sub = pkg / "shapes"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "_impl.py").write_text(
+        '"""Private implementation module."""\n\n\n'
+        'class Circle:\n    """A round shape."""\n\n\n'
+        'class Square:\n    """A boxy shape."""\n\n\n'
+        'def area(shape):\n    """Compute an area."""\n    return 0\n',
+        encoding="utf-8",
+    )
+    (sub / "__init__.py").write_text(
+        '"""Shapes."""\n\n'
+        "from pathlib import Path\n"
+        f"from {package_name}.shapes._impl import Circle, area\n"
+        "from ._impl import Square as Box\n\n"
+        "MAX_SIDES = 4\n\n"
+        '__all__ = ["Box", "Circle", "MAX_SIDES", "area"]\n',
+        encoding="utf-8",
+    )
+
+    # A package exposing an optional extra, guarding its re-exports in a try block.
+    optional = pkg / "optional"
+    optional.mkdir(parents=True, exist_ok=True)
+    (optional / "_impl.py").write_text(
+        '"""Optional implementation."""\n\n\nclass Widget:\n    """An optional widget."""\n',
+        encoding="utf-8",
+    )
+    (optional / "__init__.py").write_text(
+        '"""Optional feature."""\n\n'
+        "try:\n"
+        f"    from {package_name}.optional._impl import Widget\n"
+        "except ImportError as err:  # pragma: no cover\n"
+        '    raise ImportError("install extras") from err\n\n'
+        '__all__ = ["Widget"]\n',
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def test_reexported_symbols_resolve(copie_session_minimal):
+    """Re-exported symbols resolve, and the API page members table populates."""
+    project_dir = copie_session_minimal.project_dir
+    pkg = _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "reexport")
+
+    members = hooks._get_public_members(pkg / "shapes" / "__init__.py", pkg)
+    names = {e["name"] for e in members["classes"] + members["functions"]}
+
+    # Re-exported classes and functions are found, despite the __init__ declaring none.
+    assert "Circle" in names, "re-exported class not resolved"
+    assert "area" in names, "re-exported function not resolved"
+    # Aliased re-export resolves under the exposed name, not the declared one.
+    assert "Box" in names, "aliased re-export not resolved under its exposed name"
+    assert "Square" not in names, "aliased re-export leaked its declared name"
+    # __all__ filters, it does not authorise: a constant has no page, so it must not resolve.
+    assert "MAX_SIDES" not in names, "__all__-listed constant resolved but has no page"
+    # An import that leaves the package is not part of this package's API.
+    assert "Path" not in names, "incidental third-party import resolved"
+
+    # Classes and functions are bucketed correctly, with descriptions from the declaring module.
+    assert {e["name"] for e in members["classes"]} == {"Circle", "Box"}
+    assert {e["name"] for e in members["functions"]} == {"area"}
+    assert next(e for e in members["classes"] if e["name"] == "Circle")["doc"] == "A round shape."
+
+
+def test_reexports_guarded_by_try_resolve(copie_session_minimal):
+    """Re-exports guarded by a try block (the optional-extra idiom) still resolve.
+
+    ``ast.iter_child_nodes`` sees only the ``Try`` node, so a top-level-only
+    scan silently renders an empty API page for these packages.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "tryblock")
+
+    members = hooks._get_public_members(pkg / "optional" / "__init__.py", pkg)
+    names = {e["name"] for e in members["classes"] + members["functions"]}
+
+    assert "Widget" in names, "re-export inside a try block was not resolved"
+    assert next(e for e in members["classes"] if e["name"] == "Widget")["doc"] == "An optional widget."
+
+
+def test_api_name_lookup_without_importing_package(copie_session_minimal):
+    """The lookup is built by static analysis, never by importing the package."""
+    import sys
+
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "noimport")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    lookup = hooks._get_api_name_lookup(project_dir)
+
+    assert lookup.get("Circle") == "minimal_project.shapes.Circle", (
+        f"re-exported symbol not in lookup: {sorted(lookup)}"
+    )
+    assert "minimal_project" not in sys.modules, "hooks imported the generated package"
+
+
+def test_api_name_lookup_every_name_has_a_page(copie_session_minimal):
+    """Interlock: every resolvable name has a generated page to link to."""
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "interlock")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    hooks._generate_api_pages(project_dir)
+    generated = {p.stem for p in (project_dir / "docs" / "pages" / "api" / "generated").glob("*.md")}
+    lookup = hooks._get_api_name_lookup(project_dir)
+
+    # Guard against a vacuous pass: the re-exported symbols must actually be under test.
+    assert "Circle" in lookup, f"re-export package not picked up; lookup={sorted(lookup)}"
+    missing = sorted(q for q in lookup.values() if q not in generated)
+    assert not missing, f"lookup resolves names with no generated page: {missing}"
+
+
+def test_api_name_lookup_available_without_examples(copie_session_minimal):
+    """The lookup is not gated behind include_examples."""
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    assert "def _get_api_name_lookup" in hooks_source, "lookup missing when examples are disabled"
+    assert "_API_NAME_LOOKUP_CACHE" in hooks_source, "lookup cache missing when examples are disabled"
+    assert "def _get_notebook_api_usage" not in hooks_source, "gallery code leaked into a no-examples project"
+
+
+def test_api_name_lookup_shared_with_notebook_usage(copie_session_default):
+    """The gallery consumes the shared lookup instead of building its own map."""
+    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    assert "def _get_api_name_lookup" in hooks_source
+    assert "name_to_qualified = _get_api_name_lookup(project_root)" in hooks_source, (
+        "_get_notebook_api_usage must consume the shared lookup, not derive a second map"
+    )
+
+
+# ---------------------------------------------------------------------------
+# See Also linkification
+# ---------------------------------------------------------------------------
+
+
+class _FakeFile:
+    def __init__(self, src_path, dest_path):
+        self.src_path = src_path
+        self.dest_path = dest_path
+
+
+class _FakePage:
+    """The subset of mkdocs' Page that on_page_content actually touches."""
+
+    def __init__(self, src_path, dest_path):
+        self.file = _FakeFile(src_path, dest_path)
+        self.meta = {}
+        self.toc = []
+
+
+def _see_also_page(package_name, class_name, entries, *, method_entries=""):
+    """Build a page shaped like real mkdocstrings output.
+
+    The ``<h2 id="{pkg}.{Class}">`` and the ``doc-children`` boundary are not
+    decoration: without the h2, ``_process_api_page_content`` returns early, and
+    a fixture missing it makes every downstream assertion meaningless.
+    """
+    method_block = ""
+    if method_entries:
+        method_block = (
+            f'<h3 id="{package_name}.{class_name}.fit">fit</h3>'
+            f'<details class="see-also" open><summary>See Also</summary><p>{method_entries}</p></details>'
+        )
+    return (
+        f'<h2 id="{package_name}.{class_name}">{class_name}</h2>'
+        f'<div class="doc doc-contents">'
+        f'<details class="see-also" open><summary>See Also</summary><p>{entries}</p></details>'
+        f"</div>"
+        f'<div class="doc doc-children">{method_block}</div>'
+    )
+
+
+def _generated_page(package_name, class_name):
+    src = f"pages/api/generated/{package_name}.models.{class_name}.md"
+    return _FakePage(src, src.replace(".md", "/index.html"))
+
+
+def _write_models_module(project_dir, package_name):
+    """A module with sibling classes for See Also entries to point at."""
+    (project_dir / "src" / package_name / "models.py").write_text(
+        '"""Models."""\n\n\nclass Alpha:\n    """Alpha."""\n\n\nclass Beta:\n    """Beta."""\n\n\nclass Gamma:\n    """Gamma."""\n',
+        encoding="utf-8",
+    )
+
+
+def test_see_also_links_class_level_entries(copie_session_minimal):
+    """Class-level See Also entries link — the case a post-restructure hook misses.
+
+    Driven through on_page_content, not the linkifier alone: the container this
+    feature depends on is destroyed partway through that function, so testing
+    the linkifier in isolation proves nothing about the real pipeline.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_class")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page(
+        "minimal_project",
+        "Alpha",
+        "Beta : Plain numpydoc. <code>Gamma</code> : Backticked. NotARealThing : Unknown.",
+    )
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "plain entry not linked"
+    assert '<a href="../minimal_project.models.Gamma/"><code>Gamma</code></a>' in out, "code-span entry not linked"
+    assert "Plain numpydoc." in out, "description text was altered"
+    assert not re.search(r"<a[^>]*>NotARealThing", out), "unresolvable entry was linked"
+    # The container is gone by the end -- proof the linkifier ran before the restructure.
+    assert '<details class="see-also"' not in out
+
+
+def test_see_also_links_method_level_entries(copie_session_minimal):
+    """Method-level See Also entries link too (they sit outside class_region)."""
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_method")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "Beta : Class level.", method_entries="Gamma : Method level.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "method-level entry not linked"
+
+
+def test_see_also_linkify_runs_before_restructure(copie_session_minimal):
+    """Order-locking: reordering on_page_content silently reverts this feature.
+
+    Linkifying after the restructure produces nothing for class-level sections
+    while still working for method-level ones, so a test that only covers
+    method-level entries would not catch the regression.
+    """
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    body = hooks_source[hooks_source.index("def on_page_content") :]
+    linkify_at = body.index("_linkify_see_also(")
+    restructure_at = body.index("_process_api_page_content(")
+    assert linkify_at < restructure_at, (
+        "_linkify_see_also must be called BEFORE _process_api_page_content; "
+        "the latter dissolves the <details class='see-also'> block the former matches"
+    )
+
+
+def test_see_also_scoped_to_generated_api_pages(copie_session_minimal):
+    """A See Also block on a non-generated page is not rewritten."""
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_scope")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = '<details class="see-also" open><summary>See Also</summary><p>Beta : Nope.</p></details>'
+    page = _FakePage("pages/api/models.md", "pages/api/models/index.html")
+    out = hooks.on_page_content(html, page, {}, None)
+
+    assert out == html, "linkification leaked outside pages/api/generated/"
+
+
+def test_see_also_external_name_defers_to_autorefs(copie_session_minimal):
+    """An external dotted name is handed to autorefs, not resolved eagerly.
+
+    Inventories are registered into the autorefs URL map but applied in its
+    on_env hook, which runs after on_page_content -- asking for the URL here
+    raises KeyError even when the inventory is configured. The `optional`
+    attribute keeps an unresolvable name quiet rather than failing --strict.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_external")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "sklearn.linear_model.Ridge : External. Beta : Project.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<autoref optional identifier="sklearn.linear_model.Ridge">sklearn.linear_model.Ridge</autoref>' in out, (
+        "external name was not deferred to autorefs"
+    )
+    # The project symbol is still resolved here, against the page set we own.
+    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out
+
+
+def test_see_also_bare_unresolvable_name_is_left_alone(copie_session_minimal):
+    """A bare name that misses the project lookup is not offered to autorefs.
+
+    It could resolve to an unrelated symbol sharing the name in some configured
+    inventory, and a wrong link is worse than no link.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_bare")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "NotAThing : Unknown bare name.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert "<autoref" not in out, "a bare name was offered to autorefs"
+    assert "NotAThing : Unknown bare name." in out, "bare unresolvable entry was altered"
+
+
+def test_see_also_qualified_name_matches_bare_form(copie_session_minimal):
+    """A fully qualified project entry links to the same page as the bare form."""
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_qualified")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "minimal_project.models.Beta : Qualified.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Beta/">minimal_project.models.Beta</a>' in out, (
+        "qualified project name did not resolve to the same page as the bare form"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Example gallery linking: api_references override and companion cards
+# ---------------------------------------------------------------------------
+
+
+def _write_notebook(project_dir, stem, gallery_body, imports=""):
+    nb = project_dir / "examples" / f"{stem}.py"
+    nb.parent.mkdir(parents=True, exist_ok=True)
+    nb.write_text(f"import marimo\n\n{imports}\n__gallery__ = {{{gallery_body}}}\n", encoding="utf-8")
+    return nb
+
+
+def _reset_gallery_caches(hooks):
+    hooks._GALLERY_CACHE = None
+    hooks._NOTEBOOK_API_USAGE_CACHE = None
+    hooks._COMPANION_INDEX_CACHE = None
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+
+def test_declared_api_references_override_imports(copie_session_default):
+    """A declared api_references list wins over what the notebook imports."""
+    project_dir = copie_session_default.project_dir
+    _write_models_module(project_dir, "test_project")
+    _write_notebook(
+        project_dir,
+        "declared_nb",
+        '"title": "Declared", "description": "d", "category": "tutorial", "api_references": ["Beta"]',
+        imports="from test_project.models import Alpha, Gamma\n",
+    )
+    hooks = _load_hooks(project_dir, "egl_declared")
+    _reset_gallery_caches(hooks)
+
+    usage = hooks._get_notebook_api_usage(project_dir)
+    stems = {q: {i["stem"] for i in items} for q, items in usage.items()}
+
+    assert "declared_nb" in stems.get("test_project.models.Beta", set()), "declared reference not used"
+    assert "declared_nb" not in stems.get("test_project.models.Alpha", set()), "import won over declaration"
+    assert "declared_nb" not in stems.get("test_project.models.Gamma", set()), "import won over declaration"
+
+
+def test_absent_api_references_falls_back_to_imports(copie_session_default):
+    """A notebook declaring nothing still gets cross-referenced.
+
+    This is the day-one path: a fresh project has no metadata, and the feature
+    must be visible before anyone opts in.
+    """
+    project_dir = copie_session_default.project_dir
+    _write_models_module(project_dir, "test_project")
+    _write_notebook(
+        project_dir,
+        "fallback_nb",
+        '"title": "Fallback", "description": "d", "category": "tutorial"',
+        imports="from test_project.models import Alpha\n",
+    )
+    hooks = _load_hooks(project_dir, "egl_fallback")
+    _reset_gallery_caches(hooks)
+
+    usage = hooks._get_notebook_api_usage(project_dir)
+    stems = {i["stem"] for i in usage.get("test_project.models.Alpha", [])}
+
+    assert "fallback_nb" in stems, "notebook without api_references was not inferred from imports"
+
+
+def test_empty_api_references_means_no_pages(copie_session_default):
+    """An empty list is a statement ('nowhere'), not an omission ('infer')."""
+    project_dir = copie_session_default.project_dir
+    _write_models_module(project_dir, "test_project")
+    _write_notebook(
+        project_dir,
+        "optout_nb",
+        '"title": "Optout", "description": "d", "category": "tutorial", "api_references": []',
+        imports="from test_project.models import Alpha\n",
+    )
+    hooks = _load_hooks(project_dir, "egl_empty")
+    _reset_gallery_caches(hooks)
+
+    usage = hooks._get_notebook_api_usage(project_dir)
+    appearances = {q for q, items in usage.items() if any(i["stem"] == "optout_nb" for i in items)}
+
+    assert not appearances, f"api_references: [] still produced cards on {appearances}"
+
+
+def test_unresolvable_api_reference_is_ignored(copie_session_default):
+    """A declared name that resolves to nothing is dropped, not fatal."""
+    project_dir = copie_session_default.project_dir
+    _write_models_module(project_dir, "test_project")
+    _write_notebook(
+        project_dir,
+        "bogus_nb",
+        '"title": "Bogus", "description": "d", "category": "tutorial", "api_references": ["NotAThing", "Beta"]',
+    )
+    hooks = _load_hooks(project_dir, "egl_bogus")
+    _reset_gallery_caches(hooks)
+
+    usage = hooks._get_notebook_api_usage(project_dir)
+
+    assert not [q for q in usage if "NotAThing" in q], "unresolvable name produced an entry"
+    assert any(i["stem"] == "bogus_nb" for i in usage.get("test_project.models.Beta", [])), "valid name was dropped too"
+
+
+def test_api_example_cards_are_capped(copie_session_default):
+    """The card list is bounded, with the remainder reachable via the gallery."""
+    project_dir = copie_session_default.project_dir
+    # A symbol only this test references: the session project is shared, so
+    # reusing one would let another test's notebooks into the card list.
+    (project_dir / "src" / "test_project" / "capped.py").write_text(
+        '"""Capped."""\n\n\nclass Capstone:\n    """Capstone."""\n', encoding="utf-8"
+    )
+    notebook_count = 9
+    for i in range(notebook_count):
+        _write_notebook(
+            project_dir,
+            f"capped_{i:02d}",
+            f'"title": "Capped {i:02d}", "description": "d", "category": "tutorial", "api_references": ["Capstone"]',
+        )
+    hooks = _load_hooks(project_dir, "egl_cap")
+    _reset_gallery_caches(hooks)
+
+    html = hooks._build_api_examples_html(project_dir, "test_project.capped.Capstone")
+
+    assert notebook_count > hooks._API_EXAMPLES_CAP, "test does not actually exceed the cap"
+    assert html.count("**Capped") == hooks._API_EXAMPLES_CAP, "card list was not capped"
+    assert "See all" in html and "in the gallery" in html, "no overflow link past the cap"
+    # Stable order: same input, same cards, so builds are reproducible.
+    assert hooks._build_api_examples_html(project_dir, "test_project.capped.Capstone") == html
+
+
+def test_api_example_cards_under_cap_have_no_gallery_link(copie_session_default):
+    """Below the cap, nothing is hidden, so no overflow link is shown."""
+    project_dir = copie_session_default.project_dir
+    _write_models_module(project_dir, "test_project")
+    _write_notebook(
+        project_dir,
+        "solo_nb",
+        '"title": "Solo", "description": "d", "category": "tutorial", "api_references": ["Gamma"]',
+    )
+    hooks = _load_hooks(project_dir, "egl_undercap")
+    _reset_gallery_caches(hooks)
+
+    html = hooks._build_api_examples_html(project_dir, "test_project.models.Gamma")
+
+    assert "**Solo**" in html
+    assert "See all" not in html, "overflow link shown when nothing was hidden"
+
+
+def test_companion_path_variants_match_same_page(copie_session_default):
+    """companion is hand-written, so authored spellings must all match."""
+    hooks = _load_hooks(copie_session_default.project_dir, "egl_norm")
+    variants = [
+        "/pages/how-to/x/",
+        "pages/how-to/x",
+        "pages/how-to/x.md",
+        "/pages/how-to/x",
+    ]
+    normalized = {hooks._normalize_companion_path(v) for v in variants}
+    assert len(normalized) == 1, f"companion path variants did not normalize together: {normalized}"
+
+
+def test_companion_placeholder_renders_nothing_when_unmatched(copie_session_default):
+    """A page with the placeholder and no companion notebooks renders empty."""
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "egl_nocompanion")
+    _reset_gallery_caches(hooks)
+
+    html = hooks._build_companion_cards_html(project_dir, "pages/how-to/nobody-references-me.md")
+
+    assert html == "", "unmatched placeholder produced output"
+
+
+def test_companion_cache_is_registered_by_name(copie_session_default):
+    """The companion cache must carry the _CACHE suffix.
+
+    The per-build reset's registration test discovers caches by that suffix, so
+    a cache named otherwise (the natural `_COMPANION_INDEX`) is invisible to it
+    and the stale-read bug returns silently.
+    """
+    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    assert "_COMPANION_INDEX_CACHE" in hooks_source, "companion cache does not follow the *_CACHE convention"
+
+
+def test_gallery_features_absent_without_examples(copie_session_minimal):
+    """The whole feature is gated behind include_examples."""
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    for symbol in ("_COMPANION_INDEX_CACHE", "_API_EXAMPLES_CAP", "_build_companion_cards_html"):
+        assert symbol not in hooks_source, f"{symbol} leaked into a project generated without examples"
+
+
+# ---------------------------------------------------------------------------
+# Docs site wiring: snippets, inventories, quadrant indexes, changelog
+# ---------------------------------------------------------------------------
+
+
+def _mkdocs_config(project_dir):
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_multi_constructor("tag:yaml.org,2002:python/name:", lambda loader, suffix, node: suffix)
+    _Loader.add_constructor("!ENV", lambda loader, node: None)
+    return yaml.load((project_dir / "mkdocs.yml").read_text(), Loader=_Loader)
+
+
+def test_snippets_resolve_docs_and_repo_root(copie_session_default):
+    """base_path must reach the repo root as well as docs/.
+
+    Narrowing this to [docs] breaks any project that includes a file from the
+    repo root or src/ -- which real projects do.
+    """
+    config = _mkdocs_config(copie_session_default.project_dir)
+    snippets = next(x["pymdownx.snippets"] for x in config["markdown_extensions"] if "pymdownx.snippets" in str(x))
+
+    assert snippets["base_path"] == ["docs", "."], "base_path must search docs first, then the repo root"
+    assert snippets["check_paths"] is True, "a missing include must fail the build, not vanish"
+
+
+def test_changelog_include_resolves(copie_session_default):
+    """The changelog page must actually render the changelog.
+
+    A green build is not evidence here: without check_paths the include is
+    dropped silently and the page renders as a heading with nothing under it.
+    """
+    import markdown
+
+    project_dir = copie_session_default.project_dir
+    page = project_dir / "docs" / "pages" / "reference" / "changelog.md"
+    assert page.is_file(), "changelog page not generated"
+
+    md = markdown.Markdown(
+        extensions=["pymdownx.snippets"],
+        extension_configs={"pymdownx.snippets": {"base_path": ["docs", "."], "check_paths": True}},
+    )
+    cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        rendered = md.convert(page.read_text())
+    finally:
+        os.chdir(cwd)
+
+    assert "Changelog" in rendered, "changelog content did not render"
+    assert rendered.count("<h1") == 1, "changelog page renders a duplicate <h1> (own heading plus the include's)"
+
+
+def test_python_inventory_configured(copie_session_default):
+    """Signatures reference stdlib types, so that inventory earns its place."""
+    config = _mkdocs_config(copie_session_default.project_dir)
+    handler = next(p["mkdocstrings"] for p in config["plugins"] if isinstance(p, dict) and "mkdocstrings" in p)
+    inventories = handler["handlers"]["python"]["inventories"]
+
+    assert any("docs.python.org" in str(i) for i in inventories), "Python inventory not configured"
+
+
+def test_quadrant_index_pages_exist_and_lead_nav(copie_session_default):
+    """navigation.indexes is on, so each quadrant needs a landing page first."""
+    project_dir = copie_session_default.project_dir
+    config = _mkdocs_config(project_dir)
+
+    for quadrant in ("tutorials", "how-to", "reference", "explanation"):
+        assert (project_dir / "docs" / "pages" / quadrant / "index.md").is_file(), f"{quadrant}/index.md missing"
+
+    sections = {k: v for entry in config["nav"] if isinstance(entry, dict) for k, v in entry.items()}
+    for label, quadrant in (
+        ("Tutorials", "tutorials"),
+        ("How-to Guides", "how-to"),
+        ("Reference", "reference"),
+        ("Explanation", "explanation"),
+    ):
+        assert sections[label][0] == f"pages/{quadrant}/index.md", f"{label} nav must start with its index page"
+
+
+def test_quadrant_indexes_are_local_owned(copie_session_default):
+    """The template's skeleton must never overwrite a project's own landing page.
+
+    Four of the seven repos generated from this template already maintain
+    hand-written index pages; an update that replaces them is a regression
+    shipped as an upgrade.
+    """
+    classification = (
+        copie_session_default.project_dir
+        / ".github"
+        / "skills"
+        / "update-from-template"
+        / "references"
+        / "file-classification.md"
+    )
+    if not classification.is_file():
+        pytest.skip("update-from-template skill not shipped to generated projects")
+    text = classification.read_text()
+    tier3 = text[text.index("## Tier 3") :]
+
+    for quadrant in ("tutorials", "how-to", "reference", "explanation"):
+        assert f"docs/pages/{quadrant}/index.md" in tier3, f"{quadrant}/index.md not listed as local-owned"
+
+
+# ---------------------------------------------------------------------------
+# Per-build cache reset
+# ---------------------------------------------------------------------------
+
+
+def _cache_names(hooks_module):
+    return [n for n in vars(hooks_module) if n.endswith("_CACHE") and not n.startswith("__")]
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expects_gallery"),
+    [("copie_session_default", True), ("copie_session_minimal", False)],
+)
+def test_on_config_resets_every_cache(request, fixture_name, expects_gallery):
+    """Sentinel round-trip: populate every cache, reset, assert all cleared.
+
+    Deliberately not a presence check on the source. Asserting that the cache
+    names appear in on_config's body passes even against an empty function, so
+    it would verify nothing. Each variant is loaded under a unique module name:
+    importing both under one name makes sys.modules return the first, and the
+    second variant is never actually exercised.
+    """
+    project_dir = request.getfixturevalue(fixture_name).project_dir
+    hooks = _load_hooks(project_dir, f"reset_{fixture_name}")
+
+    names = _cache_names(hooks)
+    assert names, "no *_CACHE globals discovered"
+    assert ("_GALLERY_CACHE" in names) is expects_gallery, (
+        f"gallery cache presence should follow include_examples; found {sorted(names)}"
+    )
+
+    sentinel = object()
+    for name in names:
+        setattr(hooks, name, sentinel)
+
+    hooks.on_config({})
+
+    still_set = [n for n in names if getattr(hooks, n) is sentinel]
+    assert not still_set, f"on_config did not clear: {still_set}"
+
+
+def test_on_config_returns_config(copie_session_default):
+    """The mkdocs contract allows returning None, but the config is clearer."""
+    hooks = _load_hooks(copie_session_default.project_dir, "reset_returns")
+    config = {"marker": True}
+    assert hooks.on_config(config) is config
+
+
+def test_hooks_define_on_config_not_on_startup(copie_session_default):
+    """on_startup runs once per invocation, so a reset there never fires again.
+
+    That is the bug this change exists to fix; defining it would reintroduce it.
+    """
+    source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    assert "def on_config(" in source, "no per-build reset"
+    assert "def on_startup(" not in source, "on_startup fires once per invocation, not per build"
+
+
+def test_no_phantom_cache_without_examples(copie_session_minimal):
+    """The reset must not name caches a project does not define.
+
+    `global X; X = None` creates the binding rather than raising, so an
+    ungated reset silently grows module attributes nothing reads -- and the
+    discovery test would then dutifully confirm they are cleared.
+    """
+    hooks = _load_hooks(copie_session_minimal.project_dir, "reset_phantom")
+    hooks.on_config({})
+
+    for gallery_cache in ("_GALLERY_CACHE", "_COMPANION_INDEX_CACHE", "_NOTEBOOK_API_USAGE_CACHE"):
+        assert not hasattr(hooks, gallery_cache), f"{gallery_cache} phantom-created in a no-examples project"
+
+
+def test_shipped_skill_mirrors_are_byte_identical(copie_session_default):
+    """The two shipped skill trees must not drift.
+
+    .github/skills and .claude/skills are hand-maintained duplicates: Copilot
+    reads one, Claude Code reads the other. Comparing directory names only
+    (the previous check) passes while their contents diverge, so an edit to one
+    copy ships a stale other -- and inside a generated project it is the
+    .claude copy that Claude Code actually loads.
+    """
+    project_dir = copie_session_default.project_dir
+    gh, cl = project_dir / ".github" / "skills", project_dir / ".claude" / "skills"
+    if not (gh.is_dir() and cl.is_dir()):
+        pytest.skip("skills not shipped to generated projects")
+
+    gh_files = {p.relative_to(gh): p for p in gh.rglob("*") if p.is_file()}
+    cl_files = {p.relative_to(cl): p for p in cl.rglob("*") if p.is_file()}
+
+    assert set(gh_files) == set(cl_files), "shipped skill trees have different files"
+    drifted = [str(rel) for rel, p in gh_files.items() if p.read_bytes() != cl_files[rel].read_bytes()]
+    assert not drifted, f"shipped skill copies have drifted: {drifted}"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2083,7 +2083,11 @@ def test_quadrant_indexes_are_local_owned(copie_session_default):
     if not classification.is_file():
         pytest.skip("update-from-template skill not shipped to generated projects")
     text = classification.read_text()
-    tier3 = text[text.index("## Tier 3") :]
+    # Slice to the section end, not EOF: running to EOF would let a path
+    # listed in a LATER section satisfy this assertion.
+    start = text.index("## Tier 3")
+    nxt = text.find("\n## ", start + 1)
+    tier3 = text[start : nxt if nxt > 0 else len(text)]
 
     for quadrant in ("tutorials", "how-to", "reference", "explanation"):
         assert f"docs/pages/{quadrant}/index.md" in tier3, f"{quadrant}/index.md not listed as local-owned"
@@ -2398,6 +2402,7 @@ def test_companion_card_renders_with_resolved_links(copie_session_default):
     out = hooks.on_page_markdown("<!-- COMPANION_NOTEBOOKS -->", page, config, None)
 
     assert "COMPANION_NOTEBOOKS" not in out, "placeholder was not consumed"
+    assert "## Try it interactively" in out, "heading not emitted with the cards"
     assert "Companion NB" in out, "companion card did not render"
     # pages/how-to/configure.md is three deep, so the rewrite prefixes ../../../
     assert "](../../../examples/companion_nb/" in out, f"View link not resolved to a relative path: {out[:200]}"
@@ -2468,3 +2473,19 @@ def test_third_party_import_rejected_without_dunder_all(copie_session_minimal):
 
     assert "Gadget" in names, "first-party re-export not resolved without __all__"
     assert "Path" not in names, "a stdlib import was resolved as package API"
+
+
+def test_companion_placeholder_renders_no_dangling_heading(copie_session_default):
+    """A page with no matching notebooks renders nothing -- not a bare heading.
+
+    The heading is emitted with the cards rather than written into the page, so
+    removing a notebook's companion cannot leave an empty section behind.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "companion_empty")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/how-to/troubleshooting.md", "pages/how-to/troubleshooting/index.html")
+    out = hooks.on_page_markdown("<!-- COMPANION_NOTEBOOKS -->", page, {"repo_url": "https://github.com/s/p"}, None)
+
+    assert out.strip() == "", f"an unmatched placeholder left content behind: {out!r}"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1904,7 +1904,10 @@ def test_api_example_cards_are_capped(copie_session_default):
     assert notebook_count > hooks._API_EXAMPLES_CAP, "test does not actually exceed the cap"
     assert html.count("**Capped") == hooks._API_EXAMPLES_CAP, "card list was not capped"
     assert "See all" in html and "in the gallery" in html, "no overflow link past the cap"
-    # Stable order: same input, same cards, so builds are reproducible.
+    # Stable order: same input, same cards, so builds are reproducible. The
+    # caches must be cleared between calls -- re-reading a warm cache returns
+    # the same object and the assertion cannot fail.
+    _reset_gallery_caches(hooks)
     assert hooks._build_api_examples_html(project_dir, "test_project.capped.Capstone") == html
 
 
@@ -2333,3 +2336,85 @@ def test_docs_watch_includes_package_source(copie_session_default):
     """
     config = _mkdocs_config(copie_session_default.project_dir)
     assert "src" in config["watch"], f"src not watched; serve will not rebuild on source edits: {config['watch']}"
+
+
+def test_see_also_does_not_linkify_names_outside_the_section(copie_session_minimal):
+    """A symbol name elsewhere on the page is left alone.
+
+    Symbol names appear throughout rendered docs -- in Notes, parameter tables,
+    source listings. Scoping to the See Also block is what stops the linkifier
+    rewriting all of them.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_scope_name")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = (
+        '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
+        "<h3>Notes</h3><p>Beta : mentioned in prose, not a See Also entry.</p>"
+        '<details class="see-also" open><summary>See Also</summary><p>Gamma : A real entry.</p></details>'
+        '</div><div class="doc doc-children"></div>'
+    )
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "the See Also entry was not linked"
+    assert not re.search(r"<a[^>]*>Beta</a>", out), "a name outside the See Also section was linkified"
+
+
+def test_companion_card_renders_with_resolved_links(copie_session_default):
+    """The primary companion path: a card with working links, end to end.
+
+    The cards are emitted as markdown so the [View]/[Open in marimo] rewrites
+    below them resolve the URLs. Emitting resolved HTML instead would bypass
+    those rewrites and ship literal placeholders -- which is why this asserts
+    the rendered hrefs, not just that a card appeared.
+    """
+    project_dir = copie_session_default.project_dir
+    _write_notebook(
+        project_dir,
+        "companion_nb",
+        '"title": "Companion NB", "description": "Demo.", "category": "how-to",'
+        ' "companion": "pages/how-to/configure.md"',
+    )
+    hooks = _load_hooks(project_dir, "companion_render")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/how-to/configure.md", "pages/how-to/configure/index.html")
+    config = {"repo_url": "https://github.com/s/p"}
+    out = hooks.on_page_markdown("<!-- COMPANION_NOTEBOOKS -->", page, config, None)
+
+    assert "COMPANION_NOTEBOOKS" not in out, "placeholder was not consumed"
+    assert "Companion NB" in out, "companion card did not render"
+    # pages/how-to/configure.md is three deep, so the rewrite prefixes ../../../
+    assert "](../../../examples/companion_nb/" in out, f"View link not resolved to a relative path: {out[:200]}"
+    assert "marimo.app" in out, "Open-in-marimo link not resolved to a playground URL"
+    assert "](/examples/" not in out, "an unresolved absolute example path survived"
+
+
+def test_changelog_page_has_a_populated_toc(copie_session_default):
+    """The changelog is the page that most needs a ToC.
+
+    Material's ToC partial takes first.children when the first heading is level
+    1, so a page with two h1s renders an empty ToC -- silently, on the one page
+    with a heading per release.
+    """
+    import markdown
+
+    project_dir = copie_session_default.project_dir
+    page = project_dir / "docs" / "pages" / "reference" / "changelog.md"
+    md = markdown.Markdown(
+        extensions=["pymdownx.snippets", "toc"],
+        extension_configs={"pymdownx.snippets": {"base_path": ["docs", "."], "check_paths": True}},
+    )
+    cwd = os.getcwd()
+    try:
+        os.chdir(project_dir)
+        md.convert(page.read_text())
+    finally:
+        os.chdir(cwd)
+
+    tokens = md.toc_tokens
+    assert tokens, "changelog page produced no table of contents"
+    assert len([t for t in tokens if t["level"] == 1]) == 1, "more than one level-1 heading collapses Material's ToC"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1485,6 +1485,18 @@ def _write_reexport_package(project_dir, package_name):
         encoding="utf-8",
     )
 
+    # A package with NO __all__: here the package-root guard in
+    # _resolve_import_from is what must reject `from pathlib import Path`. The
+    # __all__-bearing package above cannot exercise it -- the filter rejects
+    # Path first, so the guard is never consulted.
+    noall = pkg / "noall"
+    noall.mkdir(parents=True, exist_ok=True)
+    (noall / "_impl.py").write_text('"""Impl."""\n\n\nclass Gadget:\n    """A gadget."""\n', encoding="utf-8")
+    (noall / "__init__.py").write_text(
+        '"""No dunder all."""\n\nfrom pathlib import Path\nfrom ._impl import Gadget\n',
+        encoding="utf-8",
+    )
+
     # A package exposing an optional extra, guarding its re-exports in a try block.
     optional = pkg / "optional"
     optional.mkdir(parents=True, exist_ok=True)
@@ -2418,3 +2430,41 @@ def test_changelog_page_has_a_populated_toc(copie_session_default):
     tokens = md.toc_tokens
     assert tokens, "changelog page produced no table of contents"
     assert len([t for t in tokens if t["level"] == 1]) == 1, "more than one level-1 heading collapses Material's ToC"
+
+
+def test_reexported_symbols_appear_in_the_api_index(copie_session_minimal):
+    """The searchable API index lists re-exported symbols too.
+
+    The index, the package pages and the name lookup must all be fed by the
+    same member scan. Feeding the index from a scan that cannot see re-exports
+    leaves it blind to exactly the symbols this resolution exists to surface:
+    their pages exist and the lookup resolves them, while the index shows
+    nothing.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "api_index")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = hooks._build_api_table_html(project_dir)
+
+    assert "Circle" in html, "re-exported class absent from the searchable API index"
+    assert "area" in html, "re-exported function absent from the searchable API index"
+
+
+def test_third_party_import_rejected_without_dunder_all(copie_session_minimal):
+    """Without __all__, the package-root guard is what excludes stdlib imports.
+
+    The __all__-bearing fixture cannot show this: the filter rejects Path before
+    the guard is consulted. This exercises the guard itself.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "noall")
+
+    members = hooks._get_public_members(pkg / "noall" / "__init__.py", pkg)
+    names = {e["name"] for e in members["classes"] + members["functions"]}
+
+    assert "Gadget" in names, "first-party re-export not resolved without __all__"
+    assert "Path" not in names, "a stdlib import was resolved as package API"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2180,3 +2180,139 @@ def test_shipped_skill_mirrors_are_byte_identical(copie_session_default):
     assert set(gh_files) == set(cl_files), "shipped skill trees have different files"
     drifted = [str(rel) for rel, p in gh_files.items() if p.read_bytes() != cl_files[rel].read_bytes()]
     assert not drifted, f"shipped skill copies have drifted: {drifted}"
+
+
+def test_see_also_links_list_form_entries(copie_session_minimal):
+    """Entries written as a markdown list link too.
+
+    numpydoc renders See Also as a paragraph, but authors also write the
+    entries as a list, which renders as <li> rather than <p>. Handling only
+    paragraphs silently drops links for every list-style docstring.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_list")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = (
+        '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
+        '<details class="see-also" open><summary>See Also</summary>'
+        "<ul><li>Beta : A list entry.</li></ul></details></div>"
+        '<div class="doc doc-children"></div>'
+    )
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "list-form entry was not linked"
+
+
+def test_see_also_leaves_explicit_cross_references_alone(copie_session_minimal):
+    """An author's explicit [Name][target] reference is not rewritten.
+
+    autorefs turns explicit references into <autoref>/<a> before this hook runs
+    and resolves them later. Rewriting them would double-link, and the author
+    has already said exactly what they mean.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_explicit")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    inner = '<li><autoref identifier="minimal_project.models.Beta"><code>Beta</code></autoref> : Explicit.</li>'
+    html = (
+        '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
+        f'<details class="see-also" open><summary>See Also</summary><ul>{inner}</ul></details></div>'
+        '<div class="doc doc-children"></div>'
+    )
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert inner in out, "an explicit cross-reference was rewritten"
+    assert out.count("minimal_project.models.Beta") == 1, "explicit reference was double-linked"
+
+
+def test_reexported_members_render_in_the_api_page_table(copie_session_minimal):
+    """The change's observable fix: the members TABLE is non-empty.
+
+    Asserting that _get_public_members returns entries is not this. A lookup can
+    resolve every symbol while the rendered page stays empty -- the per-member
+    detail pages are written from a separate code path, so the interlock test
+    passes too. This asserts the rendered markdown a reader actually sees, and
+    fails if _build_members_tables stops emitting rows.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "table_render")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    hooks._generate_api_pages(project_dir)
+    page = (project_dir / "docs" / "pages" / "api" / "shapes.md").read_text()
+
+    assert "### Classes" in page, "members table missing its Classes heading"
+    assert "Circle" in page, "re-exported class absent from the rendered members table"
+    assert "A round shape." in page, "row is missing the description lifted from the declaring module"
+    assert "generated/minimal_project.shapes.Circle.md" in page, "row does not link to the member page"
+
+
+def test_api_name_lookup_prefers_the_published_path(copie_session_minimal):
+    """One symbol reachable by two paths resolves to the one users write."""
+    project_dir = copie_session_minimal.project_dir
+    (project_dir / "src" / "minimal_project" / "naive.py").write_text(
+        '"""Naive."""\n\n\nclass SeasonalNaive:\n    """Repeat last season."""\n', encoding="utf-8"
+    )
+    pub = project_dir / "src" / "minimal_project" / "point"
+    pub.mkdir(parents=True, exist_ok=True)
+    (pub / "__init__.py").write_text(
+        '"""Point."""\n\nfrom minimal_project.naive import SeasonalNaive\n\n__all__ = ["SeasonalNaive"]\n',
+        encoding="utf-8",
+    )
+    hooks = _load_hooks(project_dir, "prefer_public")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    lookup = hooks._get_api_name_lookup(project_dir)
+
+    assert lookup.get("SeasonalNaive") == "minimal_project.point.SeasonalNaive", (
+        f"published path not preferred; got {lookup.get('SeasonalNaive')!r}"
+    )
+
+
+def test_api_name_lookup_refuses_a_genuine_collision(copie_session_minimal):
+    """Two different symbols sharing a short name resolve to nothing.
+
+    A wrong link is worse than no link, so an ambiguous name degrades to plain
+    text rather than pointing at whichever module happened to be scanned last.
+    """
+    project_dir = copie_session_minimal.project_dir
+    for mod in ("dup_a", "dup_b"):
+        (project_dir / "src" / "minimal_project" / f"{mod}.py").write_text(
+            f'"""{mod}."""\n\n\nclass Duplicated:\n    """From {mod}."""\n', encoding="utf-8"
+        )
+    hooks = _load_hooks(project_dir, "collision")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    lookup = hooks._get_api_name_lookup(project_dir)
+
+    assert "Duplicated" not in lookup, (
+        f"an ambiguous short name resolved to {lookup.get('Duplicated')!r} instead of being refused"
+    )
+
+
+def test_gallery_overflow_link_targets_the_real_gallery_page(copie_session_default):
+    """The overflow link resolves to wherever the gallery page actually is.
+
+    The gallery page is local-owned, so a project may move it; a hardcoded path
+    404s silently. It is located by the <!-- GALLERY --> placeholder instead.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "gallery_url")
+    hooks._GALLERY_PAGE_CACHE = None
+
+    url = hooks._get_gallery_page_url(project_dir)
+
+    assert url, "gallery page not found by its GALLERY placeholder"
+    page = project_dir / "docs" / (url.strip("/") + ".md")
+    assert page.is_file(), f"overflow link {url} points at a page that does not exist"
+    assert "<!-- GALLERY -->" in page.read_text(), "located page is not the gallery"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1673,10 +1673,12 @@ def test_see_also_links_class_level_entries(copie_session_minimal):
     hooks._API_NAME_LOOKUP_CACHE = None
     hooks._SUBMODULE_CACHE = None
 
+    # One entry per line, as mkdocstrings actually renders them. Running them
+    # together on one line hides whether the linkifier respects entry boundaries.
     html = _see_also_page(
         "minimal_project",
         "Alpha",
-        "Beta : Plain numpydoc. <code>Gamma</code> : Backticked. NotARealThing : Unknown.",
+        "Beta : Plain numpydoc.\n<code>Gamma</code> : Backticked.\nNotARealThing : Unknown.",
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
@@ -1748,7 +1750,7 @@ def test_see_also_external_name_defers_to_autorefs(copie_session_minimal):
     hooks._API_NAME_LOOKUP_CACHE = None
     hooks._SUBMODULE_CACHE = None
 
-    html = _see_also_page("minimal_project", "Alpha", "sklearn.linear_model.Ridge : External. Beta : Project.")
+    html = _see_also_page("minimal_project", "Alpha", "sklearn.linear_model.Ridge : External.\nBeta : Project.")
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
     assert '<autoref optional identifier="sklearn.linear_model.Ridge">sklearn.linear_model.Ridge</autoref>' in out, (
@@ -2033,7 +2035,11 @@ def test_changelog_include_resolves(copie_session_default):
     finally:
         os.chdir(cwd)
 
-    assert "Changelog" in rendered, "changelog content did not render"
+    # Assert on text only the root CHANGELOG.md supplies. "Changelog" alone is a
+    # word a page with no include at all would provide for free, so it cannot
+    # fail for the defect this guards.
+    assert "Keep a Changelog" in rendered, "root CHANGELOG.md content did not render -- the include resolved to nothing"
+    assert "Semantic Versioning" in rendered, "changelog body missing"
     assert rendered.count("<h1") == 1, "changelog page renders a duplicate <h1> (own heading plus the include's)"
 
 
@@ -2316,3 +2322,39 @@ def test_gallery_overflow_link_targets_the_real_gallery_page(copie_session_defau
     page = project_dir / "docs" / (url.strip("/") + ".md")
     assert page.is_file(), f"overflow link {url} points at a page that does not exist"
     assert "<!-- GALLERY -->" in page.read_text(), "located page is not the gallery"
+
+
+def test_see_also_leaves_description_text_alone(copie_session_minimal):
+    """A colon-terminated word in an entry's DESCRIPTION is not linked.
+
+    Entry names sit at the start of their line. Without anchoring there, any
+    "Word:" in prose is treated as another entry -- so "Target : Note: see
+    below" linkifies "Note", rewriting text the spec says is left unchanged.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    # A class whose name also appears, colon-terminated, inside a description.
+    (project_dir / "src" / "minimal_project" / "prose.py").write_text(
+        '"""Prose."""\n\n\nclass Note:\n    """Named Note."""\n', encoding="utf-8"
+    )
+    hooks = _load_hooks(project_dir, "seealso_desc")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "Beta : Note: a colon-terminated word in the description.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "the entry name was not linked"
+    assert not re.search(r"<a[^>]*>Note</a>", out), "a word in the description was linkified as an entry"
+    assert "Note: a colon-terminated word in the description." in out, "description text was altered"
+
+
+def test_docs_watch_includes_package_source(copie_session_default):
+    """`mkdocs serve` must rebuild when the package source changes.
+
+    The API pages are generated from src/, so without it in `watch` an author
+    adding a class sees nothing until they restart the server -- which is the
+    scenario the per-build cache reset exists to satisfy.
+    """
+    config = _mkdocs_config(copie_session_default.project_dir)
+    assert "src" in config["watch"], f"src not watched; serve will not rebuild on source edits: {config['watch']}"

--- a/uv.lock
+++ b/uv.lock
@@ -987,6 +987,7 @@ lint = [
 tests = [
     { name = "copier" },
     { name = "covdefaults" },
+    { name = "mkdocs" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
@@ -1025,6 +1026,7 @@ lint = [
 tests = [
     { name = "copier", specifier = ">=9.11" },
     { name = "covdefaults", specifier = ">=2.3" },
+    { name = "mkdocs", specifier = ">=1.6" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-mock", specifier = ">=3.14" },


### PR DESCRIPTION
## Description

Generated projects now link numpydoc `See Also` entries to the API pages they name, populate API pages for packages that expose their public API by re-export, and connect example notebooks to the docs pages they accompany. Plus the docs-site wiring those depend on (snippet includes, inventories, quadrant landing pages) and a per-build cache reset that stops `mkdocs serve` serving stale content.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Motivation and Context

Five related gaps in the generated docs site:

- **API pages render empty for re-export layouts.** `_get_module_members` collected only `ClassDef`/`FunctionDef` nodes, so an `__init__.py` doing `from .x import Y` plus `__all__` resolved to nothing. Re-exporting a public API from private submodules is the conventional Python layout, so any project shaped that way documents nothing.
- **`See Also` entries are dead text.** mkdocstrings/griffe don't cross-link numpydoc `See Also` names, so a docstring pointing at three related classes gives the reader three names to copy into the search box.
- **`companion` is dead metadata.** The shipped `diataxis-notebook-writer` skill documents the key and nothing reads it — the template asks authors for metadata and then ignores it.
- **Snippet includes fail silently.** `check_paths` defaults to false, so a broken include renders a page that looks deliberate and is empty.
- **`mkdocs serve` serves stale content.** Module-level caches in `hooks.py` live for the process and were never reset, so source and metadata edits don't appear until restart.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — 83 passed, 2 skipped
- [x] Tested template generation with `copier copy . /tmp/test-project` — both `include_examples` values
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

Verified against **real `mkdocs build --strict` runs** (exit 0, zero warnings) rather than hand-written HTML fixtures. That distinction mattered: a fixture missing the `<h2 id="{pkg}...">` makes `_process_api_page_content` return early, so an isolated test of the linkifier passes while the real pipeline produces nothing.

| check | result |
|---|---|
| class-level `See Also` links | plain and backticked |
| method-level `See Also` links | yes |
| external name → external docs via inventory | yes |
| unresolvable name | plain text, no warning, `--strict` passes |
| re-export API pages populate | yes |
| flat-layout packages | unchanged (no regression) |
| companion cards | rendered with resolved `View` / `Open in marimo` URLs |
| changelog page | renders, exactly one `<h1>`, non-empty ToC |
| cache reset | 6 caches with examples / 3 without, no phantom globals |

The cache-reset test is a sentinel round-trip, confirmed to fail against an empty `on_config` body rather than passing vacuously.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

**Notes for projects running `copier update`:**

- Previously-empty API pages populate for re-export-shaped subpackages — a visible docs diff.
- `check_paths: true` surfaces snippet includes that were being dropped silently. **A docs build may now fail on an include that was already broken.** A troubleshooting entry is added for this.
- Class-level `See Also` entries begin linking.
- `mkdocs serve` stops serving stale content.
- A project that has forked `docs/hooks.py` will get a merge rather than an overwrite, since Dynamic Reclassification promotes a locally-edited Tier 1 file to Tier 2. Worth planning rather than applying blind.

**Design notes worth flagging for review:**

- **Hook order is load-bearing.** mkdocstrings emits `See Also` as `<details class="see-also">`, and `_process_api_page_content` dissolves it for class-level docstrings. Linkification therefore runs *before* it; reordering `on_page_content` silently reverts the feature for class-level entries while leaving method-level ones working. Pinned by a test.
- **External names defer to `<autoref optional>`** rather than resolving eagerly. Inventories are registered into the autorefs URL map but applied in its `on_env` hook, which runs after `on_page_content` — asking for the URL there raises `KeyError` even with the inventory configured. The `optional` attribute keeps an unresolvable name from failing a `--strict` build.
- **`__all__` filters rather than authorises.** It routinely lists constants, which get no generated page, so resolving "exactly the `__all__` names" would produce links to pages that don't exist.
- **A doc correction:** `contribute.md` told contributors that `mkdocs-autorefs` auto-links backticked `See Also` names. Disproved against a real build — neither plain nor backticked names were linked. Corrected here.
