### PR TITLE
fix(template): make the docs hooks pass ruff check in generated projects

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -124,7 +124,10 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["ARG", "S101", "T201", "PLR2004"]  # Allow assert statements, prints, and magic values in tests
-"docs/**/*" = ["T201", "ARG001", "PLW0603", "SIM105", "SIM108"]  # Allow prints, unused args, globals, and simplifiable patterns in documentation hooks
+# The hooks implement signatures they do not choose -- mkdocs' event hooks and
+# HTMLParser's handle_* methods -- so an unused parameter is the interface, not
+# an oversight. ARG002 is the method-level twin of ARG001.
+"docs/**/*" = ["T201", "ARG001", "ARG002", "PLW0603", "SIM105", "SIM108"]  # Allow prints, unused args, globals, and simplifiable patterns in documentation hooks
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ package_name }}"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2912,6 +2912,37 @@ def test_generated_project_is_ruff_format_clean(copie, include_examples):
     )
 
 
+@pytest.mark.parametrize("include_examples", [True, False])
+def test_generated_project_passes_ruff_check(copie, include_examples):
+    """A freshly generated project passes ``ruff check``.
+
+    The format guard above is not enough: it proved the template's Python is
+    *shaped* right, while nothing checked whether it *lints*. A class-based hook
+    shipped with three ARG002 violations under exactly that blind spot, and every
+    generated project without a local ARG002 ignore failed its first
+    `pre-commit run` -- the same failure the format guard exists to prevent,
+    through the other half of the same door.
+
+    Runs ruff with the project's own config, so this is what the project runs.
+    """
+    ruff = shutil.which("ruff")
+    if ruff is None:
+        pytest.skip("ruff is not installed in the test environment")
+
+    result = copie.copy(extra_answers={"include_examples": include_examples})
+    check = subprocess.run(
+        [ruff, "check", "--force-exclude", "--no-fix", "."],
+        cwd=result.project_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert check.returncode == 0, (
+        "the template ships Python that fails `ruff check`, so a generated "
+        f"project's first `pre-commit run` reds CI:\n{check.stdout}{check.stderr}"
+    )
+
+
 def test_update_guidance_restores_local_owned_files(copie_session_default):
     """The local-owned remedy must restore, not merely discard the rejection.
 


### PR DESCRIPTION
## Description

A `v0.20.1` fix release: **a clean `v0.20.0` project fails `ruff check` with three errors**, so its first `pre-commit run` reds CI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

v0.20.0's glossary linker is the template's first **class-based** hook. `HTMLParser` mandates `handle_starttag(self, tag, attrs)` whether or not a subclass needs `attrs` — that is `ARG002`, the method-level twin of `ARG001`.

The `docs/**` ignores already carry `ARG001`, for precisely this reason: these hooks implement signatures they do not choose — mkdocs' event hooks and `HTMLParser`'s `handle_*` alike. `ARG002` belongs beside it.

Only repos with a *local* `ARG002` ignore escaped (yohou has one, "common in sklearn-style APIs"), which is why this survived the fan-out unnoticed until sklearn-wrap hit it.

### The guard was the real fault

v0.19.1 added a test asserting a generated project is `ruff format --check` clean — after shipping unformatted hooks. It proved the template's Python was **shaped** right and never asked whether it **lints**. This bug walked through the other half of the same door.

There is now a `ruff check` guard beside the format one, both parametrized over `include_examples`. This is the second escape through this gap; it should be the last.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **278 fast tests pass**
- [x] Tested template generation with `copier copy` — both `include_examples` variants
- [x] Verified generated project works as expected — a clean generation now passes `ruff check`
- [x] Added/updated tests — `test_generated_project_passes_ruff_check`, mutation-checked (fails against the unfixed ignores, passes with them)
- [x] All tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation
