### PR TITLE
feat(docs): let notebooks reach their pages and indexes name their subpages

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -4,6 +4,7 @@ import ast
 import fnmatch
 {% if include_examples %}import hashlib
 {% endif %}import importlib.util
+import logging
 {% if include_examples %}import os
 {% endif %}import posixpath
 import re
@@ -12,6 +13,13 @@ import subprocess
 {% if include_examples %}import sys
 {% endif %}from html.parser import HTMLParser
 from pathlib import Path
+
+# Warnings logged under the "mkdocs" logger tree are counted by mkdocs and turn
+# a --strict build red. Every marker this file understands is silently inert
+# when it does not resolve -- a placeholder that renders nothing looks exactly
+# like a page that never had one. Warning here is what makes a dead marker a
+# build failure instead of a blank space nobody notices.
+log = logging.getLogger("mkdocs.hooks")
 
 # Module-level caches. MkDocs loads hooks as plugin instances and does not
 # reload the module between builds, so these live for the whole process --
@@ -669,6 +677,10 @@ def _get_gallery_items(project_root):
             "title": gallery.get("title", stem.replace("_", " ").title()),
             "description": gallery.get("description", ""),
             "category": gallery.get("category", ""),
+            # `category` is the Diataxis kind (tutorial / how-to); `section` is
+            # the topic grouping a gallery splits into once it outgrows one
+            # page. They are independent: a section holds both kinds.
+            "section": gallery.get("section", ""),
             "api_references": api_references,
             "companion": gallery.get("companion"),
             "view_path": view_path,
@@ -680,9 +692,42 @@ def _get_gallery_items(project_root):
     return _GALLERY_CACHE
 
 
-def _build_gallery_html(project_root):
-    """Build gallery card grid as Material 'grid cards' markdown, grouped by category."""
+_SECTION_GALLERY_RE = re.compile(r"<!-- GALLERY:section:([\w.-]+) -->")
+
+
+def _get_gallery_sections(project_root):
+    """Every section name declared by a notebook, in first-seen order."""
+    seen = []
+    for item in _get_gallery_items(project_root):
+        section = item.get("section")
+        if section and section not in seen:
+            seen.append(section)
+    return seen
+
+
+def _build_gallery_html(project_root, section=None):
+    """Build gallery card grid as Material 'grid cards' markdown, grouped by category.
+
+    ``section`` narrows the grid to the notebooks declaring that ``section``,
+    which is how a gallery too big for one page splits across subpages. The
+    category grouping still applies inside the section: a topic holds both
+    tutorials and how-tos, and the split is by topic, not by kind.
+    """
     items = _get_gallery_items(project_root)
+
+    if section is not None:
+        items = [item for item in items if item.get("section") == section]
+        if not items:
+            # An author renamed a section, or misspelled one. Either way the
+            # page silently loses its whole card grid, so refuse to be quiet.
+            known = ", ".join(_get_gallery_sections(project_root)) or "none"
+            log.warning(
+                "gallery section %r matches no notebook (declared sections: %s). "
+                "The page requesting it renders no cards.",
+                section,
+                known,
+            )
+            return f"<!-- no gallery items in section: {section} -->\n"
 
     if not items:
         return "<!-- no gallery items found -->\n"
@@ -897,6 +942,168 @@ def _build_api_examples_html(project_root, qualified_name):
         html += f"\n[See all {total} examples in the gallery]({gallery_url})\n"
     return html
 {%- endif %}
+
+
+# ---------------------------------------------------------------------------
+# Marker substitution
+# ---------------------------------------------------------------------------
+
+
+def _replace_marker(markdown, marker, replacement):
+    """Replace ``marker`` with ``replacement``, re-indented to the marker's column.
+
+    A marker nested inside an indented block -- an admonition body, a list item
+    -- carries leading whitespace that its replacement has to inherit. A plain
+    ``str.replace`` indents only the first line, so every line after it lands at
+    column 0 and silently falls out of the enclosing block: the block keeps the
+    first line and the rest renders as a sibling. That failure is invisible in
+    the markdown and only shows up in the built HTML, which is why it survived
+    so long. Matching the indentation keeps the replacement inside whatever the
+    author nested it in.
+    """
+    if marker not in markdown:
+        return markdown
+
+    out = []
+    for line in markdown.split("\n"):
+        stripped = line.strip()
+        if stripped != marker:
+            # A marker sharing its line with prose is substituted in place; it
+            # was never nested, so there is no indentation to match.
+            out.append(line.replace(marker, replacement) if marker in line else line)
+            continue
+        indent = line[: len(line) - len(line.lstrip())]
+        if not replacement:
+            continue
+        if not indent:
+            out.append(replacement)
+            continue
+        # Blank lines stay blank: trailing whitespace on an "empty" line is a
+        # lint violation, and markdown does not need it to keep the block open.
+        out.extend(indent + rline if rline.strip() else "" for rline in replacement.split("\n"))
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Section index (<!-- SUBPAGES -->)
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+_H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+_DESCRIPTION_RE = re.compile(r"^description:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _nav_order(config):
+    """Map ``src_path`` -> position in the configured nav.
+
+    The nav is the order the author chose and the order the reader sees in the
+    sidebar; an index that lists its pages in a different order than the nav
+    beside it reads as a different set of pages.
+    """
+    order = {}
+
+    def walk(node):
+        if isinstance(node, str):
+            order.setdefault(node, len(order))
+        elif isinstance(node, list):
+            for child in node:
+                walk(child)
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+
+    walk(config.get("nav") or [])
+    return order
+
+
+def _page_title_and_description(abs_path):
+    """Pull a page's title and one-line summary from its own source.
+
+    Title is the H1; summary is the frontmatter ``description`` when present,
+    else the first prose paragraph. Deriving both from the page keeps the index
+    honest -- there is no second copy of the title to drift out of sync.
+    """
+    try:
+        text = Path(abs_path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None, ""
+
+    description = ""
+    frontmatter = _FRONTMATTER_RE.match(text)
+    if frontmatter:
+        found = _DESCRIPTION_RE.search(frontmatter.group(1))
+        if found:
+            description = found.group(1).strip().strip("\"'")
+        text = text[frontmatter.end() :]
+
+    heading = _H1_RE.search(text)
+    if not heading:
+        return None, description
+    title = heading.group(1).strip()
+
+    if not description:
+        body = text[heading.end() :]
+        for raw_block in body.split("\n\n"):
+            block = raw_block.strip()
+            # Skip anything that is not prose: nested headings, markers,
+            # admonitions, code fences, tables, images, lists.
+            if not block or block[0] in "#<!|-*>`" or block.startswith("!!!"):
+                continue
+            description = " ".join(block.split())
+            break
+
+    return title, description
+
+
+def _build_subpages_list(config, page, files):
+    """List the pages this index page introduces, as ``- [Title](slug.md): summary``.
+
+    Generated rather than hand-written: an index is the one page guaranteed to
+    fall behind, because adding a page elsewhere is what makes it stale, and
+    nothing fails when it does.
+    """
+    src = page.file.src_path
+    directory = posixpath.dirname(src)
+
+    siblings = []
+    for candidate in files:
+        candidate_src = getattr(candidate, "src_path", "")
+        if not candidate_src.endswith(".md") or candidate_src == src:
+            continue
+        # Direct children only: a nested section owns its own index.
+        if posixpath.dirname(candidate_src) != directory:
+            continue
+        if posixpath.basename(candidate_src) == "index.md":
+            continue
+        siblings.append(candidate)
+
+    if not siblings:
+        log.warning("<!-- SUBPAGES --> on %s, which has no sibling pages to list.", src)
+        return "<!-- no subpages -->\n"
+
+    order = _nav_order(config)
+    rows = []
+    for sibling in siblings:
+        title, description = _page_title_and_description(sibling.abs_src_path)
+        if title is None:
+            # No H1 means no name to show. Inventing one from the filename would
+            # paper over a page that is genuinely malformed.
+            log.warning("%s has no H1 heading; omitted from the %s index.", sibling.src_path, src)
+            continue
+        rows.append((
+            order.get(sibling.src_path, len(order) + 1),
+            title,
+            posixpath.basename(sibling.src_path),
+            description,
+        ))
+
+    if not rows:
+        return "<!-- no subpages -->\n"
+
+    rows.sort(key=lambda row: (row[0], row[1]))
+    lines = [f"- [{title}]({slug})" + (f": {desc}" if desc else "") for _, title, slug, desc in rows]
+    return "\n".join(lines) + "\n"
 
 
 # ---------------------------------------------------------------------------
@@ -1631,8 +1838,11 @@ def on_page_markdown(markdown, page, config, files):
 
     Placeholder injection
     ---------------------
-    ``<!-- API_TABLE -->``         → submodule table for API index
-{% if include_examples %}    ``<!-- GALLERY -->``           → flat card grid of example notebooks
+    ``<!-- API_TABLE -->``            → submodule table for API index
+    ``<!-- SUBPAGES -->``             → linked list of the pages an index introduces
+{% if include_examples %}    ``<!-- GALLERY -->``              → flat card grid of example notebooks
+    ``<!-- GALLERY:section:name -->`` → card grid for one section of the gallery
+    ``<!-- COMPANION_NOTEBOOKS -->``  → cards for notebooks naming this page
 {% endif %}    """
     project_root = Path(__file__).parent.parent
     prefix = _site_root_prefix(page)
@@ -1641,6 +1851,10 @@ def on_page_markdown(markdown, page, config, files):
     if "<!-- API_TABLE -->" in markdown:
         table = _build_api_table_html(project_root, prefix)
         markdown = markdown.replace("<!-- API_TABLE -->", table)
+
+    # SUBPAGES placeholder
+    if "<!-- SUBPAGES -->" in markdown:
+        markdown = _replace_marker(markdown, "<!-- SUBPAGES -->", _build_subpages_list(config, page, files))
 {% if include_examples %}
     # EXAMPLES_FOR placeholders on generated API pages
     for match in re.finditer(r"<!-- EXAMPLES_FOR:([\w.]+) -->", markdown):
@@ -1656,6 +1870,13 @@ def on_page_markdown(markdown, page, config, files):
     )
     playground_base = f"https://marimo.app/{github_path}/blob/{git_ref}"
 
+    # GALLERY:section:<name> placeholders → one section's cards. Matched before
+    # the bare marker below; the two are distinct strings, so the order is for
+    # the reader, not the parser.
+    for match in _SECTION_GALLERY_RE.finditer(markdown):
+        section_html = _build_gallery_html(project_root, section=match.group(1))
+        markdown = _replace_marker(markdown, match.group(0), section_html)
+
     # GALLERY placeholder
     if "<!-- GALLERY -->" in markdown:
         gallery_html = _build_gallery_html(project_root)
@@ -1666,9 +1887,17 @@ def on_page_markdown(markdown, page, config, files):
     # through the same [View]/[Open in marimo] resolution as gallery cards.
     # Emitting resolved HTML directly would bypass those markdown-syntax
     # rewrites and ship unresolved links.
+    #
+    # The marker is optional. A notebook's `companion` is the whole declaration
+    # of the association; requiring the target page to opt in as well means a
+    # notebook can name a page that never shows it, and nothing anywhere says
+    # so. Appending when the marker is absent makes the notebook's declaration
+    # sufficient on its own, and the marker purely a placement override.
+    companion_html = _build_companion_cards_html(project_root, page.file.src_path)
     if "<!-- COMPANION_NOTEBOOKS -->" in markdown:
-        companion_html = _build_companion_cards_html(project_root, page.file.src_path)
-        markdown = markdown.replace("<!-- COMPANION_NOTEBOOKS -->", companion_html)
+        markdown = _replace_marker(markdown, "<!-- COMPANION_NOTEBOOKS -->", companion_html)
+    elif companion_html:
+        markdown = markdown.rstrip("\n") + "\n\n" + companion_html
 
     # Resolve [Open in marimo] placeholder URLs → full marimo.app playground URLs
     markdown = re.sub(

--- a/template/docs/pages/explanation/index.md.jinja
+++ b/template/docs/pages/explanation/index.md.jinja
@@ -4,4 +4,6 @@ Understanding-oriented discussion of how {{ project_name }} works and why it is
 built the way it is. Read these when you want context and background rather
 than instructions.
 
+<!-- SUBPAGES -->
+
 For what things do rather than why, see [Reference](../reference/index.md).

--- a/template/docs/pages/how-to/index.md.jinja
+++ b/template/docs/pages/how-to/index.md.jinja
@@ -4,5 +4,7 @@ Task-oriented recipes for getting a specific job done with {{ project_name }}.
 These assume you already know the basics and want to accomplish something
 concrete.
 
+<!-- SUBPAGES -->
+
 If you are still finding your feet, start with the
 [Tutorials](../tutorials/index.md).

--- a/template/docs/pages/reference/index.md.jinja
+++ b/template/docs/pages/reference/index.md.jinja
@@ -5,4 +5,6 @@ its behaviour, and its release history. Reference material is for looking
 things up, not for learning — it describes the machinery and stays out of your
 way.
 
+<!-- SUBPAGES -->
+
 For the reasoning behind the design, see [Explanation](../explanation/index.md).

--- a/template/docs/pages/tutorials/index.md.jinja
+++ b/template/docs/pages/tutorials/index.md.jinja
@@ -4,5 +4,7 @@ Learning-oriented guides that teach {{ project_name }} by walking you through
 hands-on steps. Start here if you are new: a tutorial's job is to give you a
 first success, not to cover every option.
 
+<!-- SUBPAGES -->
+
 Once you know your way around, the [How-to Guides](../how-to/index.md) show you
 how to solve specific problems.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3133,11 +3133,6 @@ def test_update_guidance_restores_local_owned_files(copie_session_default):
         assert wrong not in conflicts, f"the guidance still claims a conflicted file is untouched: {wrong!r}"
 
 
-# ---------------------------------------------------------------------------
-# Docs marker substitution: sectioned galleries, companions, subpage indexes
-# ---------------------------------------------------------------------------
-
-
 def _write_sectioned_notebook(examples_dir, stem, *, title, section="", category="how-to", companion=None):
     """Write a marimo notebook whose __gallery__ carries section/companion keys.
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,5 +1,6 @@
 """Tests for the copier template."""
 
+import logging
 import os
 import posixpath
 import re
@@ -1616,9 +1617,12 @@ def test_api_name_lookup_shared_with_notebook_usage(copie_session_default):
 
 
 class _FakeFile:
-    def __init__(self, src_path, dest_path):
+    def __init__(self, src_path, dest_path, abs_src_path=None):
         self.src_path = src_path
         self.dest_path = dest_path
+        # mkdocs' File exposes the on-disk source; the subpage index reads each
+        # sibling's own H1 and summary out of it.
+        self.abs_src_path = abs_src_path
 
 
 class _FakePage:
@@ -1991,6 +1995,7 @@ def _reset_gallery_caches(hooks):
     hooks._COMPANION_INDEX_CACHE = None
     hooks._API_NAME_LOOKUP_CACHE = None
     hooks._SUBMODULE_CACHE = None
+    hooks._GALLERY_PAGE_CACHE = None
 
 
 def test_declared_api_references_override_imports(copie_session_default):
@@ -3126,3 +3131,231 @@ def test_update_guidance_restores_local_owned_files(copie_session_default):
     )
     for wrong in ("Keeps local file intact", "local file is clean", "local file** unchanged"):
         assert wrong not in conflicts, f"the guidance still claims a conflicted file is untouched: {wrong!r}"
+
+
+# ---------------------------------------------------------------------------
+# Docs marker substitution: sectioned galleries, companions, subpage indexes
+# ---------------------------------------------------------------------------
+
+
+def _write_sectioned_notebook(examples_dir, stem, *, title, section="", category="how-to", companion=None):
+    """Write a marimo notebook whose __gallery__ carries section/companion keys.
+
+    Distinct from _write_notebook above, which takes a raw gallery body: these
+    tests care about specific keys, so they name them rather than spelling out
+    the literal each time.
+    """
+    examples_dir.mkdir(parents=True, exist_ok=True)
+    fields = [f'"title": {title!r}', f'"description": "Demo of {title}."', f'"category": {category!r}']
+    if section:
+        fields.append(f'"section": {section!r}')
+    if companion:
+        fields.append(f'"companion": {companion!r}')
+    body = ",\n    ".join(fields)
+    (examples_dir / f"{stem}.py").write_text(
+        f'"""Notebook."""\n\nimport marimo\n\n__generated_with = "0.9.0"\n__gallery__ = {{\n    {body},\n}}\napp = marimo.App()\n',
+        encoding="utf-8",
+    )
+
+
+def test_gallery_section_marker_renders_only_that_section(copie_session_default):
+    """`<!-- GALLERY:section:name -->` renders that section's cards and no others.
+
+    A gallery outgrows one page and splits into per-topic subpages, each asking
+    for its own slice. Only the bare `<!-- GALLERY -->` used to be understood,
+    so the sectioned form matched nothing, survived as a literal HTML comment,
+    and every subpage rendered zero cards while the build stayed green. yohou
+    shipped six such pages.
+    """
+    project_dir = copie_session_default.project_dir
+    examples = project_dir / "examples"
+    _write_sectioned_notebook(examples, "sec_alpha_one", title="Alpha One", section="alpha")
+    _write_sectioned_notebook(examples, "sec_alpha_two", title="Alpha Two", section="alpha")
+    _write_sectioned_notebook(examples, "sec_beta_one", title="Beta One", section="beta")
+
+    hooks = _load_hooks(project_dir, "gallery_section")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/examples/alpha.md", "pages/examples/alpha/index.html")
+    out = hooks.on_page_markdown("# Alpha\n\n<!-- GALLERY:section:alpha -->\n", page, {"repo_url": "https://x/y"}, None)
+
+    assert "<!-- GALLERY:section:alpha -->" not in out, "the sectioned marker was left in the page as a dead comment"
+    assert "Alpha One" in out and "Alpha Two" in out, "the section's own notebooks are missing from its page"
+    assert "Beta One" not in out, "a notebook from another section leaked into this section's page"
+
+
+def test_unknown_gallery_section_warns_instead_of_rendering_nothing(copie_session_default, caplog):
+    """A section naming no notebook warns, so --strict catches the typo.
+
+    This is the failure mode that hid the bug above: a marker that resolves to
+    nothing looks exactly like a page that never had one. Renaming a section and
+    missing a page silently empties it, so the miss has to be loud.
+    """
+    project_dir = copie_session_default.project_dir
+    _write_sectioned_notebook(project_dir / "examples", "sec_real", title="Real", section="real")
+
+    hooks = _load_hooks(project_dir, "gallery_section_unknown")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/examples/typo.md", "pages/examples/typo/index.html")
+    with caplog.at_level(logging.WARNING, logger="mkdocs.hooks"):
+        hooks.on_page_markdown("# T\n\n<!-- GALLERY:section:typoed -->\n", page, {"repo_url": "https://x/y"}, None)
+
+    assert "typoed" in caplog.text, "a gallery section matching no notebook rendered silently; --strict cannot catch it"
+
+
+def test_companion_cards_render_without_a_marker_on_the_page(copie_session_default):
+    """A notebook's `companion` is enough on its own to place it on that page.
+
+    The association used to need declaring twice: the notebook naming the page,
+    and the page carrying `<!-- COMPANION_NOTEBOOKS -->`. Miss the second and
+    the notebook points at a page that never shows it, with nothing reporting
+    it. Three sibling repos had 23 notebooks in exactly that state.
+    """
+    project_dir = copie_session_default.project_dir
+    _write_sectioned_notebook(
+        project_dir / "examples",
+        "companion_no_marker",
+        title="Unmarked Companion",
+        companion="pages/how-to/configure.md",
+    )
+
+    hooks = _load_hooks(project_dir, "companion_no_marker")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/how-to/configure.md", "pages/how-to/configure/index.html")
+    out = hooks.on_page_markdown("# Configure\n\nProse.\n", page, {"repo_url": "https://x/y"}, None)
+
+    assert "Unmarked Companion" in out, "a notebook naming this page as its companion is nowhere on it"
+
+
+def test_companion_cards_stay_inside_an_indented_marker(copie_session_default):
+    """A marker nested in an admonition keeps its whole replacement nested.
+
+    yohou wraps the marker in `!!! tip "Try it interactively"`. A plain
+    str.replace indents only the first line, so the heading stayed in the box
+    and the cards fell out at column 0 and closed it -- rendering a tip callout
+    whose entire body was a heading repeating its own title. The markdown looked
+    correct; only the built HTML showed it.
+    """
+    project_dir = copie_session_default.project_dir
+    _write_sectioned_notebook(
+        project_dir / "examples",
+        "companion_indented",
+        title="Indented Companion",
+        companion="pages/how-to/troubleshooting.md",
+    )
+
+    hooks = _load_hooks(project_dir, "companion_indented")
+    _reset_gallery_caches(hooks)
+
+    page = _FakePage("pages/how-to/troubleshooting.md", "pages/how-to/troubleshooting/index.html")
+    source = '# Troubleshooting\n\n!!! tip "Try it interactively"\n    <!-- COMPANION_NOTEBOOKS -->\n'
+    out = hooks.on_page_markdown(source, page, {"repo_url": "https://x/y"}, None)
+
+    assert "Indented Companion" in out, "the companion card vanished"
+    body = out.split('!!! tip "Try it interactively"\n', 1)[1]
+    for line in body.split("\n"):
+        if line.strip():
+            assert line.startswith("    "), (
+                f"line {line!r} escaped the admonition -- it renders as a sibling, not inside the callout"
+            )
+
+
+def test_index_page_lists_its_subpages(copie_session_default):
+    """`<!-- SUBPAGES -->` lists the pages an index introduces, in nav order.
+
+    An index is the page guaranteed to fall behind: adding a page elsewhere is
+    what makes it stale, and nothing fails when it does. Every generated index
+    used to describe its Diataxis quadrant and then name none of its own pages.
+    """
+    project_dir = copie_session_default.project_dir
+    docs = project_dir / "docs"
+    hooks = _load_hooks(project_dir, "subpages")
+
+    page = _FakePage("pages/how-to/index.md", "pages/how-to/index.html")
+    files = [
+        _FakeFile(
+            f"pages/how-to/{name}.md", f"pages/how-to/{name}/index.html", str(docs / "pages" / "how-to" / f"{name}.md")
+        )
+        for name in ("configure", "troubleshooting", "contribute")
+    ]
+    # A page from a different quadrant. mkdocs hands the hook every file in the
+    # site, so an index that does not filter by directory lists the whole docs
+    # tree under its own heading.
+    files.append(
+        _FakeFile(
+            "pages/tutorials/getting-started.md",
+            "pages/tutorials/getting-started/index.html",
+            str(docs / "pages" / "tutorials" / "getting-started.md"),
+        )
+    )
+    # Troubleshooting is deliberately the nav's only entry AND the last of the
+    # three by title ("Contributing to..." < "How to Configure..." <
+    # "Troubleshooting"). Asserting it leads therefore fails if nav order is
+    # ignored -- picking a page that sorts first alphabetically would pass
+    # either way and assert nothing.
+    config = {
+        "nav": [
+            {"How-to Guides": ["pages/how-to/index.md", {"Troubleshooting": "pages/how-to/troubleshooting.md"}]},
+        ]
+    }
+    out = hooks.on_page_markdown("# How-to\n\n<!-- SUBPAGES -->\n", page, config, files)
+
+    assert "<!-- SUBPAGES -->" not in out, "the marker was left in the page as a dead comment"
+    for name, title in (("configure", "Configure"), ("troubleshooting", "Troubleshoot"), ("contribute", "Contribut")):
+        assert f"({name}.md)" in out, f"the index does not link its own subpage {name}.md"
+        assert title in out, f"the index links {name}.md without naming it ({title!r} missing)"
+
+    assert out.index("(troubleshooting.md)") < out.index("(contribute.md)"), (
+        "subpages ignore the configured nav order; the index contradicts the sidebar beside it"
+    )
+    assert "getting-started" not in out, "the how-to index lists a tutorials page; it is not filtering by directory"
+
+
+def test_subpage_index_summarises_each_page_from_its_own_source(copie_session_default):
+    """Each listed subpage carries a summary read out of that page.
+
+    A hand-written index re-states every title and blurb, so it drifts from the
+    pages the moment one is edited. Reading both from the page itself means
+    there is no second copy to drift.
+    """
+    project_dir = copie_session_default.project_dir
+    docs_dir = project_dir / "docs" / "pages" / "subtest"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "frontmatter.md").write_text(
+        "---\ndescription: Summary from frontmatter.\n---\n\n# Frontmatter Page\n\nSome other prose.\n",
+        encoding="utf-8",
+    )
+    (docs_dir / "prose.md").write_text(
+        "# Prose Page\n\n!!! note\n    An admonition, not the summary.\n\nThe first real paragraph.\n",
+        encoding="utf-8",
+    )
+
+    hooks = _load_hooks(project_dir, "subpages_desc")
+    page = _FakePage("pages/subtest/index.md", "pages/subtest/index.html")
+    files = [
+        _FakeFile(f"pages/subtest/{n}.md", f"pages/subtest/{n}/index.html", str(docs_dir / f"{n}.md"))
+        for n in ("frontmatter", "prose")
+    ]
+    out = hooks.on_page_markdown("# Sub\n\n<!-- SUBPAGES -->\n", page, {}, files)
+
+    assert "Summary from frontmatter." in out, "a frontmatter description was not used as the summary"
+    assert "The first real paragraph." in out, "the first prose paragraph was not used as the summary"
+    assert "An admonition, not the summary." not in out, "an admonition was mistaken for the page's opening prose"
+
+
+def test_generated_index_pages_introduce_their_subpages(copie_session_default):
+    """Every seeded Diataxis index asks for its subpage list.
+
+    Pinning the seed, not just the mechanism: yohou-nixtla's how-to index was
+    the template's own index verbatim, so a template that ships the marker on
+    none of its indexes leaves every generated project's index bare.
+    """
+    pages = copie_session_default.project_dir / "docs" / "pages"
+    for quadrant in ("tutorials", "how-to", "reference", "explanation"):
+        index = pages / quadrant / "index.md"
+        assert index.exists(), f"{quadrant} has no index page"
+        assert "<!-- SUBPAGES -->" in index.read_text(encoding="utf-8"), (
+            f"the {quadrant} index describes its quadrant but never lists its own pages"
+        )


### PR DESCRIPTION
## Summary

Four docs markers that resolved to nothing while `mkdocs build --strict` stayed green. They share one failure mode: **a marker that renders nothing looks exactly like a page that never had one**, so none of them ever failed a build. Found while auditing why yohou's how-to pages carry an empty callout.

## The bugs

### 1. `<!-- GALLERY:section:name -->` was never matched

Only the bare `<!-- GALLERY -->` was understood. A gallery that outgrows one page splits into per-topic subpages, each asking for its slice — the sectioned marker matched nothing and survived as a literal HTML comment. `_get_gallery_items` parsed `section` out of `__gallery__` and then threw it away.

Measured against yohou's real 79 notebooks: **all six example subpages rendered 0 cards.** Now:

| section | cards |
|---|---|
| data-features | 19 |
| evaluation-search | 12 |
| forecasting-models | 13 |
| getting-started | 18 |
| panel-data | 9 |
| visualization | 8 |

### 2. An indented marker lost everything after its first line

`str.replace` indents only the first line of a multi-line replacement; the rest lands at column 0 and falls out of the enclosing block. Inside yohou's `!!! tip "Try it interactively"` the rendered HTML was:

```html
<div class="admonition tip">
<p class="admonition-title">Try it interactively</p>
<h2>Try it interactively</h2>   <!-- the entire body -->
</div>
```

A tip box whose only content is a heading repeating its own title, with the cards escaping below it. The markdown looks correct; only the built HTML shows it. `_replace_marker` now re-indents to the marker's column.

### 3. A notebook's `companion` was not enough to place it

The association had to be declared twice — the notebook naming the page, *and* the page carrying `<!-- COMPANION_NOTEBOOKS -->`. Miss the second and the notebook points at a page that never displays it, with nothing reporting it:

| repo | notebooks declaring a companion | pages carrying a marker |
|---|---|---|
| sklearn-wrap | 9 | **0** |
| sklearn-optuna | 9 | **0** |
| yohou-optuna | 5 | **0** |

**23 dead declarations.** The notebook's declaration is now sufficient on its own; the marker becomes a placement override. This restores cards to 21 target pages across the three repos.

### 4. Index pages never named their own subpages

Every seeded Diataxis index described its quadrant and stopped. yohou hand-wrote rich indexes; yohou-nixtla's how-to index is the template's seed **verbatim**, which is exactly why it introduces nothing. An index is the page guaranteed to fall behind — adding a page elsewhere is what makes it stale, and nothing fails when it does.

`<!-- SUBPAGES -->` lists direct children in nav order, reading each title (H1) and summary (frontmatter `description`, else first prose paragraph) from the page itself, so there is no second copy to drift.

## Not silent any more

Unresolved markers now log under the `mkdocs` logger, so `--strict` fails on the next one rather than quietly emptying a page. That warning is what would have caught all four.

## Tests

7 new tests, **each mutation-verified** — every one was confirmed to fail against the unfixed code before being kept:

| mutation | test that caught it |
|---|---|
| drop `GALLERY:section` handling | `test_gallery_section_marker_renders_only_that_section` |
| remove the unknown-section warning | `test_unknown_gallery_section_warns_instead_of_rendering_nothing` |
| require the marker again | `test_companion_cards_render_without_a_marker_on_the_page` |
| naked `str.replace` | `test_companion_cards_stay_inside_an_indented_marker` |
| `_nav_order` returns nothing | `test_index_page_lists_its_subpages` |
| ignore frontmatter `description` | `test_subpage_index_summarises_each_page_from_its_own_source` |
| treat an admonition as opening prose | `test_subpage_index_summarises_each_page_from_its_own_source` |
| recurse into nested dirs | `test_index_page_lists_its_subpages` |
| drop `<!-- SUBPAGES -->` from the seed | `test_generated_index_pages_introduce_their_subpages` |

One assertion was found **vacuous during that pass and rewritten**: the nav-order check originally used `configure`, which sorts first alphabetically anyway, so it passed with nav ordering entirely removed. It now pins `troubleshooting` — the nav's only entry and last by title — so it genuinely fails when nav order is ignored.

296 fast tests pass; pre-commit clean.
