### PR TITLE
fix(template): resolve downstream API links, See Also members, and hook formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ tests = [
     "pytest-mock>=3.14",
     "pytest-xdist>=3.8",
     "covdefaults>=2.3",
+    # A generated project is format-checked with ruff (test_generated_project_is
+    # _ruff_format_clean): the template's Python lives in .jinja files that ruff
+    # never sees here, so unformatted code ships and a generated project's first
+    # pre-commit run reformats template-owned files and reds its CI. Pinned to
+    # match the lint group so the check agrees with what a project would run.
+    "ruff>=0.15.21",
 ]
 lint = [
     "interrogate>=1.7.0",

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -39,11 +39,7 @@ CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 docs/api-submodule.html
 docs/assets/.gitkeep
-docs/assets/favicon.png
-docs/assets/logo.png
-docs/assets/logo_dark.png
-docs/assets/logo_light.png
-docs/assets/made_by_stateful-y.png
+docs/assets/made_by_stateful-y.png   # the "made by stateful-y" mark is template branding
 docs/assets/README.md
 docs/hooks.py
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
@@ -96,6 +92,14 @@ Project-specific files where the template only provides initial scaffolding. Nev
 src/<package_name>/**              # All source code
 tests/**                           # All test files
 examples/**                        # conditional: include_examples
+docs/assets/favicon.png            # The template seeds a placeholder logo/favicon
+docs/assets/logo.png               # and the project replaces it with its own
+docs/assets/logo_dark.png          # branding. These are binary, so a template
+docs/assets/logo_light.png         # update overwrites them with no conflict and
+                                   # no signal -- the project's brand is silently
+                                   # lost. Never overwrite. (made_by_stateful-y.png
+                                   # is the exception: it is template branding and
+                                   # stays Tier 1.)
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
 docs/pages/how-to/configure.md         # The template seeds these two pages and

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -39,11 +39,7 @@ CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 docs/api-submodule.html
 docs/assets/.gitkeep
-docs/assets/favicon.png
-docs/assets/logo.png
-docs/assets/logo_dark.png
-docs/assets/logo_light.png
-docs/assets/made_by_stateful-y.png
+docs/assets/made_by_stateful-y.png   # the "made by stateful-y" mark is template branding
 docs/assets/README.md
 docs/hooks.py
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
@@ -96,6 +92,14 @@ Project-specific files where the template only provides initial scaffolding. Nev
 src/<package_name>/**              # All source code
 tests/**                           # All test files
 examples/**                        # conditional: include_examples
+docs/assets/favicon.png            # The template seeds a placeholder logo/favicon
+docs/assets/logo.png               # and the project replaces it with its own
+docs/assets/logo_dark.png          # branding. These are binary, so a template
+docs/assets/logo_light.png         # update overwrites them with no conflict and
+                                   # no signal -- the project's brand is silently
+                                   # lost. Never overwrite. (made_by_stateful-y.png
+                                   # is the exception: it is template branding and
+                                   # stays Tier 1.)
 docs/pages/explanation/concepts.md
 docs/pages/tutorials/getting-started.md
 docs/pages/how-to/configure.md         # The template seeds these two pages and

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -207,9 +207,12 @@ def _get_reexported_members(init_file, pkg_dir):
                 match = next((e for e in entries if e["name"] == alias.name), None)
                 if match is None:
                     continue
-                (classes if bucket == "classes" else functions).append(
-                    {"name": exposed, "doc": match["doc"], "origin": str(decl_file), "reexported": True}
-                )
+                (classes if bucket == "classes" else functions).append({
+                    "name": exposed,
+                    "doc": match["doc"],
+                    "origin": str(decl_file),
+                    "reexported": True,
+                })
                 seen.add(exposed)
                 break
 
@@ -266,9 +269,11 @@ def _get_api_name_lookup(project_root):
         members = _get_public_members(mod_file, pkg_dir)
         for entry in members["classes"] + members["functions"]:
             qualified = f"{{ package_name }}.{mod['module_name']}.{entry['name']}"
-            candidates.setdefault(entry["name"], []).append(
-                {"qualified": qualified, "origin": entry.get("origin"), "reexported": entry.get("reexported", False)}
-            )
+            candidates.setdefault(entry["name"], []).append({
+                "qualified": qualified,
+                "origin": entry.get("origin"),
+                "reexported": entry.get("reexported", False),
+            })
 
     lookup = {}
     for name, cands in candidates.items():
@@ -429,7 +434,7 @@ def _build_api_table_html(project_root):
 
         members = _get_public_members(mod_file, pkg_dir)
         module_label = f"{{ package_name }}.{mod['module_name']}"
-        module_href = f"../api/{mod['module_name']}/"
+        module_href = f"../../api/{mod['module_name']}/"
 
         for cls in members["classes"]:
             qualified = f"{{ package_name }}.{mod['module_name']}.{cls['name']}"
@@ -448,7 +453,7 @@ def _build_api_table_html(project_root):
 
     tbody_lines = []
     for name, kind, module_label, module_href, desc, qualified in rows:
-        href = f"../api/generated/{qualified}/"
+        href = f"../../api/generated/{qualified}/"
         badge_cls = _type_badge_cls.get(kind, "")
         tbody_lines.append(
             f"      <tr>"
@@ -961,11 +966,42 @@ def _external_autoref(name, title):
     return f'<autoref optional identifier="{name}">{title}</autoref>'
 
 
+def _resolve_member_identifier(name):
+    """Qualify a dotted ``Class.member`` See Also entry to its autoref identifier.
+
+    A member -- a method or attribute -- has no page of its own; it is an anchor
+    on its class page, so it cannot be resolved to a URL the way a class or a
+    function can.  This qualifies the entry to a full identifier and hands it to
+    autorefs, which does know the anchor.
+
+    ``OtherClass.build`` becomes ``{{ package_name }}.module.OtherClass.build``
+    via the short-name lookup; an entry already led by the package name is
+    returned unchanged (its trailing segment is a member, so
+    ``_resolve_see_also_url`` did not resolve it to a page).  Returns None when
+    the leading segment is neither this package nor a known project symbol, so a
+    genuinely external dotted name (``sklearn.linear_model.Ridge``) falls through
+    to external handling and keeps its own inventory link.
+    """
+    package = "{{ package_name }}"
+    if "." not in name:
+        return None
+    head, rest = name.split(".", 1)
+    if head == package:
+        return name
+    qualified_head = _get_api_name_lookup(Path(__file__).parent.parent).get(head)
+    if qualified_head is None:
+        return None
+    return f"{qualified_head}.{rest}"
+
+
 def _link_entry(name, title, colon, entry):
     """Render one See Also entry: project link, deferred external ref, or as-is."""
     url = _resolve_see_also_url(name)
     if url:
         return f'<a href="{url}">{title}</a>{colon}'
+    member_identifier = _resolve_member_identifier(name)
+    if member_identifier is not None:
+        return _external_autoref(member_identifier, title) + colon
     if "." in name and name.split(".", 1)[0] != "{{ package_name }}":
         return _external_autoref(name, title) + colon
     return entry
@@ -1240,7 +1276,8 @@ def _process_api_page_content(html, page, config):
     if examples_h2:
         old = examples_h2.group(0)
         new = (
-            old.replace('<h2 id="examples">', '<h3 id="tutorials">')
+            old
+            .replace('<h2 id="examples">', '<h3 id="tutorials">')
             .replace("</h2>", "</h3>")
             .replace(">Examples<", ">Tutorials<")
             .replace("#examples", "#tutorials")

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -386,9 +386,10 @@ rather than an API object — are left as plain text rather than failing the
 build, so you can reference anything that reads well.
 
 Fully qualified names work too (`{{ package_name }}.module.OtherClass`), and
-resolve to the same page as the short form. A name from another project (for
-example `sklearn.linear_model.Ridge`) links to that project's documentation
-when its inventory is configured in `mkdocs.yml`.
+resolve to the same page as the short form. A member reference
+(`OtherClass.method`) links to that member on its class page. A name from
+another project (for example `sklearn.linear_model.Ridge`) links to that
+project's documentation when its inventory is configured in `mkdocs.yml`.
 
 For hyperlinks, always use Markdown syntax: `[text](url)`.
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,6 +2,8 @@
 
 import os
 import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -1706,6 +1708,33 @@ def test_see_also_links_method_level_entries(copie_session_minimal):
     assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "method-level entry not linked"
 
 
+def test_see_also_links_member_path_entries(copie_session_minimal):
+    """A ``Class.member`` See Also entry qualifies to a full autoref identifier.
+
+    A member -- a method or attribute -- has no page of its own; it is an anchor
+    on its class page, so it cannot resolve to a direct URL the way a class can.
+    Its short leading segment (``Beta``) is a project symbol, so the entry is
+    qualified to ``minimal_project.models.Beta.build`` and deferred to autorefs,
+    which knows the anchor. The pre-fix path treated any dotted entry whose head
+    was not the package as external and emitted the bare ``Beta.build`` as the
+    identifier, which never matches the registered qualified name and degraded
+    silently to plain text under the ``optional`` attribute.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "seealso_member")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    html = _see_also_page("minimal_project", "Alpha", "Beta.build : Instantiate from a config.")
+    out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
+
+    assert '<autoref optional identifier="minimal_project.models.Beta.build">Beta.build</autoref>' in out, (
+        "a Class.member entry was not qualified to its full autoref identifier"
+    )
+    assert 'identifier="Beta.build"' not in out, "member path was deferred to autorefs unqualified (never resolves)"
+
+
 def test_see_also_linkify_runs_before_restructure(copie_session_minimal):
     """Order-locking: reordering on_page_content silently reverts this feature.
 
@@ -2492,6 +2521,19 @@ def test_reexported_symbols_appear_in_the_api_index(copie_session_minimal):
     assert "Circle" in html, "re-exported class absent from the searchable API index"
     assert "area" in html, "re-exported function absent from the searchable API index"
 
+    # The index renders on pages/reference/api.md, served at pages/reference/api/.
+    # Its symbol and module links must climb two levels to reach pages/api/, the
+    # same as _build_module_toc on the same page. A single ../ resolves to
+    # pages/reference/api/... which does not exist, so the links 404 in every
+    # generated site while the table still looks populated.
+    assert '<a href="../../api/generated/minimal_project.shapes.Circle/">' in html, (
+        "symbol link does not resolve from pages/reference/api/ to the generated page"
+    )
+    assert '<a href="../../api/shapes/">' in html, (
+        "module link does not resolve from pages/reference/api/ to the submodule page"
+    )
+    assert 'href="../api/' not in html, "a single-../ link (the pre-fix 404) is still emitted"
+
 
 def test_third_party_import_rejected_without_dunder_all(copie_session_minimal):
     """Without __all__, the package-root guard is what excludes stdlib imports.
@@ -2582,6 +2624,52 @@ def test_every_generated_file_is_classified(copie, include_examples):
 
     assert not missing, (
         f"these generated files have no update tier, so a conflict on them has no resolution rule: {missing}"
+    )
+
+
+@pytest.mark.parametrize("include_examples", [True, False])
+def test_generated_project_is_ruff_format_clean(copie, include_examples):
+    """A freshly generated project passes ``ruff format --check``.
+
+    The template's Python is authored in ``.jinja`` files, which ruff does not
+    recognise as Python and never formats in this repo. So unformatted code can
+    ship, and because the generated ``pyproject.toml`` enables preview-style
+    formatting, a generated project's first ``pre-commit run`` reformats
+    template-owned files (``docs/hooks.py`` chief among them) and reds its CI on
+    arrival -- the fix then drifts the file from the template, guaranteeing a
+    conflict at the next update. This checks the emitted code, not the code the
+    template happens to be.
+
+    Both include_examples values run: the gallery hooks ship in only one variant,
+    so a formatting slip behind that gate is invisible to the other.
+
+    Runs ruff via the project's own config (discovered from its pyproject.toml),
+    so the check matches what the project would run.
+    """
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        pytest.skip("ruff is not installed in the test environment")
+
+    result = copie.copy(extra_answers={"include_examples": include_examples})
+    project_dir = result.project_dir
+
+    check = subprocess.run(
+        [ruff, "format", "--check", "."],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    diff = subprocess.run(
+        [ruff, "format", "--check", "--diff", "."],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert check.returncode == 0, (
+        "the template ships Python that ruff would reformat, so a generated "
+        f"project's first `pre-commit run` reds CI:\n{diff.stdout}{check.stdout}{check.stderr}"
     )
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2093,6 +2093,41 @@ def test_quadrant_indexes_are_local_owned(copie_session_default):
         assert f"docs/pages/{quadrant}/index.md" in tier3, f"{quadrant}/index.md not listed as local-owned"
 
 
+def test_project_branding_assets_are_local_owned(copie_session_default):
+    """A project's logo and favicon must survive a template update.
+
+    The template seeds placeholder branding, and a project replaces it with its
+    own. These files are binary, so a template update overwrites them with no
+    conflict and no signal -- the project's brand is silently reverted to the
+    placeholder. Classifying them Tier 1 (template-managed) is what caused that;
+    they belong in Tier 3. ``made_by_stateful-y.png`` is the exception: it is the
+    template's own mark and stays Tier 1.
+    """
+    classification = (
+        copie_session_default.project_dir
+        / ".github"
+        / "skills"
+        / "update-from-template"
+        / "references"
+        / "file-classification.md"
+    )
+    if not classification.is_file():
+        pytest.skip("update-from-template skill not shipped to generated projects")
+    text = classification.read_text(encoding="utf-8")
+    t3_start = text.index("## Tier 3")
+    t3_end = text.find("\n## ", t3_start + 1)
+    tier3 = text[t3_start : t3_end if t3_end > 0 else len(text)]
+    t1_start = text.index("## Tier 1")
+    t1_end = text.find("\n## ", t1_start + 1)
+    tier1 = text[t1_start:t1_end]
+
+    for asset in ("favicon.png", "logo.png", "logo_dark.png", "logo_light.png"):
+        assert f"docs/assets/{asset}" in tier3, f"{asset} is not local-owned; a template update would overwrite it"
+        assert f"docs/assets/{asset}" not in tier1, f"{asset} is still Tier 1 (template-managed)"
+    # The template's own mark is genuinely template-managed.
+    assert "docs/assets/made_by_stateful-y.png" in tier1, "the made-by mark should stay template-managed"
+
+
 def _cache_names(hooks_module):
     return [n for n in vars(hooks_module) if n.endswith("_CACHE") and not n.startswith("__")]
 

--- a/uv.lock
+++ b/uv.lock
@@ -992,6 +992,7 @@ tests = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -1031,6 +1032,7 @@ tests = [
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-mock", specifier = ">=3.14" },
     { name = "pytest-xdist", specifier = ">=3.8" },
+    { name = "ruff", specifier = ">=0.15.21" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

A `v0.19.1` fix release for four defects found while updating the stateful-y repos to `v0.19.0`. Each degrades **every** generated project, and two shipped in `v0.19.0` itself. Every fix is verified on a real `--strict` docs build and covered by a test proven to fail without it.

| # | Defect | Fix | Verification |
|---|--------|-----|--------------|
| 1 | API index links 404 in every generated site | `_build_api_table_html` hrefs climb two levels (`../` → `../../`), matching the sibling module TOC on the same page | real build: 10/10 links resolve |
| 2 | Template update silently overwrites a project's logos | logos + favicon reclassified Tier 1 → Tier 3 (local-owned) in both skill copies | test asserts Tier 3; made-by mark stays Tier 1 |
| 3 | `Class.method` See Also entries never link | `_resolve_member_identifier` qualifies the head and defers the full identifier to autorefs | real `--strict` build: member entries link to their anchors |
| 4 | Template hooks ship unformatted → generated project's first `pre-commit` reds CI | reformatted source + a test that fails if any generated Python is not `ruff format`-clean | real build format-clean, both `include_examples` variants |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

These surfaced during the `v0.19.0` fan-out to downstream repos. The links and formatting defects (1, 3, 4) were introduced by the `v0.19.0` API-cross-referencing work; the logo classification (2) predates it but is newly damaging now that updates are flowing.

Why they hid until now:

- **#1** — the broken hrefs are raw HTML in generated markdown, so `mkdocs build --strict` does not check them; only following a link reveals the 404.
- **#3** — autorefs' `optional` attribute degrades an unresolved reference to plain text at debug level, so `--strict` stays green while the link silently disappears.
- **#4** — the template's Python lives in `.jinja` files that `ruff` does not recognise as Python, so the root suite never formatted or checked it.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **267 fast tests pass**
- [x] Tested template generation with `copier copy` — both `include_examples` variants
- [x] Verified generated project works as expected — real `mkdocs build --strict` exits 0; API index links resolve 10/10; `Class.method` See Also entries link to member anchors
- [x] Added/updated tests — one per defect, each mutation-checked (reintroduce the bug → the test goes red)
- [x] All tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (`contribute.md` documents the member-reference form)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

A fifth item was logged during the fan-out — a project's new `uv.lock` pins stricter `ty`/`ruff` than the project has run, surfacing pre-existing source bugs as update-PR failures. That needs **no template change**; it is fan-out guidance (budget a small per-repo source fix, do not mistake it for update damage). sklearn-wrap's instance is already fixed in its own PR.
