### PR TITLE
feat(template): add glossary auto-linking and cache notebook exports

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -2,9 +2,11 @@
 
 import ast
 import fnmatch
-import importlib.util
+{% if include_examples %}import hashlib
+{% endif %}import importlib.util
 {% if include_examples %}import os
-{% endif %}import re
+{% endif %}import posixpath
+import re
 import shutil
 import subprocess
 {% if include_examples %}import sys
@@ -20,6 +22,7 @@ from pathlib import Path
 # `_CACHE` suffix, so a cache named otherwise escapes both, silently.
 _SUBMODULE_CACHE = None
 _API_NAME_LOOKUP_CACHE = None
+_GLOSSARY_TERMS_CACHE = None
 
 
 def _get_submodules(project_root):
@@ -562,6 +565,33 @@ _GALLERY_CACHE = None
 _COMPANION_INDEX_CACHE = None
 _GALLERY_PAGE_CACHE = None
 
+# Written beside an exported notebook to record the source it was built from.
+# Deliberately not a _CACHE module global: this one has to outlive the process,
+# because its whole purpose is to skip work on a *later* build.
+_SOURCE_HASH_FILE = ".source_hash"
+
+
+def _notebook_content_hash(notebook):
+    """Hash a notebook's source, to tell an unchanged one from an edited one."""
+    return hashlib.sha256(notebook.read_bytes()).hexdigest()
+
+
+def _is_cached(output_dir, expected_hash):
+    """Whether this notebook's export is present and built from this exact source.
+
+    Requires the rendered page *and* a matching hash. Checking the hash alone
+    would reuse a directory whose html failed to write; checking the page alone
+    would serve a stale render of an edited notebook forever.
+    """
+    hash_file = output_dir / _SOURCE_HASH_FILE
+    if not (output_dir / "index.html").exists() or not hash_file.exists():
+        return False
+    try:
+        return hash_file.read_text(encoding="utf-8").strip() == expected_hash
+    except OSError:
+        return False
+
+
 # Max example cards on a single API page.  Most symbols are well under this
 # (a typical notebook demonstrates a handful of things); the cap exists for the
 # widely used helpers, where an uncapped list runs to dozens of cards and stops
@@ -1054,6 +1084,162 @@ def _link_entry(name, title, colon, entry):
     return entry
 
 
+# The glossary lives in the explanation quadrant by Diataxis convention. A
+# project without this page simply gets no glossary linking.
+_GLOSSARY_SRC_PATH = "pages/explanation/glossary.md"
+
+# Text inside these never becomes a glossary link: code is not prose, a heading
+# linking mid-title looks broken, and nesting an <a> inside an <a> is invalid.
+_GLOSSARY_SKIP_TAGS = frozenset({"code", "pre", "a", "h1", "h2", "h3", "h4", "h5", "h6", "script", "style"})
+
+# A definition-list term carrying attributes, e.g. ``Memory buffer { #memory-buffer .autolink }``.
+_GLOSSARY_TERM_RE = re.compile(r"^(?!\s)(.+?)\s*\{:?\s*([^}]*)\}\s*$")
+
+
+def _get_glossary_terms(project_root):
+    """Map each auto-linkable glossary term to its anchor (cached).
+
+    The glossary page is the single source of truth: terms are read from it, so
+    a term and its definition cannot drift apart the way a second list in this
+    file would.
+
+    A term opts in with ``.autolink``::
+
+        Memory buffer { #memory-buffer .autolink }
+        :   The internal store of recent rows...
+
+    Opting in is deliberate rather than automatic. A glossary defines whatever
+    its authors find worth defining, including short common words -- "step",
+    "pipeline", "ensemble" -- and auto-linking those wherever they appear in
+    prose produces noise, not navigation. Defining a term and advertising it
+    everywhere are separate editorial decisions, so they get separate syntax.
+    """
+    global _GLOSSARY_TERMS_CACHE  # noqa: PLW0603
+    if _GLOSSARY_TERMS_CACHE is not None:
+        return _GLOSSARY_TERMS_CACHE
+
+    terms = {}
+    page = project_root / "docs" / _GLOSSARY_SRC_PATH
+    try:
+        lines = page.read_text(encoding="utf-8").split("\n")
+    except (OSError, UnicodeDecodeError):
+        _GLOSSARY_TERMS_CACHE = terms
+        return terms
+
+    for i, line in enumerate(lines[:-1]):
+        match = _GLOSSARY_TERM_RE.match(line)
+        # The next line starting with ':' is what makes this a definition-list
+        # term rather than ordinary prose that happens to end in braces.
+        if not match or not lines[i + 1].lstrip().startswith(":"):
+            continue
+        attrs = match.group(2).split()
+        if ".autolink" not in attrs:
+            continue
+        anchor = next((a[1:] for a in attrs if a.startswith("#")), None)
+        if anchor:
+            terms[match.group(1).strip().lower()] = anchor
+
+    _GLOSSARY_TERMS_CACHE = terms
+    return terms
+
+
+def _glossary_link_replacer(terms, rel_glossary, linked):
+    """Build the text-node rewriter that links a term's first occurrence."""
+    # Longest first, so "seasonal naive forecaster" wins over "forecaster"
+    # rather than being shadowed by the shorter term inside it.
+    pattern = re.compile(
+        r"\b(" + "|".join(re.escape(t) for t in sorted(terms, key=len, reverse=True)) + r")\b",
+        re.IGNORECASE,
+    )
+
+    def _replace(text):
+        def _sub(match):
+            term = match.group(1).lower()
+            if term in linked:
+                return match.group(0)
+            linked.add(term)
+            return f'<a href="{rel_glossary}/#{terms[term]}">{match.group(0)}</a>'
+
+        return pattern.sub(_sub, text)
+
+    return _replace
+
+
+class _GlossaryLinker(HTMLParser):
+    """Rewrites text nodes into glossary links, leaving markup untouched.
+
+    Parsed rather than regexed over the whole page: a bare regex would match
+    inside tag attributes and code blocks, producing broken markup from a
+    document that was fine.
+    """
+
+    def __init__(self, replace):
+        super().__init__(convert_charrefs=False)
+        self._replace = replace
+        self.result = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() in _GLOSSARY_SKIP_TAGS:
+            self._skip_depth += 1
+        self.result.append(self.get_starttag_text())
+
+    def handle_startendtag(self, tag, attrs):
+        self.result.append(self.get_starttag_text())
+
+    def handle_endtag(self, tag):
+        if tag.lower() in _GLOSSARY_SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+        self.result.append(f"</{tag}>")
+
+    def handle_data(self, data):
+        self.result.append(data if self._skip_depth else self._replace(data))
+
+    def handle_entityref(self, name):
+        self.result.append(f"&{name};")
+
+    def handle_charref(self, name):
+        self.result.append(f"&#{name};")
+
+    def handle_comment(self, data):
+        self.result.append(f"<!--{data}-->")
+
+    def handle_decl(self, decl):
+        self.result.append(f"<!{decl}>")
+
+    def get_html(self):
+        """Return the rewritten HTML."""
+        return "".join(self.result)
+
+
+def _linkify_glossary_terms(html, page, project_root):
+    """Link the first occurrence of each glossary term on a page.
+
+    First occurrence only: linking every "memory buffer" in a paragraph is
+    noise, and the reader only needs the definition once.
+
+    The glossary page itself is skipped -- it would link its own terms to
+    themselves.
+    """
+    src = page.file.src_path
+    if src == _GLOSSARY_SRC_PATH or not src.startswith("pages/"):
+        return html
+
+    terms = _get_glossary_terms(project_root)
+    if not terms:
+        return html
+
+    # Relative, not absolute: the site may be served under a subpath, and
+    # use_directory_urls means a page's own URL is a directory.
+    dest_dir = posixpath.dirname(page.file.dest_path)
+    rel_glossary = posixpath.relpath(posixpath.splitext(_GLOSSARY_SRC_PATH)[0], dest_dir)
+
+    linker = _GlossaryLinker(_glossary_link_replacer(terms, rel_glossary, set()))
+    linker.feed(html)
+    linker.close()
+    return linker.get_html()
+
+
 def _linkify_see_also(html):
     """Turn the names in a rendered See Also section into links.
 
@@ -1386,10 +1572,11 @@ def on_config(config):
     reset there fires when the caches are already empty and never again, and
     `mkdocs serve` keeps serving the first build's content.
     """
-    global _SUBMODULE_CACHE, _API_NAME_LOOKUP_CACHE, _GIT_REF_CACHE  # noqa: PLW0603
+    global _SUBMODULE_CACHE, _API_NAME_LOOKUP_CACHE, _GIT_REF_CACHE, _GLOSSARY_TERMS_CACHE  # noqa: PLW0603
     _SUBMODULE_CACHE = None
     _API_NAME_LOOKUP_CACHE = None
     _GIT_REF_CACHE = None
+    _GLOSSARY_TERMS_CACHE = None
 {%- if include_examples %}
     global _GALLERY_CACHE, _COMPANION_INDEX_CACHE, _NOTEBOOK_API_USAGE_CACHE, _GALLERY_PAGE_CACHE  # noqa: PLW0603
     _GALLERY_CACHE = None
@@ -1424,6 +1611,10 @@ def on_page_content(html, page, config, files):
     ):
         # Submodule page: module list with active/children expansion
         page.meta["module_toc"] = _build_module_toc(config, current_src_path=src)
+
+    # Last: the API restructuring above rewrites whole regions, so linking
+    # before it would have its links discarded with the markup they sat in.
+    html = _linkify_glossary_terms(html, page, Path(__file__).parent.parent)
 
     return html
 
@@ -1531,6 +1722,13 @@ def on_pre_build(config):
         rel_path = notebook.relative_to(project_root)
         output_dir = docs_examples / notebook.stem
 
+        # Exporting a notebook means executing it, which dominates the build.
+        # Skip the ones whose source has not changed since their last export.
+        content_hash = _notebook_content_hash(notebook)
+        if _is_cached(output_dir, content_hash):
+            print(f"[hooks] unchanged, reusing export: {rel_path}")
+            continue
+
         # Clean previous export artifacts before re-exporting
         if output_dir.exists():
             shutil.rmtree(output_dir)
@@ -1558,6 +1756,10 @@ def on_pre_build(config):
                 text=True,
             )
             print(f"[hooks] exported html {rel_path} -> {static_file.relative_to(project_root)}")
+            # Stamp the source hash only after a successful export, so a failed
+            # or interrupted run re-exports next time instead of caching a
+            # half-written page.
+            (output_dir / _SOURCE_HASH_FILE).write_text(content_hash, encoding="utf-8")
         except subprocess.CalledProcessError as e:
             failed.append(str(rel_path))
             print(f"[hooks] FAILED html {rel_path}: {e}", file=sys.stderr)

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -393,6 +393,28 @@ project's documentation when its inventory is configured in `mkdocs.yml`.
 
 For hyperlinks, always use Markdown syntax: `[text](url)`.
 
+### Glossary
+
+A glossary is optional. Create `docs/pages/explanation/glossary.md` and define
+terms as a definition list, giving each one an explicit anchor:
+
+```markdown
+Memory buffer { #memory-buffer .autolink }
+:   The internal store of recent rows a stateful component maintains.
+
+Step { #step }
+:   One timestep.
+```
+
+A term marked `.autolink` has its **first** occurrence on every other page
+turned into a link to its definition. The glossary page is the only place terms
+are listed, so a definition and its links cannot drift apart.
+
+Opting in is per term because defining a word and advertising it everywhere are
+different decisions: a glossary is free to define short, common words — `step`
+above — and auto-linking those wherever prose happens to use them is noise. Text
+inside code, headings and existing links is never touched.
+
 ### Documentation
 
 Build documentation:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1708,6 +1708,114 @@ def test_see_also_links_method_level_entries(copie_session_minimal):
     assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "method-level entry not linked"
 
 
+def _write_glossary(project_dir, extra=""):
+    """A glossary page in the shape the linker reads: def-list terms with anchors."""
+    page = project_dir / "docs" / "pages" / "explanation" / "glossary.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(
+        "# Glossary\n\n"
+        "## Core\n\n"
+        "Memory buffer { #memory-buffer .autolink }\n"
+        ":   The store of recent rows.\n\n"
+        "Forecasting horizon { #forecasting-horizon .autolink }\n"
+        ":   How far ahead to predict.\n\n"
+        # Defined but NOT opted in: a short common word that would over-link.
+        "Step { #step }\n"
+        ":   One timestep.\n\n" + extra,
+        encoding="utf-8",
+    )
+    return page
+
+
+def _glossary_page(src="pages/explanation/concepts.md"):
+    return _FakePage(src, src.replace(".md", "/index.html"))
+
+
+def test_glossary_terms_link_on_other_pages(copie_session_minimal):
+    """A term marked .autolink links to the glossary, once, from prose only.
+
+    The glossary page is the single source of truth: a second list of terms in
+    hooks.py would drift from the definitions it points at.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_glossary(project_dir)
+    hooks = _load_hooks(project_dir, "glossary_link")
+    hooks._GLOSSARY_TERMS_CACHE = None
+
+    html = "<p>The memory buffer holds rows. A second memory buffer mention.</p><p>The forecasting horizon matters.</p>"
+    out = hooks.on_page_content(html, _glossary_page(), {}, None)
+
+    assert '<a href="../glossary/#memory-buffer">memory buffer</a>' in out, "term was not linked"
+    assert '<a href="../glossary/#forecasting-horizon">forecasting horizon</a>' in out
+    # First occurrence only -- linking every mention is noise, not navigation.
+    assert out.count('href="../glossary/#memory-buffer"') == 1, "linked more than the first occurrence"
+
+
+def test_glossary_skips_terms_not_opted_in(copie_session_minimal):
+    """A defined term without .autolink is never linked.
+
+    Defining a word and advertising it everywhere are separate decisions. A
+    glossary legitimately defines short common words ("step"), and linking those
+    wherever prose happens to use them produces noise.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_glossary(project_dir)
+    hooks = _load_hooks(project_dir, "glossary_optin")
+    hooks._GLOSSARY_TERMS_CACHE = None
+
+    out = hooks.on_page_content("<p>Each step is a step.</p>", _glossary_page(), {}, None)
+
+    assert "#step" not in out, "a term that did not opt in was linked"
+    assert "Each step is a step." in out, "text was altered"
+
+
+def test_glossary_never_links_inside_code_or_headings(copie_session_minimal):
+    """Code is not prose, and a link inside a heading or another link is broken markup."""
+    project_dir = copie_session_minimal.project_dir
+    _write_glossary(project_dir)
+    hooks = _load_hooks(project_dir, "glossary_skip")
+    hooks._GLOSSARY_TERMS_CACHE = None
+
+    html = (
+        "<h2>The memory buffer heading</h2>"
+        "<pre><code>memory buffer = 1</code></pre>"
+        '<p>See <a href="x">the memory buffer docs</a>.</p>'
+        "<p>A real memory buffer in prose.</p>"
+    )
+    out = hooks.on_page_content(html, _glossary_page(), {}, None)
+
+    assert "<h2>The memory buffer heading</h2>" in out, "linked inside a heading"
+    assert "<code>memory buffer = 1</code>" in out, "linked inside code"
+    assert '<a href="x">the memory buffer docs</a>' in out, "nested a link inside a link"
+    assert '<a href="../glossary/#memory-buffer">memory buffer</a>' in out, "prose occurrence was not linked"
+
+
+def test_glossary_page_does_not_link_itself(copie_session_minimal):
+    """The glossary must not turn its own definitions into links to themselves."""
+    project_dir = copie_session_minimal.project_dir
+    _write_glossary(project_dir)
+    hooks = _load_hooks(project_dir, "glossary_self")
+    hooks._GLOSSARY_TERMS_CACHE = None
+
+    page = _glossary_page("pages/explanation/glossary.md")
+    out = hooks.on_page_content("<p>A memory buffer is defined here.</p>", page, {}, None)
+
+    assert "<a href=" not in out, "the glossary linked its own terms"
+
+
+def test_glossary_absent_is_not_an_error(copie_session_minimal):
+    """Most projects ship no glossary; the feature must simply do nothing."""
+    project_dir = copie_session_minimal.project_dir
+    glossary = project_dir / "docs" / "pages" / "explanation" / "glossary.md"
+    if glossary.exists():
+        glossary.unlink()
+    hooks = _load_hooks(project_dir, "glossary_absent")
+    hooks._GLOSSARY_TERMS_CACHE = None
+
+    html = "<p>A memory buffer here.</p>"
+    assert hooks.on_page_content(html, _glossary_page(), {}, None) == html
+
+
 def test_see_also_links_member_path_entries(copie_session_minimal):
     """A ``Class.member`` See Also entry qualifies to a full autoref identifier.
 
@@ -1831,6 +1939,49 @@ def _write_notebook(project_dir, stem, gallery_body, imports=""):
     nb.parent.mkdir(parents=True, exist_ok=True)
     nb.write_text(f"import marimo\n\n{imports}\n__gallery__ = {{{gallery_body}}}\n", encoding="utf-8")
     return nb
+
+
+def test_notebook_export_is_cached_by_source_hash(copie_session_default):
+    """An unchanged notebook is not re-exported; an edited one is.
+
+    Exporting means executing the notebook, which dominates the docs build, so
+    this is the difference between a fast rebuild and a slow one under
+    `mkdocs serve`.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "nbcache")
+
+    notebook = project_dir / "examples" / "cache_probe.py"
+    notebook.parent.mkdir(parents=True, exist_ok=True)
+    notebook.write_text("x = 1\n", encoding="utf-8")
+    output_dir = project_dir / "docs" / "examples" / "cache_probe"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    digest = hooks._notebook_content_hash(notebook)
+
+    # Nothing exported yet.
+    assert not hooks._is_cached(output_dir, digest), "claimed a cache hit with no exported page"
+
+    # A hash with no rendered page must not count: the export may have died
+    # before writing the html, and reusing that ships a missing page.
+    (output_dir / hooks._SOURCE_HASH_FILE).write_text(digest, encoding="utf-8")
+    assert not hooks._is_cached(output_dir, digest), "claimed a cache hit with no index.html"
+
+    (output_dir / "index.html").write_text("<html></html>", encoding="utf-8")
+    assert hooks._is_cached(output_dir, digest), "did not reuse an unchanged export"
+
+    # Editing the notebook must invalidate it, or the site serves a stale render.
+    notebook.write_text("x = 2\n", encoding="utf-8")
+    assert not hooks._is_cached(output_dir, hooks._notebook_content_hash(notebook)), (
+        "reused the export of an edited notebook"
+    )
+
+
+def test_notebook_cache_is_absent_without_examples(copie_session_minimal):
+    """The caching code ships only where notebooks do."""
+    hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
+    assert "_notebook_content_hash" not in hooks_source, "notebook caching leaked into a no-examples project"
+    assert "import hashlib" not in hooks_source, "hashlib imported with nothing to hash"
 
 
 def _reset_gallery_caches(hooks):


### PR DESCRIPTION
## Description

Brings the two features `yohou` had forked `docs/hooks.py` to get into the template itself, so it — and any other project — can stop maintaining a fork of a template-managed file.

This is the last piece of the fan-out. yohou's fork is ~90% redundant already (its runtime API discovery is now **beaten** by the template's AST resolution: +29 real `Base*` classes, −5 helpers that live in a private `_utils.py` and are in no `__all__`). These two features were the only reasons left to keep it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Motivation and Context

### Glossary auto-linking

A project with `docs/pages/explanation/glossary.md` gets its terms linked from prose:

```markdown
Memory buffer { #memory-buffer .autolink }
:   The internal store of recent rows.

Step { #step }
:   One timestep.
```

A term marked `.autolink` has its **first** occurrence on every other page turned into a link to its definition. `Step` is defined but never linked.

Two decisions worth stating:

**The page is the single source of truth.** yohou kept a 44-entry dict in `hooks.py` naming terms defined on the page — a second copy, free to drift from the definitions it points at, living in a **Tier 1** file. That put the project's editorial data in the template's hands, which is exactly backwards.

**Opting in per term is the feature, not ceremony.** A glossary defines whatever is worth defining, including short common words — yohou's page defines `step`, `pipeline`, `ensemble`, `observe` — and auto-linking those wherever prose happens to use them is noise, not navigation. yohou curated **44 of its 62** defined terms; that judgment has to live somewhere, and `.autolink` puts it on the page next to the definition. A derive-everything design would have silently added those 18 back.

Linking runs over parsed HTML rather than a regex over the page, so code, headings and existing links are untouched; first occurrence only, since the reader needs the definition once.

### Notebook export caching

Exporting a notebook **executes** it, which dominates the docs build. Each export now records a SHA-256 of its source, and an unchanged notebook is reused rather than re-run — the difference between a fast and a slow rebuild under `mkdocs serve`.

The hash is stamped only after a successful export, and reuse requires the hash **and** the rendered page: a hash alone would reuse a directory whose html never got written, and a page alone would serve a stale render of an edited notebook forever. Ships only where notebooks do (`include_examples`).

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **276 fast tests pass**
- [x] Tested template generation with `copier copy` — both `include_examples` variants
- [x] Verified generated project works as expected — **verified against yohou, whose fork these come from: the template parses its real glossary page to exactly its 44 curated terms, with identical anchors**
- [x] Added/updated tests — 7 new, each mutation-checked
- [x] All tests pass

| behaviour | test |
|---|---|
| a `.autolink` term links, once, from prose | `test_glossary_terms_link_on_other_pages` |
| a defined term without `.autolink` never links | `test_glossary_skips_terms_not_opted_in` |
| code, headings and existing links untouched | `test_glossary_never_links_inside_code_or_headings` |
| the glossary does not link itself | `test_glossary_page_does_not_link_itself` |
| no glossary ⇒ no-op, not an error | `test_glossary_absent_is_not_an_error` |
| unchanged reused, edited re-exported, partial not reused | `test_notebook_export_is_cached_by_source_hash` |
| caching ships only with examples | `test_notebook_cache_is_absent_without_examples` |

All five mutations I tried were caught: ignoring `.autolink`, linking every occurrence, dropping the skip-tags, ignoring the source hash, and ignoring a missing `index.html`.

The new `_GLOSSARY_TERMS_CACHE` is picked up automatically by the existing `test_on_config_resets_every_cache`, which discovers caches by their `_CACHE` suffix.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (`contribute.md` documents the glossary syntax)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

The v0.19.1 `ruff format --check` guard earned its keep here — it caught a missing blank line in this very PR's new code before it could ship and red every generated project's first `pre-commit run`.

No generated project changes behaviour without opting in: no glossary page means no linking, and the notebook cache only ever skips work that would have produced the same output.
