### PR TITLE
fix(template): stop v0.22.0 breaking the gallery link and the seed pages

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -29,6 +29,23 @@ _skip_if_exists:
   - "docs/assets/logo_dark.png"
   - "docs/assets/logo_light.png"
   - "docs/assets/favicon.png"
+  # Seed pages, and the same shape of problem as the logos above. Every real
+  # project rewrites these two wholesale -- the template's `hello("World")` tour
+  # and placeholder landing page survive nowhere. The template then keeps trying
+  # to patch them, and copier applies an update as a diff against the *template's*
+  # version: when the local file no longer resembles it, one shifted line rejects
+  # the whole hunk and the page reverts to the placeholder, with the project's
+  # content left only in a .rej nobody reads.
+  #
+  # v0.22.0 proved it: gating a blank line behind {% if include_examples %} was a
+  # whitespace-only change for projects without examples, and it still replaced a
+  # 244-line curated tutorial with the 74-line stub. Five of five projects with a
+  # customised getting-started.md were hit by that one release.
+  #
+  # Unlike the logos there is no merge to lose: a project that has rewritten these
+  # wants nothing the template ships in them. Seed once; never deliver again.
+  - "docs/index.md"
+  - "docs/pages/tutorials/getting-started.md"
 
 _envops:
   block_start_string: "{%"

--- a/copier.yml
+++ b/copier.yml
@@ -46,6 +46,12 @@ _skip_if_exists:
   # wants nothing the template ships in them. Seed once; never deliver again.
   - "docs/index.md"
   - "docs/pages/tutorials/getting-started.md"
+  # The gallery index goes the same way once a project curates it: yohou's lists
+  # six hand-written section pages, and v0.22.0 overwrote it with the generic
+  # one-page version. The skill's own file-classification.md already says this
+  # file "must never be overwritten" -- that classification is advisory and
+  # copier ignores it; this line is what enforces it.
+  - "docs/pages/examples/index.md"
 
 _envops:
   block_start_string: "{%"

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -803,16 +803,37 @@ def _get_gallery_page_url(project_root):
 
     docs_dir = project_root / "docs"
     _GALLERY_PAGE_CACHE = ""
-    if docs_dir.exists():
-        for md in sorted(docs_dir.rglob("*.md")):
-            try:
-                if "<!-- GALLERY -->" in md.read_text(encoding="utf-8"):
-                    rel = md.relative_to(docs_dir).with_suffix("")
-                    parts = rel.parts[:-1] if rel.name == "index" else rel.parts
-                    _GALLERY_PAGE_CACHE = "/" + "".join(f"{part}/" for part in parts)
-                    break
-            except (OSError, UnicodeDecodeError):
-                continue
+    if not docs_dir.exists():
+        return None
+
+    def _url_of(md):
+        rel = md.relative_to(docs_dir).with_suffix("")
+        parts = rel.parts[:-1] if rel.name == "index" else rel.parts
+        return "/" + "".join(f"{part}/" for part in parts)
+
+    sectioned = []
+    for md in sorted(docs_dir.rglob("*.md")):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "<!-- GALLERY -->" in text:
+            _GALLERY_PAGE_CACHE = _url_of(md)
+            return _GALLERY_PAGE_CACHE
+        if _SECTION_GALLERY_RE.search(text):
+            sectioned.append(md)
+
+    # A gallery too big for one page has no bare <!-- GALLERY --> at all: it is a
+    # directory of <!-- GALLERY:section:… --> pages behind an index. Looking only
+    # for the bare marker returns None for those projects, and the caller drops
+    # the "see all N examples" link on an `and gallery_url` -- so the API pages
+    # for the most-used symbols, which are the ones that overflow the cap, link to
+    # nothing at all. Silently: no marker is involved, so nothing warns.
+    if sectioned:
+        directory = sectioned[0].parent
+        if all(md.parent == directory for md in sectioned) and (directory / "index.md").is_file():
+            _GALLERY_PAGE_CACHE = _url_of(directory / "index.md")
+
     return _GALLERY_PAGE_CACHE or None
 
 
@@ -945,8 +966,23 @@ def _build_api_examples_html(project_root, qualified_name):
 
     html = "## Examples\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(shown)
     gallery_url = _get_gallery_page_url(project_root)
-    if total > _API_EXAMPLES_CAP and gallery_url:
-        html += f"\n[See all {total} examples in the gallery]({gallery_url})\n"
+    if total > _API_EXAMPLES_CAP:
+        if gallery_url:
+            html += f"\n[See all {total} examples in the gallery]({gallery_url})\n"
+        else:
+            # The symbols that overflow the cap are the most-used ones, so this
+            # drops the link exactly where the remaining examples matter most --
+            # and does it on an `if`, with no marker involved for the catch-all
+            # to notice. yohou renders 6 of PointReductionForecaster's 45 and
+            # links to none of the other 39.
+            log.warning(
+                "%s has %d examples but no gallery page to link the other %d to. Give the "
+                "gallery index a <!-- GALLERY --> marker, or put its "
+                "<!-- GALLERY:section:… --> pages behind an index.md.",
+                qualified_name,
+                total,
+                total - _API_EXAMPLES_CAP,
+            )
     return html
 {%- endif %}
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -790,6 +790,12 @@ def _get_gallery_page_url(project_root):
     placeholder -- found by looking, because that page is local-owned and a
     project is free to move it.  A hardcoded path is wrong the moment someone
     reorganises their docs, and produces a 404 with no build error.
+
+    ``index.md`` is dropped from the URL: under ``use_directory_urls`` (mkdocs'
+    default) ``pages/examples/index.md`` serves at ``/pages/examples/``, not at
+    ``/pages/examples/index/``.  This link is emitted as raw HTML, so mkdocs
+    never validates it and even --strict cannot see it break -- only RTD's
+    post-build linkchecker catches it.
     """
     global _GALLERY_PAGE_CACHE  # noqa: PLW0603
     if _GALLERY_PAGE_CACHE is not None:
@@ -802,7 +808,8 @@ def _get_gallery_page_url(project_root):
             try:
                 if "<!-- GALLERY -->" in md.read_text(encoding="utf-8"):
                     rel = md.relative_to(docs_dir).with_suffix("")
-                    _GALLERY_PAGE_CACHE = "/" + "/".join(rel.parts) + "/"
+                    parts = rel.parts[:-1] if rel.name == "index" else rel.parts
+                    _GALLERY_PAGE_CACHE = "/" + "".join(f"{part}/" for part in parts)
                     break
             except (OSError, UnicodeDecodeError):
                 continue
@@ -1936,6 +1943,19 @@ def on_page_markdown(markdown, page, config, files):
     # sufficient on its own, and the marker purely a placement override.
     companion_html = _build_companion_cards_html(project_root, page.file.src_path)
     if "<!-- COMPANION_NOTEBOOKS -->" in markdown:
+        if not companion_html:
+            # The marker is well-formed, so the catch-all below never sees it:
+            # it is consumed and replaced with nothing, leaving a blank where the
+            # page asked for cards. This is the one marker the template seeds by
+            # default -- it points at hello.py, so replacing hello.py without
+            # re-pointing its `companion` empties the page and says nothing.
+            log.warning(
+                "%s carries <!-- COMPANION_NOTEBOOKS --> but no notebook names it as their "
+                'companion, so it renders blank. Add `"companion": "%s"` to a notebook\'s '
+                "__gallery__, or drop the marker.",
+                page.file.src_path,
+                page.file.src_path,
+            )
         markdown = _replace_marker(markdown, "<!-- COMPANION_NOTEBOOKS -->", companion_html)
     elif companion_html:
         markdown = markdown.rstrip("\n") + "\n\n" + companion_html

--- a/template/noxfile.py.jinja
+++ b/template/noxfile.py.jinja
@@ -292,9 +292,16 @@ def build_docs(session: nox.Session) -> None:
     session.run("mkdocs", "build", "--clean", external=True)
 
 
-@nox.session(venv_backend="uv")
+@nox.session(python=PYTHON_VERSIONS[0], venv_backend="uv")
 def check_docs(session: nox.Session) -> None:
     """Build the docs with warnings fatal, without executing the notebooks.
+
+    Pinned to the lowest supported Python rather than whatever the caller happens
+    to have: an unpinned session takes the ambient interpreter, which can sit
+    outside requires-python and die in `uv sync` before mkdocs runs. CI only
+    passes today because the runner's default happens to be in range -- a runner
+    bumped past the ceiling would turn this red for a reason that has nothing to
+    do with the docs.
 
     docs/hooks.py warns when a marker resolves to nothing, because a placeholder
     that renders nothing looks exactly like a page that never had one -- the

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2655,6 +2655,11 @@ def test_gallery_overflow_link_targets_the_real_gallery_page(copie_session_defau
 
     The gallery page is local-owned, so a project may move it; a hardcoded path
     404s silently. It is located by the <!-- GALLERY --> placeholder instead.
+
+    Resolution mirrors use_directory_urls, under which `/a/b/` is served by
+    EITHER `a/b.md` OR `a/b/index.md`. This test knew only the first form, so it
+    passed while the url for an index page was `/a/b/index/` -- agreeing with the
+    bug rather than catching it. Both forms are checked now.
     """
     project_dir = copie_session_default.project_dir
     hooks = _load_hooks(project_dir, "gallery_url")
@@ -2663,9 +2668,15 @@ def test_gallery_overflow_link_targets_the_real_gallery_page(copie_session_defau
     url = hooks._get_gallery_page_url(project_dir)
 
     assert url, "gallery page not found by its GALLERY placeholder"
-    page = project_dir / "docs" / (url.strip("/") + ".md")
-    assert page.is_file(), f"overflow link {url} points at a page that does not exist"
-    assert "<!-- GALLERY -->" in page.read_text(encoding="utf-8"), "located page is not the gallery"
+    docs = project_dir / "docs"
+    stem = url.strip("/")
+    candidates = [docs / f"{stem}.md", docs / stem / "index.md"]
+    served = next((p for p in candidates if p.is_file()), None)
+    assert served is not None, (
+        f"overflow link {url} points at a page that does not exist "
+        f"(tried {[str(p.relative_to(docs)) for p in candidates]})"
+    )
+    assert "<!-- GALLERY -->" in served.read_text(encoding="utf-8"), "located page is not the gallery"
 
 
 def test_see_also_leaves_description_text_alone(copie_session_minimal):
@@ -3229,6 +3240,98 @@ def _write_sectioned_notebook(examples_dir, stem, *, title, section="", category
     )
 
 
+def test_seed_pages_every_project_rewrites_are_never_redelivered(copie_session_default):
+    """The landing page and the tutorial are seeded once, then left alone.
+
+    Same shape as the logos: the template ships a placeholder every real project
+    rewrites wholesale, then keeps trying to patch it. Copier applies an update as
+    a diff against the *template's* version, so once the local file no longer
+    resembles it, one shifted line rejects the whole hunk and the page silently
+    reverts to the stub. v0.22.0 proved it -- gating a blank line behind
+    {% raw %}{% if include_examples %}{% endraw %} was whitespace-only for projects without
+    examples and still replaced a 244-line curated tutorial with the 74-line stub.
+    Five of five projects with a customised getting-started.md were hit.
+    """
+    import yaml
+
+    copier_yml = yaml.safe_load((Path(__file__).parent.parent / "copier.yml").read_text(encoding="utf-8"))
+    skipped = copier_yml.get("_skip_if_exists") or []
+
+    for page in ("docs/index.md", "docs/pages/tutorials/getting-started.md"):
+        assert page in skipped, f"{page} is re-delivered on every update; a stray line reverts it to the stub"
+
+    # Seeded, so a new project still has a landing page and a tutorial.
+    for page in ("docs/index.md", "docs/pages/tutorials/getting-started.md"):
+        assert (copie_session_default.project_dir / page).is_file(), f"{page} is not seeded for a new project"
+
+
+def test_companion_marker_that_resolves_to_nothing_warns(copie_session_default):
+    """A well-formed COMPANION_NOTEBOOKS naming no notebook is reported.
+
+    The catch-all added in v0.21.2 only sees markers nothing *recognised*. A
+    well-formed one is consumed and replaced with an empty string, so a page that
+    asked for cards renders blank and the catch-all never sees it. This is the one
+    marker the template seeds by default -- it relies on hello.py naming the
+    tutorial, so any project that replaces hello.py without re-pointing its
+    `companion` silently empties that section. Exactly the shape v0.21.2 existed
+    to close, left open on the template's own default.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "companion_resolves_to_nothing")
+    _reset_gallery_caches(hooks)
+    page = _FakePage("pages/tutorials/named-by-nobody.md", "pages/tutorials/named-by-nobody/index.html")
+
+    with caplog_at_warning() as records:
+        out = hooks.on_page_markdown(
+            "# T\n\n<!-- COMPANION_NOTEBOOKS -->\n\n## Body\n", page, {"repo_url": "https://x/y"}, []
+        )
+
+    assert records, "a page asked for companion cards, got none, and said nothing"
+    assert "named-by-nobody" in " ".join(records), "the warning does not name the offending page"
+    assert "<!-- COMPANION_NOTEBOOKS -->" not in out, "the marker leaked into the page"
+
+
+def test_gallery_overflow_link_resolves_for_an_index_page(copie_session_default):
+    """The "see all examples" link points where the gallery actually serves.
+
+    Under use_directory_urls, `pages/examples/index.md` serves at
+    `/pages/examples/` -- but the URL was built from the file path, yielding
+    `/pages/examples/index/`, a 404. Dormant while the gallery was a non-index
+    page; v0.22.0 moved it to index.md and so shipped the break by default.
+
+    The link is emitted as raw HTML, so mkdocs never validates it and even
+    --strict cannot see it: it surfaces only in RTD's post-build linkchecker.
+    Driven through the real generated tree because that is the shape that broke.
+    """
+    project_dir = copie_session_default.project_dir
+    gallery = project_dir / "docs" / "pages" / "examples" / "index.md"
+    assert "<!-- GALLERY -->" in gallery.read_text(encoding="utf-8"), (
+        "the seeded gallery page carries no <!-- GALLERY --> marker; this test would assert nothing"
+    )
+
+    hooks = _load_hooks(project_dir, "gallery_url_index")
+    _reset_gallery_caches(hooks)
+    url = hooks._get_gallery_page_url(project_dir)
+
+    assert url == "/pages/examples/", f"the gallery link is {url!r}, which 404s; the page serves at /pages/examples/"
+
+    # A gallery that is NOT an index page keeps its own segment -- the case that
+    # worked before and must keep working.
+    other = project_dir / "docs" / "pages" / "examples" / "browse.md"
+    gallery_text = gallery.read_text(encoding="utf-8")
+    gallery.write_text("# Moved\n", encoding="utf-8")
+    other.write_text(gallery_text, encoding="utf-8")
+    try:
+        _reset_gallery_caches(hooks)
+        assert hooks._get_gallery_page_url(project_dir) == "/pages/examples/browse/", (
+            "a non-index gallery page lost its own path segment"
+        )
+    finally:
+        other.unlink()
+        gallery.write_text(gallery_text, encoding="utf-8")
+        _reset_gallery_caches(hooks)
+
+
 def test_examples_are_a_top_level_section(copie_session_default):
     """Examples is its own nav section, not a page filed under Tutorials.
 
@@ -3551,6 +3654,12 @@ def test_docs_warnings_are_fatal_somewhere_automated(copie_session_default):
     assert "MKDOCS_SKIP_NOTEBOOKS" in session, (
         "check_docs executes every notebook; that is too slow to run per-PR and it will be dropped from CI"
     )
+    # An unpinned session takes the ambient interpreter, which can sit outside
+    # requires-python and die in `uv sync` before mkdocs ever runs. CI passes
+    # today only because the runner's default happens to be in range.
+    assert (
+        "python=PYTHON_VERSIONS[0]" in noxfile[noxfile.index("def check_docs") - 60 : noxfile.index("def check_docs")]
+    ), "check_docs pins no Python; it runs on whatever the caller happens to have"
 
     workflow = project_dir / ".github" / "workflows" / "tests.yml"
     assert workflow.is_file(), "no tests workflow"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3257,11 +3257,18 @@ def test_seed_pages_every_project_rewrites_are_never_redelivered(copie_session_d
     copier_yml = yaml.safe_load((Path(__file__).parent.parent / "copier.yml").read_text(encoding="utf-8"))
     skipped = copier_yml.get("_skip_if_exists") or []
 
-    for page in ("docs/index.md", "docs/pages/tutorials/getting-started.md"):
+    # The gallery index goes the same way once curated: yohou's lists six
+    # hand-written section pages and v0.22.0 overwrote it with the generic one.
+    seed_pages = (
+        "docs/index.md",
+        "docs/pages/tutorials/getting-started.md",
+        "docs/pages/examples/index.md",
+    )
+    for page in seed_pages:
         assert page in skipped, f"{page} is re-delivered on every update; a stray line reverts it to the stub"
 
-    # Seeded, so a new project still has a landing page and a tutorial.
-    for page in ("docs/index.md", "docs/pages/tutorials/getting-started.md"):
+    # Still seeded, so a new project has a landing page, a tutorial and a gallery.
+    for page in seed_pages:
         assert (copie_session_default.project_dir / page).is_file(), f"{page} is not seeded for a new project"
 
 
@@ -3289,6 +3296,65 @@ def test_companion_marker_that_resolves_to_nothing_warns(copie_session_default):
     assert records, "a page asked for companion cards, got none, and said nothing"
     assert "named-by-nobody" in " ".join(records), "the warning does not name the offending page"
     assert "<!-- COMPANION_NOTEBOOKS -->" not in out, "the marker leaked into the page"
+
+
+def test_sectioned_gallery_is_still_findable_for_the_overflow_link(copie_session_default):
+    """A gallery split across section pages still has a home to link to.
+
+    A gallery too big for one page has no bare <!-- GALLERY --> at all -- it is a
+    directory of <!-- GALLERY:section:... --> pages behind an index. Looking only
+    for the bare marker returned None for those projects, and the caller dropped
+    the "see all N examples" link on an `and gallery_url`. The symbols that
+    overflow the cap are the most-used ones, so the link vanished exactly where
+    the remaining examples mattered most: yohou renders 6 of
+    PointReductionForecaster's 45 and links to none of the other 39. Silently --
+    no marker is involved, so the catch-all cannot see it.
+    """
+    project_dir = copie_session_default.project_dir
+    examples = project_dir / "docs" / "pages" / "examples"
+    gallery = examples / "index.md"
+    original = gallery.read_text(encoding="utf-8")
+
+    # Reshape into a sectioned gallery: a curated index with no bare marker, and
+    # section pages beside it. This is yohou's shape.
+    gallery.write_text("# Examples\n\n- [Alpha](alpha.md)\n", encoding="utf-8")
+    (examples / "alpha.md").write_text("# Alpha\n\n<!-- GALLERY:section:alpha -->\n", encoding="utf-8")
+    hooks = _load_hooks(project_dir, "sectioned_gallery_home")
+    try:
+        _reset_gallery_caches(hooks)
+        assert "<!-- GALLERY -->" not in gallery.read_text(encoding="utf-8"), "fixture still has a bare marker"
+        url = hooks._get_gallery_page_url(project_dir)
+        assert url == "/pages/examples/", (
+            f"a sectioned gallery has no findable home (got {url!r}); the overflow link is dropped"
+        )
+    finally:
+        (examples / "alpha.md").unlink()
+        gallery.write_text(original, encoding="utf-8")
+        _reset_gallery_caches(hooks)
+
+
+def test_dropped_overflow_link_warns(copie_session_default):
+    """Having nowhere to link the remaining examples is reported, not swallowed.
+
+    The drop happens on an `if`, not a marker, so nothing else can notice it.
+    """
+    project_dir = copie_session_default.project_dir
+    hooks = _load_hooks(project_dir, "dropped_overflow_warns")
+    _reset_gallery_caches(hooks)
+
+    # More notebooks than the cap, all using one symbol, and no gallery page.
+    examples_dir = project_dir / "examples"
+    for i in range(hooks._API_EXAMPLES_CAP + 2):
+        _write_sectioned_notebook(examples_dir, f"overflow_{i}", title=f"Overflow {i}", section="s")
+    hooks._NOTEBOOK_API_USAGE_CACHE = {"test_project.Widget": hooks._get_gallery_items(project_dir)}
+    hooks._GALLERY_PAGE_CACHE = ""  # no gallery page anywhere
+
+    with caplog_at_warning() as records:
+        html = hooks._build_api_examples_html(project_dir, "test_project.Widget")
+
+    assert "See all" not in html, "the fixture did not reproduce the drop"
+    assert records, "the overflow link was dropped with nothing said"
+    assert "Widget" in " ".join(records), "the warning does not name the symbol whose examples were dropped"
 
 
 def test_gallery_overflow_link_resolves_for_an_index_page(copie_session_default):


### PR DESCRIPTION
## Summary

Four bugs the v0.22.0 fan-out surfaced across seven repos. **Two were introduced by v0.22.0 itself.** Every one was found by an agent, not by me.

## 1. The "see all N examples" link 404s — RTD is red

`_get_gallery_page_url()` built the URL from the file path and never dropped a trailing `index`:

```python
rel = md.relative_to(docs_dir).with_suffix("")        # pages/examples/index
_GALLERY_PAGE_CACHE = "/" + "/".join(rel.parts) + "/" # -> /pages/examples/index/
```

Under `use_directory_urls`, that page serves at `/pages/examples/`. **Dormant** while the gallery was a non-index page (where the mapping is correct) — v0.22.0 both triggered it *and* shipped the gallery at that path by default, so every project on v0.22.0 with `include_examples` and a symbol used by more than 6 notebooks emits it.

Found independently by sklearn-wrap and sklearn-optuna, both diagnosed to the same line, **neither patched Tier 1**. yohou-nixtla and yohou-optuna proved it *dormant rather than absent* under the 6-example cap — yohou-optuna noted a 7th notebook fires it, since all 5 of its notebooks already use `OptunaSearchCV`.

It is invisible to `--strict`: the hook emits **raw HTML**, so mkdocs never validates the link. It surfaced only in RTD's `post_build` linkchecker, which CI doesn't run — `check_docs` passes and RTD still goes red.

**The test that should have caught it agreed with the bug.** It resolved the URL only as `<path>.md`; `use_directory_urls` also serves `<path>/index.md`. It passed *because* the buggy URL matched its incomplete mapping. Both forms are checked now.

## 2. Five of five curated tutorials were destroyed by a whitespace change

`docs/index.md` and `docs/pages/tutorials/getting-started.md` are now `_skip_if_exists` — **the same shape as the logos**: a placeholder every real project rewrites wholesale, which the template then keeps trying to patch. Copier applies an update as a diff against the *template's* version, so once the local file no longer resembles it, one shifted line rejects the whole hunk and the page reverts to the stub, content surviving only in a `.rej` nobody reads.

v0.22.0 proved it. Gating a blank line behind `{% if include_examples %}` was **whitespace-only** for projects without examples — and still did this:

| repo | curated | after update |
|---|---|---|
| kedro-dagster | 244 lines | **74-line stub** |
| kedro-azureml-pipeline | 197 lines | **58-line stub** |
| sklearn-wrap | 177 lines | **58-line stub** |
| yohou-nixtla | 120 lines | **58-line stub** |
| yohou-optuna | curated | **boilerplate** |

`docs/index.md` was reset to placeholders in three of them. Every agent caught and restored it — but a `Bin`-line-sized diff in a 30-file update is exactly what gets scrolled past.

Unlike the logos there's no merge to lose: a project that has rewritten these wants nothing the template ships in them. Seed once, never deliver again.

## 3. The one marker the template seeds by default could still render blank

v0.21.2's catch-all only sees markers nothing *recognised*. A **well-formed** `<!-- COMPANION_NOTEBOOKS -->` naming no notebook is consumed and replaced with an empty string — page renders blank, catch-all never sees it, `--strict` green:

```
marker consumed?  True
cards rendered?   0
warnings emitted? 0
```

The template **seeds that marker** in `getting-started.md.jinja`, relying on its own `hello.py` to name that page. Any project that replaces `hello.py` without re-pointing its `companion` silently empties the section — yohou-nixtla did exactly this, and found it. Precisely the shape v0.21.2 existed to close, left open on the template's own default.

## 4. `check_docs` ran on whatever Python happened to be around

Unpinned, it took the ambient interpreter — yohou-nixtla's was 3.14, outside `requires-python >=3.11,<3.14`, and it died in `uv sync` before mkdocs ran. CI passes today **only because the runner's default is in range**; a runner bump turns it red for reasons unrelated to the docs. Now pinned to the lowest supported version.

## Tests

Each confirmed to fail against v0.22.0 first:

| mutation | test |
|---|---|
| revert the index-URL fix | `test_gallery_overflow_link_resolves_for_an_index_page` |
| remove the empty-companion warning | `test_companion_marker_that_resolves_to_nothing_warns` |
| drop the seed pages from `_skip_if_exists` | `test_seed_pages_every_project_rewrites_are_never_redelivered` |
| unpin `check_docs`' Python | `test_docs_warnings_are_fatal_somewhere_automated` |

The Python-pin mutation **survived the first pass** — nothing tested it — so an assertion was added and the mutation re-run until it failed.

307 fast tests pass; pre-commit clean.
