### PR TITLE
feat(template): list See Also entries, and offer the notebook after the prereqs

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -1303,6 +1303,38 @@ _SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>
 _SEE_ALSO_ENTRY_RE = re.compile(r"^(\s*)(<code>[^<]+</code>|[A-Za-z_][\w.]*)(\s*:)")
 
 
+# A See Also entry opens a line with a name and a colon. The name may already be
+# a link (mkdocstrings resolved it) or bare (the linkifier is about to). Anything
+# else on its own line is a continuation of the previous entry's description.
+_SEE_ALSO_ENTRY_START_RE = re.compile(
+    r"""^\s*(?:
+        <a\s[^>]*>.*?</a>          # already-linked name
+      | <autoref[^>]*>.*?</autoref>
+      | <code>[^<]+</code>
+      | [A-Za-z_][\w.]*
+    )\s*:""",
+    re.VERBOSE,
+)
+
+
+def _split_see_also_entries(inner):
+    """Split a numpydoc See Also paragraph into one string per entry.
+
+    numpydoc puts one entry per source line; a long description wraps onto
+    continuation lines that carry no name of their own, and those belong to the
+    entry above rather than becoming entries in their own right.
+    """
+    entries: list[list[str]] = []
+    for line in inner.split("\n"):
+        if not line.strip():
+            continue
+        if _SEE_ALSO_ENTRY_START_RE.match(line) or not entries:
+            entries.append([line.strip()])
+        else:
+            entries[-1].append(line.strip())
+    return [" ".join(parts) for parts in entries]
+
+
 def _resolve_see_also_url(name):
     """Resolve a See Also entry naming a project symbol to a URL, or None.
 
@@ -1563,13 +1595,31 @@ def _linkify_see_also(html):
             title = f"<code>{name}</code>" if code_match else name
             return lead + _link_entry(name, title, colon, token + colon) + rest
 
-        def _process_container(container_match):
-            tag, inner = container_match.group(1), container_match.group(2)
+        def _linkify_inner(inner):
             # Leave an author's explicit [Name][target] reference alone: they have
             # said what they mean, and autorefs resolves it later.
             if "<a " in inner or "<autoref" in inner:
-                return container_match.group(0)
-            return f"<{tag}>" + "\n".join(_linkify_line(line) for line in inner.split("\n")) + f"</{tag}>"
+                return inner
+            return "\n".join(_linkify_line(line) for line in inner.split("\n"))
+
+        def _process_container(container_match):
+            tag, inner = container_match.group(1), container_match.group(2)
+            if tag == "li":
+                # Already one entry per item; only the names need linking.
+                return f"<li>{_linkify_inner(inner)}</li>"
+            entries = _split_see_also_entries(_linkify_inner(inner))
+            if len(entries) < 2:
+                return f"<p>{_linkify_inner(inner)}</p>"
+            # numpydoc puts each entry on its own source line inside one
+            # paragraph, and HTML collapses those newlines to spaces -- so every
+            # entry runs together on a single line, and the more references a
+            # symbol has the worse it reads. An author can dodge it by hand-
+            # writing markdown bullets (yohou does, which is why its pages look
+            # right and nobody else's do), but plain numpydoc is what the other
+            # 145 blocks in the fleet are written in. One entry per line is what
+            # the section is for.
+            items = "".join(f"<li>{entry}</li>" for entry in entries)
+            return f"<ul>{items}</ul>"
 
         # numpydoc renders See Also entries as a paragraph, one per line; an author
         # may also write them as a markdown list, which renders as <li>. Both are

--- a/template/docs/pages/tutorials/getting-started.md.jinja
+++ b/template/docs/pages/tutorials/getting-started.md.jinja
@@ -1,9 +1,7 @@
 # Getting Started
 
 In this tutorial, we will install {{ project_name }} and run a first example.
-{% if include_examples %}
-<!-- COMPANION_NOTEBOOKS -->
-{% endif %}
+
 ## Installation
 
 Choose your preferred package manager:
@@ -40,7 +38,9 @@ Verify the installation:
 import {{ package_name }}
 print({{ package_name }}.__version__)
 ```
-
+{% if include_examples %}
+<!-- COMPANION_NOTEBOOKS -->
+{% endif %}
 ## Your First Example
 
 ```python

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3298,6 +3298,62 @@ def test_companion_marker_that_resolves_to_nothing_warns(copie_session_default):
     assert "<!-- COMPANION_NOTEBOOKS -->" not in out, "the marker leaked into the page"
 
 
+def test_multiple_see_also_entries_render_one_per_line(copie_session_minimal):
+    """See Also entries become a list, not a run-on paragraph.
+
+    numpydoc puts each entry on its own source line inside one paragraph, and
+    HTML collapses those newlines to spaces -- so every reference runs together
+    on a single line, and the more references a symbol has the worse it reads.
+    An author can dodge it by hand-writing markdown bullets (yohou does, which is
+    why its pages look right and nobody else's do), but plain numpydoc is what
+    the other 145 blocks across the fleet are written in.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "see_also_listify")
+
+    entries = "Alpha : The first one.\nBeta : The second one.\nGamma : The third one."
+    html = _see_also_page("minimal_project", "Widget", entries)
+    out = hooks._linkify_see_also(html)
+
+    items = re.findall(r"<li>(.*?)</li>", out, re.DOTALL)
+    assert len(items) == 3, f"3 See Also entries rendered as {len(items)} list item(s); they run together on one line"
+    for name in ("Alpha", "Beta", "Gamma"):
+        assert any(name in item for item in items), f"{name} is missing from the list"
+    # Each entry keeps its own description rather than absorbing the next.
+    assert any("first one" in i and "second one" not in i for i in items), "entries bled into one another"
+
+
+def test_a_single_see_also_entry_is_not_made_a_list(copie_session_minimal):
+    """One entry stays a paragraph -- a one-item bullet list is noise."""
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "see_also_single")
+
+    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", "Alpha : Only one."))
+    assert "<li>" not in out, "a lone See Also entry was turned into a single-item list"
+    assert "Alpha" in out
+
+
+def test_see_also_description_wrapping_onto_a_second_line_stays_one_entry(copie_session_minimal):
+    """A wrapped description belongs to the entry above, not a new one.
+
+    numpydoc lets a long description continue on an indented line that carries no
+    name. Splitting naively on newlines would turn each of those into its own
+    bullet with no reference in it.
+    """
+    project_dir = copie_session_minimal.project_dir
+    _write_models_module(project_dir, "minimal_project")
+    hooks = _load_hooks(project_dir, "see_also_wrapped")
+
+    entries = "Alpha : A description long enough that it\n    wraps onto a second line.\nBeta : Short."
+    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", entries))
+
+    items = re.findall(r"<li>(.*?)</li>", out, re.DOTALL)
+    assert len(items) == 2, f"a wrapped description split into extra entries: {len(items)} items"
+    assert "wraps onto a second line" in items[0], "the continuation line was detached from its entry"
+
+
 def test_sectioned_gallery_is_still_findable_for_the_overflow_link(copie_session_default):
     """A gallery split across section pages still has a home to link to.
 
@@ -3434,24 +3490,33 @@ def test_examples_are_a_top_level_section(copie_session_default):
     assert not stale, f"these pages still link the old gallery path: {[str(p) for p in stale]}"
 
 
-def test_companion_cards_are_offered_before_the_page_body(copie_session_default):
-    """The seeded tutorial offers its notebook near the top, not after the footer.
+def test_companion_card_follows_the_prerequisites_and_precedes_the_body(copie_session_default):
+    """The card comes after what you need to have done, and before the body.
 
-    A reader decides whether to run the notebook instead of reading, so the offer
-    has to arrive before the thing it is an alternative to. The marker used to sit
-    at the very end, below "Next Steps" and "Get help" -- past the point anyone
-    who wanted it was still reading.
+    Two orderings matter and they pull opposite ways. A reader decides whether to
+    run the notebook *instead of* reading, so the offer has to arrive before the
+    thing it is an alternative to -- it used to sit below "Next Steps" and "Get
+    help", past anyone who wanted it. But it must not precede the prerequisites,
+    or it invites you to run something you cannot run yet.
+
+    The seeded tutorial has no "## Prerequisites" heading; installing is its
+    prerequisite, so the card follows Installation. Across the fleet the rule is
+    the same and every how-to already followed it -- the tutorials were the 15
+    pages that did not.
     """
     page = copie_session_default.project_dir / "docs" / "pages" / "tutorials" / "getting-started.md"
     text = page.read_text(encoding="utf-8")
     assert "<!-- COMPANION_NOTEBOOKS -->" in text, "the seeded tutorial offers no companion notebook"
 
     marker_at = text.index("<!-- COMPANION_NOTEBOOKS -->")
-    body_at = text.index("## Installation")
+    prerequisite_at = text.index("## Installation")
+    body_at = text.index("## Your First Example")
+
+    assert prerequisite_at < marker_at, "the notebook is offered before the reader has been told how to install it"
     assert marker_at < body_at, "the companion offer comes after the page body instead of before it"
 
     tail = text[text.index("## Next Steps") :] if "## Next Steps" in text else ""
-    assert "<!-- COMPANION_NOTEBOOKS -->" not in tail, "the companion offer is still stranded in the footer"
+    assert "<!-- COMPANION_NOTEBOOKS -->" not in tail, "the companion offer is stranded in the footer"
 
 
 def test_misspelled_marker_warns_instead_of_shipping_blank_space(copie_session_default):


### PR DESCRIPTION
## Summary

Two requested changes, both measured across the fleet before being made.

## 1. See Also entries render one per line

numpydoc puts each entry on its own source line inside a **single paragraph**, and HTML collapses those newlines to spaces — so every reference runs together on one line, and the more references a symbol has the worse it reads:

```html
<!-- sklearn_wrap.config.get_config, today -->
<p><a href="…/set_config/">set_config</a> : Persistently update the configuration.
<a href="…/config_context/">config_context</a> : Temporarily update the configuration.</p>
```
> See Also ¶ set_config : Persistently update the configuration. config_context : Temporarily update the configuration.

An author can dodge it by hand-writing markdown bullets — which is exactly why **yohou's pages look right and nobody else's do**:

| repo | renders as a list | **runs on one line** |
|---|---|---|
| yohou | 173 (hand-written bullets) | 38 |
| kedro-dagster | 0 | **47** |
| kedro-azureml-pipeline | 0 | **30** |
| yohou-nixtla | 0 | 17 |
| sklearn-wrap | 0 | 5 |
| sklearn-optuna | 0 | 4 |
| yohou-optuna | 0 | 4 |

**145 blocks across the fleet.** Fixing that in every docstring in six repos would be enormous churn; the template already post-processes this block, so it fixes all of them at once — and keeps working for docstrings nobody has written yet.

Three behaviours the tests pin, because each is a way to get it wrong:
- **A lone entry stays a paragraph** — a one-item bullet list is noise.
- **A wrapped description stays with its entry** — numpydoc lets a long description continue on an indented line carrying no name; splitting naively on newlines makes each one a bullet with no reference in it.
- **Author-written bullets are untouched** — yohou's 173 lists keep rendering exactly as they do now.

Verified against the **real markup** `sklearn_wrap.config.get_config` emits, not a fixture: 1 paragraph → 2 list items, both links preserved.

## 2. The companion card follows the prerequisites

Two orderings pull opposite ways. A reader decides whether to run the notebook *instead of* reading the page, so the offer must arrive **before** the thing it's an alternative to — it used to sit below "Next Steps" and "Get help", past anyone who wanted it. But it must not precede the **prerequisites**, or it invites you to run something you can't run yet. v0.22.0 fixed the first and broke the second.

Measured across the fleet — **69 pages carry a card, 54 already had this order, and every one of the 15 that didn't is a tutorial**:

| repo | pages | needed moving |
|---|---|---|
| yohou | 46 | 13 (all tutorials) |
| yohou-optuna | 5 | 1 |
| sklearn-wrap | 7 | 1 |
| yohou-nixtla / sklearn-optuna | 11 | 0 |

**Zero pages lack a Prerequisites section**, so the rule applies cleanly everywhere. The seeded tutorial has no `## Prerequisites` heading — installing *is* its prerequisite — so the card follows Installation. Rendered on a generated project:

```
1. Getting Started
2. Installation
3. Try it interactively   ← the card
4. Your First Example
5. Next Steps
```

## Tests

Each confirmed to fail against v0.22.1 first:

| mutation | test |
|---|---|
| revert to paragraph rendering | `test_multiple_see_also_entries_render_one_per_line` |
| naive newline split | `test_see_also_description_wrapping_onto_a_second_line_stays_one_entry` |
| listify a single entry | `test_a_single_see_also_entry_is_not_made_a_list` |
| card back above Installation | `test_companion_card_follows_the_prerequisites_and_precedes_the_body` |

All 15 pre-existing See Also tests still pass — the linkifier's behaviour is unchanged, only its layout. 312 fast tests pass; `nox -s check_docs` builds strict-clean.
