### PR TITLE
feat(template)!: make Examples a top-level section and lead with the notebook

### DIFF
--- a/template/.claude/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.claude/skills/update-from-template/references/conflict-resolution.md
@@ -156,7 +156,7 @@ nav:
   - Home: index.md
   - Tutorials:
     - Getting Started: pages/tutorials/getting-started.md
-    - Examples: pages/tutorials/examples.md  # conditional
+    - Examples: pages/examples/index.md  # conditional
   - How-to Guides:
     - Configure: pages/how-to/configure.md
     - Troubleshooting: pages/how-to/troubleshooting.md

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -116,7 +116,7 @@ docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
 docs/pages/how-to/index.md             # template ships a skeleton, but a
 docs/pages/reference/index.md          # project's own landing page is better
 docs/pages/explanation/index.md        # and must never be overwritten
-docs/pages/tutorials/examples.md    # conditional: include_examples
+docs/pages/examples/index.md        # conditional: include_examples
 docs/examples/**                   # conditional: include_examples
 ```
 

--- a/template/.github/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.github/skills/update-from-template/references/conflict-resolution.md
@@ -156,7 +156,7 @@ nav:
   - Home: index.md
   - Tutorials:
     - Getting Started: pages/tutorials/getting-started.md
-    - Examples: pages/tutorials/examples.md  # conditional
+    - Examples: pages/examples/index.md  # conditional
   - How-to Guides:
     - Configure: pages/how-to/configure.md
     - Troubleshooting: pages/how-to/troubleshooting.md

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -116,7 +116,7 @@ docs/pages/tutorials/index.md          # Diataxis quadrant landing pages: the
 docs/pages/how-to/index.md             # template ships a skeleton, but a
 docs/pages/reference/index.md          # project's own landing page is better
 docs/pages/explanation/index.md        # and must never be overwritten
-docs/pages/tutorials/examples.md    # conditional: include_examples
+docs/pages/examples/index.md        # conditional: include_examples
 docs/examples/**                   # conditional: include_examples
 ```
 

--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -38,7 +38,7 @@
 
     Explore interactive example notebooks.
 
-    [Examples](pages/tutorials/examples.md)
+    [Examples](pages/examples/index.md)
 {% endif %}
 
 </div>
@@ -50,7 +50,7 @@
 Install and run your first example.
 
 {% if include_examples %}
-### [Examples](pages/tutorials/examples.md)
+### [Examples](pages/examples/index.md)
 
 Interactive notebooks demonstrating {{ project_name }} in practice.
 {% endif %}

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -576,7 +576,7 @@ Run the example test suite to verify your notebook passes:
     uv run pytest tests/test_examples.py -m example
     ```
 
-Add a link to your example in `docs/pages/tutorials/examples.md`:
+Add a link to your example in `docs/pages/examples/index.md`:
 
 ```markdown
 - [Example Name](../examples/<name>/) - Brief description

--- a/template/docs/pages/tutorials/getting-started.md.jinja
+++ b/template/docs/pages/tutorials/getting-started.md.jinja
@@ -1,7 +1,9 @@
 # Getting Started
 
 In this tutorial, we will install {{ project_name }} and run a first example.
-
+{% if include_examples %}
+<!-- COMPANION_NOTEBOOKS -->
+{% endif %}
 ## Installation
 
 Choose your preferred package manager:
@@ -48,31 +50,9 @@ result = hello("World")
 print(result)  # Output: Hello, World!
 ```
 
-{% if include_examples %}
-## Try Interactive Examples
-
-For hands-on learning with interactive notebooks, see the [Examples](examples.md) page.
-
-Run locally:
-
-=== "just"
-
-    ```bash
-    just example
-    ```
-
-=== "uv run"
-
-    ```bash
-    uv run marimo edit examples/hello.py
-    ```
-{% endif %}
 ## Next Steps
 
 - **Learn the concepts**: Read [Concepts](../explanation/concepts.md) to understand the design
-{% if include_examples %}- **Explore examples**: Check out the [Examples](examples.md) for interactive notebooks
+{% if include_examples %}- **Explore examples**: Check out the [Examples](../examples/index.md) for interactive notebooks
 {% endif %}- **Dive into the API**: Browse the [API Reference](../reference/api.md) for detailed documentation
 - **Get help**: Visit [GitHub Discussions](https://github.com/{{ github_username }}/{{ project_slug }}/discussions) or [open an issue](https://github.com/{{ github_username }}/{{ project_slug }}/issues)
-
-{% if include_examples %}<!-- COMPANION_NOTEBOOKS -->
-{% endif %}

--- a/template/docs/pages/{% if include_examples %}examples{% endif %}/index.md.jinja
+++ b/template/docs/pages/{% if include_examples %}examples{% endif %}/index.md.jinja
@@ -1,6 +1,7 @@
-{% if include_examples %}# Examples
+# Examples
 
-Interactive notebooks grouped by purpose: **Tutorials** walk through a topic step-by-step, while **How-to Guides** solve a specific task.
+Interactive notebooks you can read, run, or edit in the browser. **Tutorials**
+walk through a topic step-by-step, while **How-to Guides** solve a specific task.
 
 <!-- GALLERY -->
 
@@ -18,4 +19,3 @@ python examples/hello.py
 
 - Browse the [API Reference](../reference/api.md) for detailed documentation
 - Check the [Concepts](../explanation/concepts.md) to understand core ideas
-{% endif -%}

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -155,13 +155,14 @@ nav:
   - Tutorials:
     - pages/tutorials/index.md
     - Getting Started: pages/tutorials/getting-started.md
-{% if include_examples %}    - Examples: pages/tutorials/examples.md
-{% endif %}  - How-to Guides:
+  - How-to Guides:
     - pages/how-to/index.md
     - Configuration: pages/how-to/configure.md
     - Troubleshooting: pages/how-to/troubleshooting.md
     - Contributing: pages/how-to/contribute.md
-  - Reference:
+{% if include_examples %}  - Examples:
+    - pages/examples/index.md
+{% endif %}  - Reference:
     - pages/reference/index.md
     - API: pages/reference/api.md
     - Changelog: pages/reference/changelog.md

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -322,7 +322,7 @@ class TestExamplesPage:
         result = copie.copy(extra_answers={"include_examples": True})
         assert result.exit_code == 0
 
-        examples_page = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+        examples_page = result.project_dir / "docs" / "pages" / "examples" / "index.md"
         assert examples_page.is_file()
 
     def test_examples_page_not_exists_when_disabled(self, copie):
@@ -330,7 +330,7 @@ class TestExamplesPage:
         result = copie.copy(extra_answers={"include_examples": False})
         assert result.exit_code == 0
 
-        examples_page = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+        examples_page = result.project_dir / "docs" / "pages" / "examples" / "index.md"
         assert not examples_page.exists()
 
     def test_examples_page_references_notebooks(self, copie):
@@ -338,7 +338,7 @@ class TestExamplesPage:
         result = copie.copy(extra_answers={"include_examples": True})
         assert result.exit_code == 0
 
-        examples_page = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+        examples_page = result.project_dir / "docs" / "pages" / "examples" / "index.md"
         content = examples_page.read_text(encoding="utf-8")
 
         # Should reference examples or notebooks
@@ -352,7 +352,7 @@ class TestExamplesPage:
         result = copie.copy(extra_answers={"include_examples": True})
         assert result.exit_code == 0
 
-        examples_page = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+        examples_page = result.project_dir / "docs" / "pages" / "examples" / "index.md"
         assert examples_page.is_file()
 
         content = examples_page.read_text(encoding="utf-8")
@@ -368,7 +368,7 @@ class TestExamplesPage:
         result = copie.copy(extra_answers={"include_examples": True})
         assert result.exit_code == 0
 
-        examples_page = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+        examples_page = result.project_dir / "docs" / "pages" / "examples" / "index.md"
         content = examples_page.read_text(encoding="utf-8")
 
         assert "Tutorials" in content

--- a/tests/test_propagated_features.py
+++ b/tests/test_propagated_features.py
@@ -205,7 +205,7 @@ class TestGallerySystem:
     def test_examples_page_has_gallery_placeholder(self, copie):
         """Test that examples.md uses the GALLERY placeholder."""
         result = copie.copy(extra_answers={"include_examples": True})
-        content = (result.project_dir / "docs" / "pages" / "tutorials" / "examples.md").read_text()
+        content = (result.project_dir / "docs" / "pages" / "examples" / "index.md").read_text()
         assert "<!-- GALLERY -->" in content
 
     def test_hello_notebook_has_gallery_metadata(self, copie):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -523,15 +523,15 @@ def test_examples_directory_when_enabled(copie):
     assert "-n auto" in justfile_content
 
     # Check examples.md exists and uses gallery placeholder
-    examples_md = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
-    assert examples_md.is_file(), "docs/pages/tutorials/examples.md not created"
+    examples_md = result.project_dir / "docs" / "pages" / "examples" / "index.md"
+    assert examples_md.is_file(), "docs/pages/examples/index.md not created"
     examples_content = examples_md.read_text(encoding="utf-8")
     assert "<!-- GALLERY -->" in examples_content
     assert "## Running Examples Locally" in examples_content
 
     # Check mkdocs.yml includes examples in nav and has exclude_docs
     mkdocs_content = (result.project_dir / "mkdocs.yml").read_text(encoding="utf-8")
-    assert "Examples: pages/tutorials/examples.md" in mkdocs_content
+    assert "pages/examples/index.md" in mkdocs_content
     # Check for exclude_docs with CLAUDE.md files
     assert "exclude_docs:" in mkdocs_content
     assert "examples/**/CLAUDE.md" in mkdocs_content
@@ -593,16 +593,16 @@ def test_examples_directory_when_disabled(copie):
     assert len(example_command_lines) == 0, "example command should not exist"
 
     # Check examples.md doesn't exist or is empty
-    examples_md = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+    examples_md = result.project_dir / "docs" / "pages" / "examples" / "index.md"
     if examples_md.exists():
         content = examples_md.read_text(encoding="utf-8").strip()
         assert content == "", (
-            f"docs/pages/tutorials/examples.md should be empty when examples are disabled, but contains: {content[:100]}"
+            f"docs/pages/examples/index.md should not exist when examples are disabled, but contains: {content[:100]}"
         )
 
     # Check mkdocs.yml doesn't include examples in nav
     mkdocs_content = (result.project_dir / "mkdocs.yml").read_text(encoding="utf-8")
-    assert "Examples: tutorials/examples.md" not in mkdocs_content
+    assert "pages/examples/index.md" not in mkdocs_content
 
     # Check GitHub workflow doesn't include examples job
     tests_workflow = result.project_dir / ".github" / "workflows" / "tests.yml"
@@ -855,7 +855,7 @@ def test_three_tier_documentation_system(copie):
     assert result.exit_code == 0
 
     # Tier 1: Verify embedded marimo setup in examples.md
-    examples_md = result.project_dir / "docs" / "pages" / "tutorials" / "examples.md"
+    examples_md = result.project_dir / "docs" / "pages" / "examples" / "index.md"
     examples_content = examples_md.read_text(encoding="utf-8")
     # Check for marimo-embed directive with inline code
     has_marimo = "/// marimo-embed" in examples_content and "@app.cell" in examples_content
@@ -3227,6 +3227,62 @@ def _write_sectioned_notebook(examples_dir, stem, *, title, section="", category
         f'"""Notebook."""\n\nimport marimo\n\n__generated_with = "0.9.0"\n__gallery__ = {{\n    {body},\n}}\napp = marimo.App()\n',
         encoding="utf-8",
     )
+
+
+def test_examples_are_a_top_level_section(copie_session_default):
+    """Examples is its own nav section, not a page filed under Tutorials.
+
+    A gallery is not a tutorial: it holds how-tos too, it is browsed rather than
+    read in order, and it grows until it needs subpages of its own. Filing it
+    under Tutorials caps it at one page and hides it from anyone who is past the
+    tutorials -- which is most of the people who want a runnable example.
+    """
+    project_dir = copie_session_default.project_dir
+
+    assert (project_dir / "docs" / "pages" / "examples" / "index.md").is_file(), (
+        "the examples gallery is not at pages/examples/index.md"
+    )
+    assert not (project_dir / "docs" / "pages" / "tutorials" / "examples.md").exists(), (
+        "the gallery is still filed under tutorials"
+    )
+
+    import yaml
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_multi_constructor("!", lambda loader, suffix, node: None)
+    nav = yaml.load((project_dir / "mkdocs.yml").read_text(encoding="utf-8"), Loader=_Loader)["nav"]
+
+    top_level = [key for entry in nav if isinstance(entry, dict) for key in entry]
+    assert "Examples" in top_level, f"Examples is not a top-level nav section; top level is {top_level}"
+
+    # Nothing may still point at the old path: a nav entry for a file that does
+    # not exist is a build error, but a *link* to one is a silent 404.
+    stale = [
+        p for p in (project_dir / "docs").rglob("*.md") if "tutorials/examples.md" in p.read_text(encoding="utf-8")
+    ]
+    assert not stale, f"these pages still link the old gallery path: {[str(p) for p in stale]}"
+
+
+def test_companion_cards_are_offered_before_the_page_body(copie_session_default):
+    """The seeded tutorial offers its notebook near the top, not after the footer.
+
+    A reader decides whether to run the notebook instead of reading, so the offer
+    has to arrive before the thing it is an alternative to. The marker used to sit
+    at the very end, below "Next Steps" and "Get help" -- past the point anyone
+    who wanted it was still reading.
+    """
+    page = copie_session_default.project_dir / "docs" / "pages" / "tutorials" / "getting-started.md"
+    text = page.read_text(encoding="utf-8")
+    assert "<!-- COMPANION_NOTEBOOKS -->" in text, "the seeded tutorial offers no companion notebook"
+
+    marker_at = text.index("<!-- COMPANION_NOTEBOOKS -->")
+    body_at = text.index("## Installation")
+    assert marker_at < body_at, "the companion offer comes after the page body instead of before it"
+
+    tail = text[text.index("## Next Steps") :] if "## Next Steps" in text else ""
+    assert "<!-- COMPANION_NOTEBOOKS -->" not in tail, "the companion offer is still stranded in the footer"
 
 
 def test_misspelled_marker_warns_instead_of_shipping_blank_space(copie_session_default):


### PR DESCRIPTION
## Summary

Two changes to match how **yohou** actually organises its docs — the shape the other projects were meant to have, and the one you pointed at.

## 1. Examples is a top-level nav section

It was a page filed under Tutorials (`pages/tutorials/examples.md`). A gallery isn't a tutorial: it holds how-tos too, it's browsed rather than read in order, and it grows until it needs subpages of its own — yohou's has **six**, plus a quickstart. Filing it under Tutorials caps it at one page and hides it from everyone past the tutorials, which is most of the people who want a runnable example.

yohou already does it right — `Examples` sits between How-to Guides and Explanation with `pages/examples/index.md` and seven subpages. The template now matches:

```yaml
  - How-to Guides: …
  - Examples:
    - pages/examples/index.md
  - Reference: …
```

Every link that pointed at the old path moved with it (`docs/index.md`, `getting-started.md` ×2, `contribute.md`, and both skill references). A nav entry for a missing file is a build error; a **link** to one is a silent 404 — so the test asserts no page still references the old path, rather than trusting the grep I did.

## 2. The notebook is offered before the page body

The companion marker sat at the very **end** of `getting-started.md`, below "Next Steps" and "Get help". A reader decides whether to run the notebook *instead of* reading the page, so the offer has to arrive before the thing it's an alternative to. It now leads the page, as it does on all 46 of yohou's.

Rendered heading order on a generated project:

```
1. Getting Started
2. Try it interactively   ← the card
3. Installation
4. Your First Example
5. Next Steps
```

Moving it up exposed a redundancy that was invisible while it sat at the bottom: a **"Try Interactive Examples"** section three lines below **"Try it interactively"** — whose run-locally block already lives on the Examples page, and whose gallery link already lives in Next Steps. Removed.

## Breaking change

`docs/pages/tutorials/examples.md` → `docs/pages/examples/index.md`. On update, copier applies the template's version and puts a project's customised page in the `.rej` — the trap that reset every curated index at v0.21.0. Projects with their own gallery page (yohou, whose index is hand-curated with six section links) should **keep theirs** and take only the nav change.

## Verified

| mutation | test |
|---|---|
| put Examples back under Tutorials | `test_examples_are_a_top_level_section` |
| move the marker back to the footer | `test_companion_cards_are_offered_before_the_page_body` |

Both confirmed to fail against v0.21.2 before being kept. Six pre-existing tests hardcoded the old path and failed on the move — updated, because they were correctly noticing a real change.

End-to-end on a generated project: `nox -s check_docs` still builds **strict-clean**, the nav has its Examples section, and the card renders at position 2, before the body. 304 fast tests pass; pre-commit clean.
