### PR TITLE
feat(template): make a silently-empty page fail the build

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -192,6 +192,36 @@ jobs:
 
       - name: Run docstring tests
         run: nox -s test_docstrings
+
+
+  check_docs:
+    name: Docs build (strict)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install nox
+        run: uv tool install nox
+
+      - name: Set up Python
+        run: uv python install {{ min_python_version }}
+
+      # docs/hooks.py warns when a marker resolves to nothing. Nothing ran with
+      # warnings fatal, so those warnings went to a log nobody reads and pages
+      # kept silently shipping blank space where a card grid or an index should
+      # be. This is the job that makes them count.
+      - name: Build docs with warnings fatal
+        run: nox -s check_docs
 {% if include_examples %}
 
   examples:

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -949,6 +949,41 @@ def _build_api_examples_html(project_root, qualified_name):
 # ---------------------------------------------------------------------------
 
 
+# Every name this file substitutes. A comment *opening* with one of these is a
+# marker; if one survives to the end of on_page_markdown, it was misspelled.
+# Matched without a word boundary so `<!-- GALLERY:quickstart -->` and
+# `<!-- SUBPAGES_FOO -->` are both caught, not just the separator-delimited ones.
+#
+# The net is deliberately the marker namespace and nothing else: it cannot catch
+# a typo that mangles the name itself (`<!-- GALLRY -->`), because widening it to
+# every upper-case comment would flag ordinary `<!-- TODO -->`s. The realistic
+# mistake is right name, wrong syntax -- which is exactly what shipped.
+_MARKER_NAMES = ("API_TABLE", "SUBPAGES", "GALLERY", "COMPANION_NOTEBOOKS", "EXAMPLES_FOR")
+_UNHANDLED_MARKER_RE = re.compile(r"<!--\s*(?:" + "|".join(_MARKER_NAMES) + r")[^>]*-->")
+
+
+def _warn_on_unhandled_markers(markdown, src_path):
+    """Warn about a marker that no substitution above recognised.
+
+    The per-marker warnings only fire for a *well-formed* marker that resolves to
+    nothing -- an unknown gallery section, an index with no children. A
+    misspelled one is worse and was completely silent: `<!-- GALLERY:quickstart
+    -->` matches neither the bare nor the sectioned pattern, so nothing claimed
+    it, nothing substituted it, and it shipped to the page as a raw comment that
+    renders as blank space. It cannot even be reported by the code that would
+    have handled it, because that code never sees it. Catching the leftovers is
+    the only place a typo in the marker namespace can be noticed at all.
+    """
+    for match in _UNHANDLED_MARKER_RE.finditer(markdown):
+        log.warning(
+            "%s: unrecognised marker %s -- it renders as blank space. "
+            "Known markers: <!-- API_TABLE -->, <!-- SUBPAGES -->, <!-- GALLERY -->, "
+            "<!-- GALLERY:section:NAME -->, <!-- COMPANION_NOTEBOOKS -->, <!-- EXAMPLES_FOR:NAME -->.",
+            src_path,
+            match.group(0),
+        )
+
+
 def _replace_marker(markdown, marker, replacement):
     """Replace ``marker`` with ``replacement``, re-indented to the marker's column.
 
@@ -1922,6 +1957,8 @@ def on_page_markdown(markdown, page, config, files):
     # Strip EXAMPLES_FOR placeholders when examples are disabled
     markdown = re.sub(r"<!-- EXAMPLES_FOR:[\w.]+ -->\n?", "", markdown)
 {% endif %}
+    _warn_on_unhandled_markers(markdown, page.file.src_path)
+
     return markdown
 
 

--- a/template/docs/pages/reference/changelog.md.jinja
+++ b/template/docs/pages/reference/changelog.md.jinja
@@ -1,1 +1,5 @@
+---
+description: Release history for every published version, newest first.
+---
+
 --8<-- "CHANGELOG.md"

--- a/template/noxfile.py.jinja
+++ b/template/noxfile.py.jinja
@@ -293,6 +293,42 @@ def build_docs(session: nox.Session) -> None:
 
 
 @nox.session(venv_backend="uv")
+def check_docs(session: nox.Session) -> None:
+    """Build the docs with warnings fatal, without executing the notebooks.
+
+    docs/hooks.py warns when a marker resolves to nothing, because a placeholder
+    that renders nothing looks exactly like a page that never had one -- the
+    warning is the only signal that a page silently lost its content. That signal
+    is worthless unless something fails on it, which is what this session is for.
+
+    A full build is too slow to run on every PR: exporting the notebooks executes
+    every one of them and dominates the time. MKDOCS_SKIP_NOTEBOOKS skips only the
+    export -- the gallery still parses every notebook's source, so sections,
+    companions and cards resolve exactly as they do in a real build, which is what
+    the markers depend on. build_docs remains the real, notebook-executing build.
+    """
+    session.run_install(
+        "uv",
+        "sync",
+        "--no-default-groups",
+        "--group",
+        "docs",
+{% if include_examples %}        "--group",
+        "examples",
+{% endif %}        env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
+    )
+
+    session.run(
+        "mkdocs",
+        "build",
+        "--clean",
+        "--strict",
+        external=True,
+        env={"MKDOCS_SKIP_NOTEBOOKS": "1"},
+    )
+
+
+@nox.session(venv_backend="uv")
 def serve_docs(session: nox.Session) -> None:
     """Run a development server for working on documentation."""
     # Install dependencies

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3229,6 +3229,34 @@ def _write_sectioned_notebook(examples_dir, stem, *, title, section="", category
     )
 
 
+def test_misspelled_marker_warns_instead_of_shipping_blank_space(copie_session_default):
+    """A marker with the right name and the wrong syntax is reported.
+
+    The per-marker warnings only fire for a *well-formed* marker that resolves to
+    nothing. A misspelled one was worse and completely silent: yohou shipped
+    `<!-- GALLERY:quickstart -->`, which matches neither the bare nor the
+    sectioned pattern, so nothing claimed it, nothing substituted it, and it
+    reached the page as a raw comment rendering as blank space. The code that
+    would have reported it never saw it.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "unhandled_markers")
+    _reset_gallery_caches(hooks)
+    page = _FakePage("pages/examples/x.md", "pages/examples/x/index.html")
+
+    for marker in ("<!-- GALLERY:quickstart -->", "<!-- SUBPAGES_FOR:x -->", "<!-- EXAMPLES_FOR -->"):
+        with caplog_at_warning() as records:
+            out = hooks.on_page_markdown(f"# X\n\n{marker}\n", page, {"repo_url": "https://x/y"}, [])
+        assert records, f"{marker} shipped silently; it renders as blank space and nothing says so"
+        assert marker in out, f"{marker} was consumed without being understood"
+
+    # An ordinary comment is not in the marker namespace and must stay quiet, or
+    # the warning becomes noise and gets ignored -- which is how this started.
+    with caplog_at_warning() as records:
+        hooks.on_page_markdown("# X\n\n<!-- prettier-ignore -->\n", page, {"repo_url": "https://x/y"}, [])
+    assert not records, "an ordinary HTML comment was flagged as a broken marker"
+
+
 def test_gallery_section_marker_renders_only_that_section(copie_session_default):
     """`<!-- GALLERY:section:name -->` renders that section's cards and no others.
 
@@ -3448,6 +3476,33 @@ def test_subpage_index_summarises_each_page_from_its_own_source(copie_session_de
     assert "An admonition, not the summary." not in out, "an admonition was mistaken for the page's opening prose"
 
 
+def test_docs_warnings_are_fatal_somewhere_automated(copie_session_default):
+    """Something that runs on every PR must build the docs with warnings fatal.
+
+    Every marker warning this template emits was decorative until this existed.
+    Nothing ran `mkdocs build --strict`: not CI, not nox's default sessions, and
+    RTD sets no `fail_on_warning`. So a page that silently lost its whole card
+    grid produced a warning in a log nobody reads, and shipped. A warning nothing
+    fails on is not a signal.
+    """
+    project_dir = copie_session_default.project_dir
+
+    noxfile = (project_dir / "noxfile.py").read_text(encoding="utf-8")
+    assert "def check_docs" in noxfile, "no nox session builds the docs with warnings fatal"
+    session = noxfile[noxfile.index("def check_docs") :]
+    session = session[: session.find("@nox.session", 1) if session.find("@nox.session", 1) > 0 else len(session)]
+    assert '"--strict"' in session, "check_docs builds the docs without --strict, so warnings stay advisory"
+    assert "MKDOCS_SKIP_NOTEBOOKS" in session, (
+        "check_docs executes every notebook; that is too slow to run per-PR and it will be dropped from CI"
+    )
+
+    workflow = project_dir / ".github" / "workflows" / "tests.yml"
+    assert workflow.is_file(), "no tests workflow"
+    assert "nox -s check_docs" in workflow.read_text(encoding="utf-8"), (
+        "the strict docs build is never run by CI, so its warnings gate nothing"
+    )
+
+
 def test_seeded_reference_index_lists_the_headingless_changelog(copie_session_default):
     """The template's own seeded pages must survive their own SUBPAGES marker.
 
@@ -3489,6 +3544,32 @@ def test_seeded_reference_index_lists_the_headingless_changelog(copie_session_de
 
     assert "(changelog.md)" in out, "the seeded reference index drops its own changelog"
     assert not records, f"the seeded docs warn on their own marker, which fails --strict: {records}"
+
+
+def test_headingless_changelog_still_gets_a_summary(copie_session_default):
+    """The changelog row carries a summary like every other row.
+
+    Its title comes from the nav (it has no H1 of its own until snippets expand)
+    and its summary has nowhere to come from -- a bare include has no prose to
+    derive one from. So it rendered as a bare `- [Changelog](changelog.md)`
+    beside siblings that had one. Projects fixed that locally by giving the page
+    its own H1, which drifts: changelog.md is Tier 1. Shipping the frontmatter in
+    the template is the version that survives an update.
+    """
+    project_dir = copie_session_default.project_dir
+    changelog = project_dir / "docs" / "pages" / "reference" / "changelog.md"
+    text = changelog.read_text(encoding="utf-8")
+
+    assert "description:" in text, "the seeded changelog has no description; its index row renders bare"
+    assert '--8<-- "CHANGELOG.md"' in text, "the changelog no longer includes the real CHANGELOG"
+    assert not re.search(r"^# ", text, re.MULTILINE), (
+        "the seeded changelog grew its own H1; it would duplicate the one inside CHANGELOG.md"
+    )
+
+    hooks = _load_hooks(project_dir, "changelog_summary")
+    title, description = hooks._page_title_and_description(str(changelog))
+    assert title is None, "a bare include has no H1 of its own; the nav supplies the title"
+    assert description, "the changelog frontmatter yields no summary"
 
 
 def test_generated_index_pages_introduce_their_subpages(copie_session_default):


### PR DESCRIPTION
## Summary

v0.21.0 added warnings for markers that resolve to nothing, on the theory that **a placeholder rendering nothing is indistinguishable from a page that never had one**. Those warnings were decorative. Three gaps, all found by the v0.21.1 fan-out — none by me.

## 1. Nothing ran `--strict`, so no warning ever failed anything

Checked across the template and all seven repos:

| | runs `mkdocs build --strict`? |
|---|---|
| CI (`tests.yml`) | never builds docs |
| `nox` default sessions | `build_docs` builds without `--strict` |
| Read the Docs | no `fail_on_warning` |

So every marker warning went to a log nobody reads. A page that silently lost its entire card grid still shipped, still green. **A warning nothing fails on is not a signal** — which also means my v0.21.0 claim that unresolved markers "now fail `--strict`" was simply untrue, and my claim that v0.21.0 "broke `--strict` for every generated project" was overstated: it failed only when someone ran `--strict` by hand, as the agents did.

`nox -s check_docs` builds with warnings fatal and runs on every PR. It skips only the notebook **export** — the gallery still parses every notebook's source, so sections, companions and cards resolve exactly as in a real build. It finishes in **0.58s** instead of executing 79 notebooks. `build_docs` remains the real, notebook-executing build.

## 2. A misspelled marker was invisible even to the warnings

yohou shipped `<!-- GALLERY:quickstart -->`. It matches neither the bare nor the sectioned pattern, so nothing claimed it, nothing substituted it, and it reached the page as a raw comment rendering as blank space. The code that would have reported it **never saw it**:

```
<!-- GALLERY:quickstart -->      cards=0  marker-left-in-page=True   warnings=0   ← invisible
<!-- GALLERY:section:nosuch -->  cards=0  marker-left-in-page=False  warnings=1   ← caught
```

Leftovers in the marker namespace are now reported. An ordinary `<!-- prettier-ignore -->` still passes — if the warning becomes noise it gets ignored, which is how this started. It deliberately cannot catch a typo that mangles the name itself (`<!-- GALLRY -->`); catching those means flagging every upper-case comment. The realistic mistake is **right name, wrong syntax**, which is exactly what shipped.

Also worth recording: yohou had a **seventh** dead marker nobody had counted — `<!-- GALLERY:section:data-catalog -->`, naming a section no notebook has ever declared, dead since PR #34.

## 3. The changelog row lost its summary

`reference/changelog.md` is a bare `--8<-- "CHANGELOG.md"`: no prose to derive a summary from, so it rendered as `- [Changelog](changelog.md)` beside siblings that had one. Projects fixed that locally by giving the page its own H1 — which drifts, `changelog.md` being Tier 1. The frontmatter now ships in the template, where an update keeps it. Result: `- [Changelog](changelog.md): Release history for every published version, newest first.`

## Verified end to end, not asserted

On a freshly generated project:

| state | `nox -s check_docs` |
|---|---|
| clean | **green**, 0.58s |
| `<!-- GALLERY:quickstart -->` (the exact yohou bug) | **RED** — *"unrecognised marker … it renders as blank space"* |
| `<!-- GALLERY:section:nosuchsection -->` | **RED** — *"matches no notebook"* |
| clean again | **green** |

This two-way control is the method kedro-azureml-pipeline's agent used on the logo fix: "nothing happened" and "the check is blind" look identical, so you have to make it fail on purpose. Every repo already builds `--strict`-clean, so the new job should land green fleet-wide.

## Tests

Each was confirmed to fail against v0.21.1 before being kept:

| mutation | test |
|---|---|
| remove the catch-all validation | `test_misspelled_marker_warns_instead_of_shipping_blank_space` |
| drop `--strict` from `check_docs` | `test_docs_warnings_are_fatal_somewhere_automated` |
| remove the CI job that runs it | `test_docs_warnings_are_fatal_somewhere_automated` |
| remove the changelog description | `test_headingless_changelog_still_gets_a_summary` |

302 fast tests pass; pre-commit clean.
