### PR TITLE
fix(template): track only the .claude/skills copy, and stop hardcoding one project's domain

### DIFF
--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -56,7 +56,10 @@ docs/stylesheets/theme.css
 .github/ISSUE_TEMPLATE/config.yml
 .github/ISSUE_TEMPLATE/feature_request.yml
 .github/PULL_REQUEST_TEMPLATE.md
-.github/skills/**                   # Skill files managed by template
+.claude/skills/**                   # Skill files managed by template (the tracked copy)
+.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
+                                    # update never delivers it -- copier works through
+                                    # git and skips ignored paths. Edit .claude/skills.
 ```
 
 ---

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -56,7 +56,10 @@ docs/stylesheets/theme.css
 .github/ISSUE_TEMPLATE/config.yml
 .github/ISSUE_TEMPLATE/feature_request.yml
 .github/PULL_REQUEST_TEMPLATE.md
-.github/skills/**                   # Skill files managed by template
+.claude/skills/**                   # Skill files managed by template (the tracked copy)
+.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
+                                    # update never delivers it -- copier works through
+                                    # git and skips ignored paths. Edit .claude/skills.
 ```
 
 ---

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -141,6 +141,16 @@ llm-instructions/
 .claude/*
 !.claude/skills/
 
+# openspec installs its own skills. They are tool state that openspec rewrites,
+# not project content, so they are never tracked -- even though the rule above
+# tracks .claude/skills.
+.claude/skills/openspec-*/
+
+# The Copilot-side skills mirror .claude/skills byte for byte. Tracking both
+# doubles every skill edit and its review. .claude/skills is the source of
+# truth; this copy is generated alongside it and stays out of git.
+.github/skills/
+
 # Project-specific AI context (that you want to keep private)
 .cursorrules
 .cursor/

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -504,25 +504,24 @@ Notebooks serve **tutorials** or **how-to guides** only - never explanation or r
 **Example intro cell (tutorial)**:
 
 ```markdown
-# Your First Hyperparameter Search
+# Your First Pipeline
 
-In this notebook, we will run a hyperparameter search using OptunaSearchCV
-and inspect the results.
+In this notebook, we will build a small {{ project_name }} pipeline end to end
+and inspect what it produces.
 
-**Prerequisites:** Python 3.11+ and familiarity with sklearn's fit/predict API.
+**Prerequisites:** Python {{ min_python_version }}+ and basic familiarity with {{ package_name }}.
 ```
 
 **Example intro cell (how-to)**:
 
 ```markdown
-# How to Stop Optimization Early with Callbacks
+# How to Handle Missing Values
 
-This notebook shows how to attach Optuna callbacks to OptunaSearchCV
-to stop a search after a fixed number of trials.
+This notebook shows how to configure {{ package_name }} to drop incomplete
+records before processing.
 
 **Prerequisites:** Familiarity with the
-OptunaSearchCV quickstart
-([View](/examples/quickstart/) · [Open in marimo](/examples/quickstart/edit/)).
+quickstart ([View](/examples/quickstart/) · [Open in marimo](/examples/quickstart/edit/)).
 ```
 
 #### Marimo Cell Conventions

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2273,6 +2273,79 @@ def test_quadrant_indexes_are_local_owned(copie_session_default):
         assert f"docs/pages/{quadrant}/index.md" in tier3, f"{quadrant}/index.md not listed as local-owned"
 
 
+def _is_ignored(project_dir, path):
+    """Whether git would ignore `path`, judged by the generated .gitignore itself."""
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", path],
+        cwd=project_dir,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _git_init(project_dir):
+    """A throwaway repo, so `git check-ignore` has a worktree to answer against."""
+    subprocess.run(["git", "init", "-q"], cwd=project_dir, capture_output=True, check=True)
+
+
+def test_only_the_claude_skills_copy_is_tracked(copie):
+    """.claude/skills is the tracked source of truth; the Copilot mirror is not.
+
+    The two copies are byte-identical by design, so tracking both doubles every
+    skill edit and its review. Judged with `git check-ignore` against the
+    generated .gitignore rather than by reading it: the rule that matters is the
+    one git actually applies, and this file's negation (`.claude/*` then
+    `!.claude/skills/`) is exactly the kind that looks right and silently is not.
+    """
+    project_dir = copie.copy().project_dir
+    _git_init(project_dir)
+
+    assert not _is_ignored(project_dir, ".claude/skills/update-from-template/SKILL.md"), (
+        ".claude/skills must be tracked -- it is the source of truth for the skills"
+    )
+    assert _is_ignored(project_dir, ".github/skills/update-from-template/SKILL.md"), (
+        ".github/skills is a byte-identical mirror of .claude/skills and must not be tracked"
+    )
+
+
+def test_openspec_skills_are_never_tracked(copie):
+    """openspec rewrites its own skills; they are tool state, not project content.
+
+    The `!.claude/skills/` negation would otherwise pull them in, so this needs
+    its own rule -- and needs testing, because the interaction between a
+    negation and a later ignore is where this silently goes wrong.
+    """
+    project_dir = copie.copy().project_dir
+    _git_init(project_dir)
+
+    assert _is_ignored(project_dir, ".claude/skills/openspec-propose/SKILL.md"), (
+        "an openspec skill under .claude/skills must stay untracked"
+    )
+    assert _is_ignored(project_dir, ".github/skills/openspec-review/SKILL.md"), (
+        "an openspec skill under .github/skills must stay untracked"
+    )
+    # The rule must not swallow the skills the template does ship.
+    assert not _is_ignored(project_dir, ".claude/skills/diataxis-howto-writer/SKILL.md"), (
+        "the openspec rule is too broad -- it is hiding a template-shipped skill"
+    )
+
+
+def test_contribute_guide_carries_no_other_projects_domain(copie_session_default):
+    """The notebook examples must not name another project's API.
+
+    Every generated project gets this page. Examples written around one
+    package's domain read as nonsense in the rest of the fleet -- a kedro plugin
+    told to document `OptunaSearchCV` -- and quietly invite copying the wrong
+    thing.
+    """
+    contribute = (copie_session_default.project_dir / "docs" / "pages" / "how-to" / "contribute.md").read_text(
+        encoding="utf-8"
+    )
+    for foreign in ("OptunaSearchCV", "Optuna", "Hyperparameter Search", "sklearn_optuna"):
+        assert foreign not in contribute, f"the contribute guide hardcodes another project's domain: {foreign!r}"
+
+
 def test_project_branding_assets_are_local_owned(copie_session_default):
     """A project's logo and favicon must survive a template update.
 


### PR DESCRIPTION
## Description

Two things every generated project inherits and should not.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Motivation and Context

### 1. Skills: one tracked copy, not two

`.claude/skills` and `.github/skills` are **byte-identical mirrors**, and both were tracked — so every skill edit had to be made and reviewed twice. `.claude/skills` is now the source of truth; `.github/skills` is gitignored beside it.

**openspec** installs its own skills under `.claude/skills`. Those are tool state that openspec rewrites, not project content, so they need their own rule — the `!.claude/skills/` negation would otherwise pull them straight in. This repo already ignores `/.github/skills/openspec-*/` for exactly that reason; this extends the same principle.

| path | tracked? |
|---|---|
| `.claude/skills/**` | ✅ yes — the source of truth |
| `.claude/skills/openspec-*/` | ❌ no — tool state |
| `.github/skills/**` | ❌ no — byte-identical mirror |

⚠️ **Worth knowing when this reaches a project:** copier works *through git*, so it never delivers files under an ignored path. Once `.github/skills` is ignored, an update stops writing it, and a repo that tracks it today must `git rm -r --cached .github/skills` once. The file-classification now records this, so the next reader is not surprised by a directory the template appears to ship but never updates.

### 2. The contribute guide named another project's API

Its example intro cells were written around **sklearn-optuna** — *"Your First Hyperparameter Search"*, `OptunaSearchCV`, "Optuna callbacks". Every generated project got them verbatim, so a kedro plugin's own contributing guide instructed its readers to document `OptunaSearchCV`. Now templated and domain-neutral.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **281 fast tests pass**
- [x] Tested template generation with `copier copy`
- [x] Verified generated project works as expected
- [x] Added/updated tests — 3 new, each mutation-checked
- [x] All tests pass

| behaviour | test |
|---|---|
| `.claude/skills` tracked, `.github/skills` not | `test_only_the_claude_skills_copy_is_tracked` |
| openspec skills never tracked, shipped skills still are | `test_openspec_skills_are_never_tracked` |
| no foreign domain in the contribute guide | `test_contribute_guide_carries_no_other_projects_domain` |

The gitignore tests ask **`git check-ignore`** rather than reading the file: the rule that matters is the one git actually applies, and a negation (`.claude/*` → `!.claude/skills/`) followed by a later ignore is precisely where this looks right and silently is not. All four mutations were caught — including an over-broad openspec rule that swallows the skills the template does ship.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (file-classification, both mirrored copies)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation
