### PR TITLE
fix(docs): make the API index links work wherever the index lives

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -77,6 +77,9 @@ examples/__marimo__/
 # Ruff
 .ruff_cache/
 
+# Markdown linter cache
+.rumdl_cache/
+
 # OpenSpec (local working artifacts, not tracked)
 openspec/
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -464,7 +464,21 @@ def _generate_api_pages(project_root):
         print(f"[hooks] generated {member_count} API member pages in pages/api/generated/")
 
 
-def _build_api_table_html(project_root):
+def _site_root_prefix(page):
+    """Relative path from `page`'s rendered URL back to the site root.
+
+    Every link this file injects is relative, because the site may be served
+    under a subpath and `use_directory_urls` makes each page its own directory.
+    A hardcoded `../../` only works if the page never moves: a project is free
+    to put its API index at `pages/api/index.md` rather than the template's
+    `pages/reference/api.md`, and a fixed prefix silently 404s every link on it.
+    """
+    parts = page.file.src_path.split("/")
+    depth = len(parts) if parts[-1] != "index.md" else len(parts) - 1
+    return "../" * depth
+
+
+def _build_api_table_html(project_root, prefix):
     """Build an HTML <table> for the API index with DataTables init.
 
     Lists every public class and function across all submodules with
@@ -484,7 +498,7 @@ def _build_api_table_html(project_root):
 
         members = _get_public_members(mod_file, pkg_dir)
         module_label = f"{{ package_name }}.{mod['module_name']}"
-        module_href = f"../../api/{mod['module_name']}/"
+        module_href = f"{prefix}pages/api/{mod['module_name']}/"
 
         for cls in members["classes"]:
             qualified = f"{{ package_name }}.{mod['module_name']}.{cls['name']}"
@@ -503,7 +517,7 @@ def _build_api_table_html(project_root):
 
     tbody_lines = []
     for name, kind, module_label, module_href, desc, qualified in rows:
-        href = f"../../api/generated/{qualified}/"
+        href = f"{prefix}pages/api/generated/{qualified}/"
         badge_cls = _type_badge_cls.get(kind, "")
         tbody_lines.append(
             f"      <tr>"
@@ -1628,10 +1642,11 @@ def on_page_markdown(markdown, page, config, files):
 {% if include_examples %}    ``<!-- GALLERY -->``           → flat card grid of example notebooks
 {% endif %}    """
     project_root = Path(__file__).parent.parent
+    prefix = _site_root_prefix(page)
 
     # API_TABLE placeholder
     if "<!-- API_TABLE -->" in markdown:
-        table = _build_api_table_html(project_root)
+        table = _build_api_table_html(project_root, prefix)
         markdown = markdown.replace("<!-- API_TABLE -->", table)
 {% if include_examples %}
     # EXAMPLES_FOR placeholders on generated API pages
@@ -1639,10 +1654,6 @@ def on_page_markdown(markdown, page, config, files):
         qualified = match.group(1)
         examples_html = _build_api_examples_html(project_root, qualified)
         markdown = markdown.replace(match.group(0), examples_html)
-
-    src_parts = page.file.src_path.split("/")
-    depth = len(src_parts) if src_parts[-1] != "index.md" else len(src_parts) - 1
-    prefix = "../" * depth
 
     repo_url = config.get("repo_url", "").rstrip("/")
     github_path = repo_url.removeprefix("https://")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,7 @@
 """Tests for the copier template."""
 
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -2740,23 +2741,62 @@ def test_reexported_symbols_appear_in_the_api_index(copie_session_minimal):
     hooks._API_NAME_LOOKUP_CACHE = None
     hooks._SUBMODULE_CACHE = None
 
-    html = hooks._build_api_table_html(project_dir)
+    prefix = hooks._site_root_prefix(_FakePage("pages/reference/api.md", "pages/reference/api/index.html"))
+    html = hooks._build_api_table_html(project_dir, prefix)
 
     assert "Circle" in html, "re-exported class absent from the searchable API index"
     assert "area" in html, "re-exported function absent from the searchable API index"
 
-    # The index renders on pages/reference/api.md, served at pages/reference/api/.
-    # Its symbol and module links must climb two levels to reach pages/api/, the
-    # same as _build_module_toc on the same page. A single ../ resolves to
-    # pages/reference/api/... which does not exist, so the links 404 in every
-    # generated site while the table still looks populated.
-    assert '<a href="../../api/generated/minimal_project.shapes.Circle/">' in html, (
+    # From pages/reference/api/, three levels reach the site root, then down to
+    # pages/api/. Get this wrong and the table still renders fully populated
+    # while every link 404s -- mkdocs does not validate hook-injected raw HTML.
+    assert '<a href="../../../pages/api/generated/minimal_project.shapes.Circle/">' in html, (
         "symbol link does not resolve from pages/reference/api/ to the generated page"
     )
-    assert '<a href="../../api/shapes/">' in html, (
+    assert '<a href="../../../pages/api/shapes/">' in html, (
         "module link does not resolve from pages/reference/api/ to the submodule page"
     )
-    assert 'href="../api/' not in html, "a single-../ link (the pre-fix 404) is still emitted"
+
+
+@pytest.mark.parametrize(
+    ("src_path", "dest_path", "prefix"),
+    [
+        ("pages/reference/api.md", "pages/reference/api/index.html", "../../../"),
+        ("pages/api/index.md", "pages/api/index.html", "../../"),
+    ],
+)
+def test_api_index_links_resolve_wherever_the_index_lives(copie_session_minimal, src_path, dest_path, prefix):
+    """The API table's links work from any page the index is placed on.
+
+    The template seeds the index at pages/reference/api.md, but a project may
+    move it -- yohou keeps it at pages/api/index.md, one level shallower. A
+    hardcoded `../../` is right for the seeded location and silently 404s every
+    one of the other's links: the table renders fully populated, and mkdocs
+    cannot catch it because it does not validate raw HTML injected by a hook.
+
+    So the prefix is derived from the page, and this checks both layouts by
+    resolving each href against the page's own URL -- the arithmetic is the
+    whole point, and asserting on a literal string would just restate it.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, f"api_index_{src_path.count('/')}_{len(prefix)}")
+    hooks._API_NAME_LOOKUP_CACHE = None
+    hooks._SUBMODULE_CACHE = None
+
+    page = _FakePage(src_path, dest_path)
+    assert hooks._site_root_prefix(page) == prefix
+
+    html = hooks._build_api_table_html(project_dir, hooks._site_root_prefix(page))
+    hrefs = re.findall(r'<a href="([^"]+)"', html)
+    assert hrefs, "the API table emitted no links at all"
+
+    page_dir = posixpath.dirname(dest_path)
+    for href in hrefs:
+        resolved = posixpath.normpath(posixpath.join(page_dir, href))
+        assert resolved.startswith("pages/api/"), (
+            f"from {dest_path}, href {href!r} resolves to {resolved!r} -- outside pages/api/, so it 404s"
+        )
 
 
 def _write_dependency_shim(project_dir, package_name):


### PR DESCRIPTION
## Description

A `v0.20.3` fix release. The API index's links **404 on any project that moved its index page** — and nothing in the build catches it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

`_build_api_table_html` hardcoded `../../api/...`, which is correct only for the page the template *seeds* the index on: `pages/reference/api.md`.

A project is free to move it. **yohou has kept its index at `pages/api/index.md` since its first commit** — one level shallower — so on that page `../../api/generated/X/` resolves to `/api/generated/X/` and 404s. **377 links**, and its Read the Docs build fails on the linkchecker.

### Why nothing caught it

`mkdocs build --strict` **passes**. mkdocs does not validate raw HTML injected by a hook, so the table renders fully populated with every link dead. It took a linkchecker in a downstream project's `post_build` to surface it — a good reminder that "strict build is green" is not the same as "the links work".

### The fix

The prefix is now derived from the page, using the same site-root arithmetic `on_page_markdown` already performed a few lines below and this table simply did not use:

```python
href = f"{prefix}pages/api/generated/{qualified}/"   # was ../../api/generated/...
```

It resolves correctly for both layouts:

| index location | page URL | prefix | resolves to |
|---|---|---|---|
| `pages/reference/api.md` (seeded) | `/pages/reference/api/` | `../../../` | `/pages/api/generated/X/` ✅ |
| `pages/api/index.md` (yohou) | `/pages/api/` | `../../` | `/pages/api/generated/X/` ✅ |

**This is a regression I introduced in v0.19.1.** That release fixed `../api/` → `../../api/` against the seeded location — and in nailing down one page's depth, hardcoded the assumption that the page never moves.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **283 fast tests pass**
- [x] Tested template generation with `copier copy` — both `include_examples` variants
- [x] Verified generated project works as expected
- [x] Added/updated tests — mutation-checked
- [x] All tests pass

`test_api_index_links_resolve_wherever_the_index_lives` **resolves every href against the page's own URL**, parametrized over both layouts, rather than asserting a literal prefix — the arithmetic is the point, and a string assertion would only restate it.

Both mutations are caught: restoring the hardcoded `../../`, and dropping the `index.md` depth special case.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Also adds `.rumdl_cache/` to the generated `.gitignore`. The other four tool caches (`.pytest_cache`, `.ty_cache`, `.mkdocs_cache`, `.ruff_cache`) were already ignored; rumdl's was missed, so a `git add -A` could commit it. Verified none of the seven repos has — the gap is latent, not active.
