### PR TITLE
fix(template): keep dependency re-exports in the generated API

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -2,6 +2,7 @@
 
 import ast
 import fnmatch
+import importlib.util
 {% if include_examples %}import os
 {% endif %}import re
 import shutil
@@ -165,8 +166,38 @@ def _resolve_import_from(node, init_file, pkg_dir):
     return None
 
 
+def _resolve_external_module(module_name):
+    """Locate a module that lives outside this package.
+
+    A package may deliberately re-export a dependency's symbol -- a convenience
+    shim such as ``from otherpkg.thing import Widget`` under its own ``__all__``.
+    That name is part of *this* package's public API, but no file under
+    ``pkg_dir`` declares it, so ``_resolve_import_from`` cannot reach it and the
+    symbol would silently vanish from the index and lose its page.
+
+    ``find_spec`` locates the module's source file so the kind and docstring can
+    be read from it like any other module, rather than guessed.  It imports the
+    *parent* package to do so, which is why this is only ever consulted for a
+    name the author listed in ``__all__``: an incidental ``from pathlib import
+    Path`` must never reach here.  Anything that does not resolve to readable
+    source is skipped, not invented.
+    """
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, AttributeError, ValueError):
+        return None
+    if spec is None or not spec.origin or not spec.origin.endswith(".py"):
+        return None
+    return Path(spec.origin)
+
+
+def _reexports_a_dunder_all_name(node, exported):
+    """Whether this ImportFrom binds any name the package advertises in ``__all__``."""
+    return any((alias.asname or alias.name) in exported for alias in node.names if alias.name != "*")
+
+
 def _get_reexported_members(init_file, pkg_dir):
-    """Discover members a package exposes by re-export from its submodules.
+    """Discover members a module exposes by re-export rather than by declaring them.
 
     A re-exporting ``__init__.py`` declares no classes or functions of its own,
     so an AST scan of that file alone finds nothing.  This resolves each
@@ -177,6 +208,13 @@ def _get_reexported_members(init_file, pkg_dir):
     it is listed there (when present) *and* resolves to a class or function in
     its declaring module.  Constants and other exports are excluded, because
     only classes and functions get generated pages.
+
+    A plain module can be a re-export shim too, so this is not limited to
+    ``__init__.py`` -- but for one, an import is normally a private detail
+    (``from .base import Helper`` to use it), not an advertisement.  Only an
+    explicit ``__all__`` marks a plain module's imports as its public surface;
+    without one, nothing here is re-exported.  An ``__init__.py`` re-exports by
+    convention, so it needs no such marker.
     """
     try:
         tree = ast.parse(init_file.read_text(encoding="utf-8"))
@@ -184,6 +222,8 @@ def _get_reexported_members(init_file, pkg_dir):
         return {"classes": [], "functions": []}
 
     exported = _get_dunder_all(tree)
+    if exported is None and init_file.name != "__init__.py":
+        return {"classes": [], "functions": []}
     classes = []
     functions = []
     seen = set()
@@ -191,7 +231,15 @@ def _get_reexported_members(init_file, pkg_dir):
     for node in _iter_reexport_nodes(tree):
         decl_file = _resolve_import_from(node, init_file, pkg_dir)
         if decl_file is None:
-            continue
+            # The import leaves the package. That is normally an incidental
+            # third-party import and must stay out of the API -- unless the
+            # author advertised the name in __all__, which makes it this
+            # package's public API no matter where it was declared.
+            if exported is None or node.level or not node.module or not _reexports_a_dunder_all_name(node, exported):
+                continue
+            decl_file = _resolve_external_module(node.module)
+            if decl_file is None:
+                continue
         decl_members = None
         for alias in node.names:
             if alias.name == "*":
@@ -233,11 +281,10 @@ def _get_public_members(mod_file, pkg_dir):
         for entry in members[key]:
             entry.setdefault("origin", str(mod_file))
             entry.setdefault("reexported", False)
-    if mod_file.name == "__init__.py":
-        reexported = _get_reexported_members(mod_file, pkg_dir)
-        declared = {e["name"] for e in members["classes"] + members["functions"]}
-        for key in ("classes", "functions"):
-            members[key].extend(e for e in reexported[key] if e["name"] not in declared)
+    reexported = _get_reexported_members(mod_file, pkg_dir)
+    declared = {e["name"] for e in members["classes"] + members["functions"]}
+    for key in ("classes", "functions"):
+        members[key].extend(e for e in reexported[key] if e["name"] not in declared)
     return members
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2535,6 +2535,94 @@ def test_reexported_symbols_appear_in_the_api_index(copie_session_minimal):
     assert 'href="../api/' not in html, "a single-../ link (the pre-fix 404) is still emitted"
 
 
+def _write_dependency_shim(project_dir, package_name):
+    """A plain module whose public API is re-exported from outside the package.
+
+    Uses stdlib modules as the "dependency": they are outside the generated
+    package exactly as a third-party one is, and they are always installed, so
+    the test does not depend on the resolver finding some optional extra.
+    """
+    pkg = project_dir / "src" / package_name
+    (pkg / "shim.py").write_text(
+        '"""Convenience re-exports."""\n\n'
+        "from dataclasses import dataclass\n"
+        "from fractions import Fraction\n\n"
+        '__all__ = ["Fraction", "dataclass"]\n',
+        encoding="utf-8",
+    )
+    (pkg / "helpers.py").write_text(
+        '"""Helpers."""\n\n\nclass Helper:\n    """A helper."""\n',
+        encoding="utf-8",
+    )
+    # A plain module with no __all__ importing a sibling for its own use. The
+    # import is IN-package, so it resolves -- nothing but the missing __all__
+    # keeps it out of the API. An out-of-package import would not test this:
+    # the external resolver already refuses to run without __all__.
+    (pkg / "internal.py").write_text(
+        '"""Uses a helper; exports nothing."""\n\n'
+        "from .helpers import Helper\n\n\n"
+        "def ratio():\n"
+        '    """Build a helper."""\n'
+        "    return Helper()\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def test_dependency_reexports_stay_in_the_api(copie_session_minimal):
+    """A name re-exported from a dependency and named in __all__ is public API.
+
+    A convenience shim (``from otherpkg import Widget`` under this package's
+    ``__all__``) declares nothing itself and its source lives outside the
+    package, so resolution that only follows in-package imports drops the name
+    entirely: gone from the index, and no page. Measured on a real project, that
+    silently removed three of its four public symbols and rendered its module
+    page as a bare docstring.
+
+    The kind and docstring must come from the declaring module rather than being
+    guessed, so a class stays a class and carries its real summary.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = _write_dependency_shim(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "depshim")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    members = hooks._get_public_members(pkg / "shim.py", pkg)
+
+    assert {e["name"] for e in members["classes"]} == {"Fraction"}, "a re-exported dependency class was dropped"
+    assert {e["name"] for e in members["functions"]} == {"dataclass"}, "a re-exported dependency function was dropped"
+    fraction = next(e for e in members["classes"] if e["name"] == "Fraction")
+    assert fraction["doc"], "the docstring was not read from the declaring module"
+    assert fraction["reexported"] is True
+
+
+def test_plain_module_imports_are_not_api_without_dunder_all(copie_session_minimal):
+    """Without __all__, a plain module's imports stay private.
+
+    Re-export resolution is not limited to __init__.py, because a plain module
+    can be a shim. That generality is what makes this necessary: in an ordinary
+    module an import is a private detail (imported to be *used*), and treating it
+    as API would publish every helper a module happens to import.
+
+    The import here is in-package on purpose. It resolves, so only the absent
+    __all__ stands between it and the API -- an out-of-package import would pass
+    this test without exercising anything, since the external resolver already
+    refuses to run without __all__.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = _write_dependency_shim(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "depshim_internal")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    members = hooks._get_public_members(pkg / "internal.py", pkg)
+    names = {e["name"] for e in members["classes"] + members["functions"]}
+
+    assert "ratio" in names, "the module's own function is missing"
+    assert "Helper" not in names, "a sibling imported for internal use leaked into the API without __all__"
+
+
 def test_third_party_import_rejected_without_dunder_all(copie_session_minimal):
     """Without __all__, the package-root guard is what excludes stdlib imports.
 


### PR DESCRIPTION
## Description

A `v0.19.2` fix release for one defect found while updating **yohou-optuna** to `v0.19.1`: a package's re-exports of a **dependency's** symbols are silently dropped from the generated API.

A convenience shim like this loses every name it exposes:

```python
"""Optuna wrapper re-exports for convenience."""
from sklearn_optuna.optuna import Callback, Sampler, Storage
__all__ = ["Callback", "Sampler", "Storage"]
```

They vanish from the searchable index and the package page, and get no generated page — while `mkdocs build --strict` stays green, because nothing is broken, only absent.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Two independent causes, both fixed:

1. **Re-export resolution only ran for `__init__.py`.** A plain shim module was never examined, so the fix to (2) alone would have changed nothing.
2. **`_resolve_import_from` returns `None` for an import that leaves the package.** That is right for an incidental `from pathlib import Path`, but it also discarded names the author had deliberately advertised in `__all__`.

Resolution now runs for any module, and a name that resolves to no in-package declaration is located with `find_spec` so its **kind and docstring are read from the declaring module** rather than guessed.

Generalising to every module is what makes the `__all__` gate necessary: in an ordinary module an import is a private detail (`from .base import Helper`, imported to be *used*), so without an explicit `__all__` nothing is treated as re-exported. Every existing exclusion stays intact — the package-root guard still rejects stdlib imports, and `__all__` still filters constants.

**Why this matters beyond one repo:** yohou-optuna had *forked* the Tier 1 `docs/hooks.py` to work around this, which is why its every future update was destined to conflict. With this fix the fork is unnecessary and the file stops drifting.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **269 fast tests pass**
- [x] Verified generated project works as expected — verified against the real repo: yohou-optuna had **3 of its 4 public re-exports missing** at v0.19.1; all three return, **with their real docstrings** (its fork listed them with empty ones)
- [x] Added/updated tests — one per part, each mutation-checked

Each of the three parts is covered by a test proven to fail without it:

| part | test |
|---|---|
| dependency re-exports are kept | `test_dependency_reexports_stay_in_the_api` |
| resolution reaches plain shim modules | same test (its fixture is a shim, not an `__init__.py`) |
| no `__all__` ⇒ imports stay private | `test_plain_module_imports_are_not_api_without_dunder_all` |

The last test's fixture imports **in-package** on purpose. An out-of-package import would pass it while exercising nothing, since the external resolver already refuses to run without `__all__` — the first version of this test did exactly that and survived the mutation, so it was rewritten.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Only yohou-optuna is affected. yohou-nixtla, kedro-dagster and kedro-azureml-pipeline re-export intra-package only (`from .catalog import ...`), which already resolved; sklearn-wrap and sklearn-optuna are already updated and unaffected. The fan-out continues on `v0.19.1` for those repos; yohou-optuna lands against this release.
