### PR TITLE
fix(skills): classify every shipped file and require a release to update

### DIFF
--- a/template/.claude/skills/update-from-template/SKILL.md
+++ b/template/.claude/skills/update-from-template/SKILL.md
@@ -35,6 +35,20 @@ Determine the target version:
 - Default: latest (omit `--vcs-ref`)
 - If user specifies a version: use `--vcs-ref=<tag>` (e.g., `--vcs-ref=v1.2.0`)
 
+**"Latest" means the template's newest released tag, not its newest commit.**
+Two consequences worth knowing before you start, because copier states the facts
+without explaining them:
+
+- Work that is merged but unreleased is **not reachable**. The update reports
+  `Keeping template version <x>` and changes nothing. If you are waiting on a
+  fix that has landed on the template's main branch, it needs a release first.
+- A project whose `_commit` is **ahead of the newest tag** cannot update at all.
+  It fails as `You are downgrading from <newer> to <tag>. Downgrades are not
+  supported.` — not as a no-op. This happens when a project was generated or
+  updated with an explicit `--vcs-ref <commit>` pointing at an unreleased
+  commit. It stays stuck until the template cuts a release newer than that
+  commit. Prefer pinning to tags for exactly this reason.
+
 ### Step 2: Detect Customizations
 
 Generate a clean baseline to identify which files have local customizations:

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -98,6 +98,13 @@ tests/**                           # All test files
 examples/**                        # conditional: include_examples
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
+docs/pages/how-to/configure.md         # The template seeds these two pages and
+docs/pages/how-to/troubleshooting.md   # the project then owns them. That means
+                                       # the template's own additions to them do
+                                       # not reach projects automatically -- the
+                                       # right trade: a template that can append
+                                       # to a page it does not own can delete
+                                       # from it too.
 docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
 docs/pages/how-to/index.md             # template ships a skeleton, but a
 docs/pages/reference/index.md          # project's own landing page is better

--- a/template/.github/skills/update-from-template/SKILL.md
+++ b/template/.github/skills/update-from-template/SKILL.md
@@ -35,6 +35,20 @@ Determine the target version:
 - Default: latest (omit `--vcs-ref`)
 - If user specifies a version: use `--vcs-ref=<tag>` (e.g., `--vcs-ref=v1.2.0`)
 
+**"Latest" means the template's newest released tag, not its newest commit.**
+Two consequences worth knowing before you start, because copier states the facts
+without explaining them:
+
+- Work that is merged but unreleased is **not reachable**. The update reports
+  `Keeping template version <x>` and changes nothing. If you are waiting on a
+  fix that has landed on the template's main branch, it needs a release first.
+- A project whose `_commit` is **ahead of the newest tag** cannot update at all.
+  It fails as `You are downgrading from <newer> to <tag>. Downgrades are not
+  supported.` — not as a no-op. This happens when a project was generated or
+  updated with an explicit `--vcs-ref <commit>` pointing at an unreleased
+  commit. It stays stuck until the template cuts a release newer than that
+  commit. Prefer pinning to tags for exactly this reason.
+
 ### Step 2: Detect Customizations
 
 Generate a clean baseline to identify which files have local customizations:

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -98,6 +98,13 @@ tests/**                           # All test files
 examples/**                        # conditional: include_examples
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
+docs/pages/how-to/configure.md         # The template seeds these two pages and
+docs/pages/how-to/troubleshooting.md   # the project then owns them. That means
+                                       # the template's own additions to them do
+                                       # not reach projects automatically -- the
+                                       # right trade: a template that can append
+                                       # to a page it does not own can delete
+                                       # from it too.
 docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
 docs/pages/how-to/index.md             # template ships a skeleton, but a
 docs/pages/reference/index.md          # project's own landing page is better

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1389,7 +1389,7 @@ def test_code_of_conduct_content(copie):
     coc_path = result.project_dir / "CODE_OF_CONDUCT.md"
     assert coc_path.is_file()
 
-    content = coc_path.read_text()
+    content = coc_path.read_text(encoding="utf-8")
     assert f"contacting the project team at {custom_email}" in content
     assert "gtauzin@stateful-y.io" not in content
 
@@ -1404,7 +1404,7 @@ def test_update_from_template_skill_generated(copie_session_default):
     skill_md = skill_dir / "SKILL.md"
     assert skill_md.is_file(), "Missing SKILL.md"
 
-    content = skill_md.read_text()
+    content = skill_md.read_text(encoding="utf-8")
     assert "name: update-from-template" in content
     assert "copier update" in content
 
@@ -1439,7 +1439,7 @@ def test_claude_skills_not_gitignored(copie_session_default):
     """
     result = copie_session_default
 
-    gitignore = (result.project_dir / ".gitignore").read_text()
+    gitignore = (result.project_dir / ".gitignore").read_text(encoding="utf-8")
     assert ".claude/*" in gitignore, "Must use '.claude/*' so the negation is reachable"
     assert "!.claude/skills/" in gitignore, "Missing negation to track shipped skills"
     assert not re.search(r"^\.claude/$", gitignore, re.MULTILINE), (
@@ -1597,7 +1597,7 @@ def test_api_name_lookup_every_name_has_a_page(copie_session_minimal):
 
 def test_api_name_lookup_available_without_examples(copie_session_minimal):
     """The lookup is not gated behind include_examples."""
-    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     assert "def _get_api_name_lookup" in hooks_source, "lookup missing when examples are disabled"
     assert "_API_NAME_LOOKUP_CACHE" in hooks_source, "lookup cache missing when examples are disabled"
     assert "def _get_notebook_api_usage" not in hooks_source, "gallery code leaked into a no-examples project"
@@ -1605,7 +1605,7 @@ def test_api_name_lookup_available_without_examples(copie_session_minimal):
 
 def test_api_name_lookup_shared_with_notebook_usage(copie_session_default):
     """The gallery consumes the shared lookup instead of building its own map."""
-    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     assert "def _get_api_name_lookup" in hooks_source
     assert "name_to_qualified = _get_api_name_lookup(project_root)" in hooks_source, (
         "_get_notebook_api_usage must consume the shared lookup, not derive a second map"
@@ -1713,7 +1713,7 @@ def test_see_also_linkify_runs_before_restructure(copie_session_minimal):
     while still working for method-level ones, so a test that only covers
     method-level entries would not catch the regression.
     """
-    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     body = hooks_source[hooks_source.index("def on_page_content") :]
     linkify_at = body.index("_linkify_see_also(")
     restructure_at = body.index("_process_api_page_content(")
@@ -1972,13 +1972,13 @@ def test_companion_cache_is_registered_by_name(copie_session_default):
     a cache named otherwise (the natural `_COMPANION_INDEX`) is invisible to it
     and the stale-read bug returns silently.
     """
-    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    hooks_source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     assert "_COMPANION_INDEX_CACHE" in hooks_source, "companion cache does not follow the *_CACHE convention"
 
 
 def test_gallery_features_absent_without_examples(copie_session_minimal):
     """The whole feature is gated behind include_examples."""
-    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text()
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     for symbol in ("_COMPANION_INDEX_CACHE", "_API_EXAMPLES_CAP", "_build_companion_cards_html"):
         assert symbol not in hooks_source, f"{symbol} leaked into a project generated without examples"
 
@@ -1991,7 +1991,7 @@ def _mkdocs_config(project_dir):
 
     _Loader.add_multi_constructor("tag:yaml.org,2002:python/name:", lambda loader, suffix, node: suffix)
     _Loader.add_constructor("!ENV", lambda loader, node: None)
-    return yaml.load((project_dir / "mkdocs.yml").read_text(), Loader=_Loader)
+    return yaml.load((project_dir / "mkdocs.yml").read_text(encoding="utf-8"), Loader=_Loader)
 
 
 def test_snippets_resolve_docs_and_repo_root(copie_session_default):
@@ -2026,7 +2026,7 @@ def test_changelog_include_resolves(copie_session_default):
     cwd = os.getcwd()
     try:
         os.chdir(project_dir)
-        rendered = md.convert(page.read_text())
+        rendered = md.convert(page.read_text(encoding="utf-8"))
     finally:
         os.chdir(cwd)
 
@@ -2082,7 +2082,7 @@ def test_quadrant_indexes_are_local_owned(copie_session_default):
     )
     if not classification.is_file():
         pytest.skip("update-from-template skill not shipped to generated projects")
-    text = classification.read_text()
+    text = classification.read_text(encoding="utf-8")
     # Slice to the section end, not EOF: running to EOF would let a path
     # listed in a LATER section satisfy this assertion.
     start = text.index("## Tier 3")
@@ -2141,7 +2141,7 @@ def test_hooks_define_on_config_not_on_startup(copie_session_default):
 
     That is the bug this change exists to fix; defining it would reintroduce it.
     """
-    source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text()
+    source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
     assert "def on_config(" in source, "no per-build reset"
     assert "def on_startup(" not in source, "on_startup fires once per invocation, not per build"
 
@@ -2247,7 +2247,7 @@ def test_reexported_members_render_in_the_api_page_table(copie_session_minimal):
     hooks._SUBMODULE_CACHE = None
 
     hooks._generate_api_pages(project_dir)
-    page = (project_dir / "docs" / "pages" / "api" / "shapes.md").read_text()
+    page = (project_dir / "docs" / "pages" / "api" / "shapes.md").read_text(encoding="utf-8")
 
     assert "### Classes" in page, "members table missing its Classes heading"
     assert "Circle" in page, "re-exported class absent from the rendered members table"
@@ -2315,7 +2315,7 @@ def test_gallery_overflow_link_targets_the_real_gallery_page(copie_session_defau
     assert url, "gallery page not found by its GALLERY placeholder"
     page = project_dir / "docs" / (url.strip("/") + ".md")
     assert page.is_file(), f"overflow link {url} points at a page that does not exist"
-    assert "<!-- GALLERY -->" in page.read_text(), "located page is not the gallery"
+    assert "<!-- GALLERY -->" in page.read_text(encoding="utf-8"), "located page is not the gallery"
 
 
 def test_see_also_leaves_description_text_alone(copie_session_minimal):
@@ -2428,7 +2428,7 @@ def test_changelog_page_has_a_populated_toc(copie_session_default):
     cwd = os.getcwd()
     try:
         os.chdir(project_dir)
-        md.convert(page.read_text())
+        md.convert(page.read_text(encoding="utf-8"))
     finally:
         os.chdir(cwd)
 
@@ -2505,7 +2505,7 @@ def _unclassified_files(project_dir, package_name):
     """Generated files that the update classification does not cover."""
     classification = (
         project_dir / ".github" / "skills" / "update-from-template" / "references" / "file-classification.md"
-    ).read_text()
+    ).read_text(encoding="utf-8")
     missing = []
     for path in sorted(project_dir.rglob("*")):
         if not path.is_file():
@@ -2563,8 +2563,8 @@ def test_update_guidance_restores_local_owned_files(copie_session_default):
     skill_dir = copie_session_default.project_dir / ".github" / "skills" / "update-from-template"
     if not skill_dir.is_dir():
         pytest.skip("update-from-template skill not shipped to generated projects")
-    skill = (skill_dir / "SKILL.md").read_text()
-    conflicts = (skill_dir / "references" / "conflict-resolution.md").read_text()
+    skill = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    conflicts = (skill_dir / "references" / "conflict-resolution.md").read_text(encoding="utf-8")
 
     assert "git checkout HEAD -- <file>" in skill, "the local-owned remedy does not restore the project's version"
     assert "Delete `.rej` without applying" not in skill, (

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2489,3 +2489,86 @@ def test_companion_placeholder_renders_no_dangling_heading(copie_session_default
     out = hooks.on_page_markdown("<!-- COMPANION_NOTEBOOKS -->", page, {"repo_url": "https://github.com/s/p"}, None)
 
     assert out.strip() == "", f"an unmatched placeholder left content behind: {out!r}"
+
+
+_CLASSIFICATION_PATTERNS = (
+    "src/",
+    "tests/",
+    "examples/",
+    "docs/examples/",
+    ".github/skills/",
+    ".claude/skills/",
+)
+
+
+def _unclassified_files(project_dir, package_name):
+    """Generated files that the update classification does not cover."""
+    classification = (
+        project_dir / ".github" / "skills" / "update-from-template" / "references" / "file-classification.md"
+    ).read_text()
+    missing = []
+    for path in sorted(project_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(project_dir).as_posix()
+        if rel.startswith(".git/"):
+            continue
+        # Pattern entries (src/<package_name>/**, tests/**, ...) cover whole
+        # trees; requiring a line per file there would be unmaintainable in the
+        # opposite direction.
+        if rel.startswith(_CLASSIFICATION_PATTERNS) or rel.startswith(f"src/{package_name}/"):
+            continue
+        if rel not in classification:
+            missing.append(rel)
+    return missing
+
+
+@pytest.mark.parametrize("include_examples", [True, False])
+def test_every_generated_file_is_classified(copie, include_examples):
+    """Every file the template ships has an update tier.
+
+    The classification tells whoever resolves an update conflict whether the
+    template's version or the project's wins. A file with no tier gives them no
+    rule at the moment they most need one -- and the list is maintained by hand,
+    so nothing notices a new file arriving without an entry. That is how two
+    shipped pages went unclassified, one of which a real update wanted to strip
+    212 lines from.
+
+    Generates a fresh project rather than reusing a session fixture: this asks
+    what the TEMPLATE ships, and a shared fixture accumulates build artifacts
+    (.nox, __pycache__, generated API pages) from whichever tests ran first.
+
+    Both include_examples values run: a file behind that gate ships in only one
+    variant.
+    """
+    result = copie.copy(extra_answers={"include_examples": include_examples})
+    project_dir = result.project_dir
+    missing = _unclassified_files(project_dir, "test_project")
+
+    assert not missing, (
+        f"these generated files have no update tier, so a conflict on them has no resolution rule: {missing}"
+    )
+
+
+def test_update_guidance_restores_local_owned_files(copie_session_default):
+    """The local-owned remedy must restore, not merely discard the rejection.
+
+    A rejected-hunks update applies every hunk that applies and rejects only the
+    rest, so a conflicted file is already partially updated. Guidance that treats
+    the rejection's presence as evidence the file is untouched leads to keeping
+    the template's changes in a file the project owns -- silently, with the
+    update reporting success. Measured once: a local-owned page went 184 lines to
+    78.
+    """
+    skill_dir = copie_session_default.project_dir / ".github" / "skills" / "update-from-template"
+    if not skill_dir.is_dir():
+        pytest.skip("update-from-template skill not shipped to generated projects")
+    skill = (skill_dir / "SKILL.md").read_text()
+    conflicts = (skill_dir / "references" / "conflict-resolution.md").read_text()
+
+    assert "git checkout HEAD -- <file>" in skill, "the local-owned remedy does not restore the project's version"
+    assert "Delete `.rej` without applying" not in skill, (
+        "the local-owned remedy discards the rejection without undoing the hunks that already applied"
+    )
+    for wrong in ("Keeps local file intact", "local file is clean", "local file** unchanged"):
+        assert wrong not in conflicts, f"the guidance still claims a conflicted file is untouched: {wrong!r}"


### PR DESCRIPTION
## Description

Two pages the template ships had no update tier, so an agent resolving a conflict on them had no rule. Both are now classified — and, more importantly, a test now fails when *any* shipped file lacks one, so the classification stops depending on someone remembering.

Also pins the conflict-resolution semantics against regression, and documents that updating a generated project targets the template's newest **released** tag.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Motivation and Context

**The classification had gaps, and nothing could notice.** `docs/pages/how-to/configure.md` and `docs/pages/how-to/troubleshooting.md` are seeded by the template and then owned by the project, but neither appeared in any tier. The list is maintained by hand and unchecked, so the next file added would arrive unclassified too — and be discovered by whoever is resolving a conflict on it, at the moment they most need the rule. Measured on a real update: the template's version of a troubleshooting page wanted to remove **212 lines** of the project's content.

**The conflict guidance is prose in a skill, and prose drifts.** The local-owned remedy was corrected recently, after it was found to describe a rejected-hunks update as leaving the local file untouched. It does not: `git apply --reject` is all-or-nothing per *hunk*, so a conflicted file is already partially updated, and discarding the rejection keeps the template's deletions in a file the project owns. Silently — the update reports success. Nothing prevented that prose regressing, so it is now a test.

**"Latest" means the newest released tag, not the newest commit.** Copier states the facts without explaining them: merged-but-unreleased work is unreachable (`Keeping template version <x>`), and a project pinned ahead of the newest tag fails as `Downgrades are not supported.` rather than as a no-op. Neither is self-explanatory, and pinning to an unreleased commit is a trap that leaves a project unable to update at all.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — 100 passed, 2 skipped
- [x] Tested template generation with `copier copy . /tmp/test-project` — both `include_examples` values
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

**Both new tests were verified to fail**, rather than assumed to work:

| mutation | result |
|---|---|
| delete one classification entry | ✅ suite goes red, naming the file |
| revert the local-owned remedy to "delete `.rej` without applying" | ✅ suite goes red |

And verified end to end against a real generated project, checking **file contents rather than the exit code**:

```
9 .rej files produced        UNCLASSIFIED: 0
a local-owned page:  184 lines (the project's version)
                      78 lines (what "delete the .rej" would ship)
                     184 lines (the documented remedy — restored exactly)
```

A first attempt at that check produced zero `.rej` files because the update never ran, which made "0 unclassified" and "184 == 184" both read as passes. The check now aborts if no `.rej` appears.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

**Both gap files are Tier 3, and that has a cost worth naming.** It means the template's own additions to those pages — including the `check_paths` troubleshooting note added in #133 — do not reach projects automatically. That is the correct direction of error: a template that can append to a page it does not own is a template that can delete from it.

**A blocker this PR cannot fix.** Inside a clone of a generated project, the update skill that actually loads is the user's global `~/.claude/skills/update-from-template`, not the copy this template ships — a generated project does not track `.claude/skills`. That global copy is a separate fork and still carries the destructive remedy. So the corrected guidance here does not reach the tool that would perform an update, and the buggy copy would perform the very update that distributes the fix. It needs settling before any project is updated; options are to patch the global copy, have generated projects track `.claude/skills` so the shipped copy wins, or make the global copy a pointer to the template's.
