### PR TITLE
fix(docs): build the module TOC for whichever page is the API index

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -904,7 +904,7 @@ def _build_api_examples_html(project_root, qualified_name):
 # ---------------------------------------------------------------------------
 
 
-def _build_module_toc(config, current_src_path=None):
+def _build_module_toc(config, current_src_path=None, prefix=None):
     """Build the module TOC list used by the api-submodule sidebar template.
 
     Parameters
@@ -925,8 +925,6 @@ def _build_module_toc(config, current_src_path=None):
     api_dir = docs_dir / "pages" / "api"
     project_root = docs_dir.parent
 
-    is_index = current_src_path is None or current_src_path == "pages/reference/api.md"
-
     modules = _get_submodules(project_root)
     module_toc = []
 
@@ -936,12 +934,11 @@ def _build_module_toc(config, current_src_path=None):
         if not md_path.exists():
             continue
 
-        # Compute relative URL
-        if is_index:
-            # reference/api.md is at pages/reference/api/, submodule pages at pages/api/
-            page_url = f"../../api/{md_filename.replace('.md', '/')}"
-        else:
-            page_url = f"../{md_filename.replace('.md', '/')}".replace("//", "/")
+        # Site-root relative, so the TOC is correct on any page that renders it.
+        # The old form branched on whether the current page was the API index and
+        # hardcoded that index's depth -- which silently 404s for a project that
+        # keeps its index somewhere else.
+        page_url = f"{prefix}pages/api/{md_filename.replace('.md', '/')}"
 
         active = current_src_path == f"pages/api/{md_filename}" if current_src_path else False
 
@@ -1615,16 +1612,12 @@ def on_page_content(html, page, config, files):
         html = _linkify_see_also(html)
         html = _process_api_page_content(html, page, config)
 
-    if src == "pages/reference/api.md":
-        # API index: flat module list (api-index.html template)
-        page.meta["module_toc"] = _build_module_toc(config, current_src_path=src)
-    elif (
-        src.startswith("pages/api/")
-        and not src.startswith("pages/api/generated/")
-        and page.meta.get("template") == "api-submodule.html"
-    ):
-        # Submodule page: module list with active/children expansion
-        page.meta["module_toc"] = _build_module_toc(config, current_src_path=src)
+    # Keyed on the template a page declares, not on where the page happens to
+    # live: the index is wherever a project put it. Matching a hardcoded
+    # `pages/reference/api.md` leaves a relocated index with no module_toc at
+    # all -- its sidebar renders empty, and nothing errors.
+    if page.meta.get("template") in ("api-index.html", "api-submodule.html"):
+        page.meta["module_toc"] = _build_module_toc(config, current_src_path=src, prefix=_site_root_prefix(page))
 
     # Last: the API restructuring above rewrites whole regions, so linking
     # before it would have its links discarded with the markup they sat in.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2799,6 +2799,54 @@ def test_api_index_links_resolve_wherever_the_index_lives(copie_session_minimal,
         )
 
 
+@pytest.mark.parametrize(
+    ("src_path", "dest_path", "template_name"),
+    [
+        ("pages/reference/api.md", "pages/reference/api/index.html", "api-index.html"),
+        ("pages/api/index.md", "pages/api/index.html", "api-index.html"),
+        ("pages/api/shapes.md", "pages/api/shapes/index.html", "api-submodule.html"),
+    ],
+)
+def test_module_toc_is_built_and_resolves_wherever_the_page_lives(
+    copie_session_minimal, src_path, dest_path, template_name
+):
+    """Any page declaring an API template gets a module TOC whose links resolve.
+
+    Two failures this pins, both silent. The TOC used to be keyed on the
+    hardcoded path `pages/reference/api.md`, so a project that moved its index --
+    yohou keeps it at pages/api/index.md -- got no module_toc at all and rendered
+    an empty sidebar with nothing erroring. And its urls hardcoded that same
+    page's depth, so they 404'd from anywhere else.
+
+    Keying on the declared template is the fix: a page says what it is, rather
+    than being recognised by where it sits.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_reexport_package(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, f"mtoc_{template_name}_{src_path.count('/')}")
+    hooks._SUBMODULE_CACHE = None
+
+    # The submodule pages the TOC points at are generated, not committed.
+    hooks._generate_api_pages(project_dir)
+
+    page = _FakePage(src_path, dest_path)
+    page.meta["template"] = template_name
+    hooks.on_page_content("<p>x</p>", page, {"docs_dir": str(project_dir / "docs")}, None)
+
+    toc = page.meta.get("module_toc")
+    assert toc, f"a page declaring {template_name} got no module_toc"
+
+    page_dir = posixpath.dirname(dest_path)
+    for entry in toc:
+        resolved = posixpath.normpath(posixpath.join(page_dir, entry["url"]))
+        assert resolved.startswith("pages/api/"), (
+            f"from {dest_path}, TOC url {entry['url']!r} resolves to {resolved!r} -- it 404s"
+        )
+        assert (project_dir / "docs" / f"{resolved}.md").exists() or (project_dir / "docs" / resolved).exists(), (
+            f"TOC url {entry['url']!r} points at a page that does not exist"
+        )
+
+
 def _write_dependency_shim(project_dir, package_name):
     """A plain module whose public API is re-exported from outside the package.
 


### PR DESCRIPTION
## Description

**v0.20.3 fixed one half of a bug and left its twin one function over.** This finishes it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

Two hardcodes, both assuming the API index never moves from where the template seeds it:

| | before | after |
|---|---|---|
| `on_page_content` | set `module_toc` only for the literal path `pages/reference/api.md` | keys on the **template a page declares** (`api-index.html` / `api-submodule.html`) |
| `_build_module_toc` | built `../../api/...` — right at depth 3, wrong at depth 2 | takes the same site-root prefix the API table uses |

**The first is the nastier one.** A project that moved its index — **yohou keeps its at `pages/api/index.md`** — got **no `module_toc` at all**, so its `api-index.html` rendered an **empty sidebar**. Nothing errored. The page just quietly lost its module list.

Keying on the declared template is the actual fix: a page *says* what it is, rather than being recognised by where it happens to sit.

### Why this survived v0.20.3

yohou is the repo it was hiding behind. It carried a forked `hooks.py` that compensated for both, so dropping the fork exposed them — and v0.20.3 only looked at `_build_api_table_html`. Its own `docs/material/overrides/api-index.html` consumes `module_toc` twice.

Found by an agent reviewing v0.20.3, not by v0.20.3 itself. That is the uncomfortable part: I fixed one function and did not go looking for its twin.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **286 fast tests pass**
- [x] Tested template generation with `copier copy` — both `include_examples` variants
- [x] Verified generated project works as expected
- [x] Added/updated tests — mutation-checked
- [x] All tests pass

`test_module_toc_is_built_and_resolves_wherever_the_page_lives` drives all three cases — the seeded index, a relocated index, and a submodule page — **resolves every TOC url against the page's own URL** and asserts the target exists on disk.

Both mutations are caught: re-keying on the hardcoded path (the relocated index loses its TOC), and restoring the hardcoded prefix (its urls 404).

There is now **no hardcoded `../../api/` or `pages/reference/api.md` special-case left** in `hooks.py`.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

The `ruff format --check` guard added in v0.19.1 caught this PR's own code before it shipped — the second time it has paid for itself.
