### PR TITLE
fix(template): reach root exports and nested notebooks, and pin checkout v7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,11 @@ exclude = ["CHANGELOG.md", "template", "site", "htmlcov", ".nox", ".venv"]
 [tool.rumdl.per-file-ignores]
 ".github/PULL_REQUEST_TEMPLATE.md" = ["MD041"]  # PR template starts with checklist
 ".github/skills/**" = ["MD007"]  # Nested lists in skill files use variable indent
+# Same files, same reason. The exemption was written when only the Copilot copy
+# was tracked; .claude/skills was gitignored, so it never needed one and the
+# asymmetry was invisible. Tracking the copy Claude Code actually reads made the
+# two mirrors lint differently despite being byte-identical.
+".claude/skills/**" = ["MD007"]
 "README.md" = ["MD041"]  # README starts with badges, not heading
 "docs/index.md" = ["MD041"]  # Landing page starts with logo, not heading
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
       - changelog
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main

--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -15,7 +15,7 @@ jobs:
     env:
       CODECOV_TOKEN: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -48,7 +48,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Create issue on failure
         uses: actions/github-script@v8

--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main
@@ -103,7 +103,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -200,7 +200,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -353,7 +353,7 @@ def _get_api_name_lookup(project_root):
 
     Shared by See Also resolution and example-notebook cross-referencing so the
     two cannot disagree about what a symbol is called.  Built by static
-    analysis only — the package is never imported.
+    analysis only; the package is never imported.
 
     When one symbol is reachable by two paths -- declared in a module and
     re-exported by a package -- the published path wins: that is the name users

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -71,6 +71,55 @@ def _get_submodules(project_root):
     return _SUBMODULE_CACHE
 
 
+def _qualified_name(module_name, member_name):
+    """Public dotted path of a member.
+
+    A symbol exported only from the package root has no module segment --
+    `pkg.Name`, not `pkg..Name` -- which is the whole reason code keyed on a
+    submodule silently drops it.
+    """
+    parts = ["{{ package_name }}", module_name, member_name]
+    return ".".join(part for part in parts if part)
+
+
+def _module_source(pkg_dir, module_name):
+    """The file backing a submodule: ``name.py``, else ``name/__init__.py``."""
+    mod_file = pkg_dir / f"{module_name}.py"
+    if not mod_file.exists():
+        mod_file = pkg_dir / module_name / "__init__.py"
+    return mod_file
+
+
+def _get_root_members(project_root):
+    """Public symbols the package exports only from its own ``__init__.py``.
+
+    ``_get_submodules`` skips every ``_``-prefixed name, which is right for
+    private modules and also silently excludes ``__init__.py`` itself. A package
+    that keeps a base class in ``_base.py`` and re-exports it from the root --
+    an ordinary layout, and what sklearn does -- therefore has a public symbol
+    that belongs to no submodule, reaches no page, and never appears in the API
+    table. Nothing reports it: yohou-nixtla ships 18 names in ``__all__`` and the
+    table lists 17.
+
+    Their public path has no module segment (``pkg.Name``, not
+    ``pkg.module.Name``), which is exactly why they fall through code keyed on a
+    submodule. Names a real submodule already publishes keep their module path;
+    only the homeless ones are adopted here.
+    """
+    pkg_dir = project_root / "src" / "{{ package_name }}"
+    init_file = pkg_dir / "__init__.py"
+    if not init_file.exists():
+        return {"classes": [], "functions": []}
+
+    covered = set()
+    for mod in _get_submodules(project_root):
+        members = _get_public_members(_module_source(pkg_dir, mod["module_name"]), pkg_dir)
+        covered.update(entry["name"] for entry in members["classes"] + members["functions"])
+
+    root = _get_public_members(init_file, pkg_dir)
+    return {key: [entry for entry in root[key] if entry["name"] not in covered] for key in ("classes", "functions")}
+
+
 def _extract_module_docstring(py_file):
     """Extract the module-level docstring from a Python file."""
     try:
@@ -320,13 +369,13 @@ def _get_api_name_lookup(project_root):
 
     pkg_dir = project_root / "src" / "{{ package_name }}"
     candidates = {}
+    scans = []
     for mod in _get_submodules(project_root):
-        mod_file = pkg_dir / f"{mod['module_name']}.py"
-        if not mod_file.exists():
-            mod_file = pkg_dir / mod["module_name"] / "__init__.py"
-        members = _get_public_members(mod_file, pkg_dir)
+        scans.append((mod["module_name"], _get_public_members(_module_source(pkg_dir, mod["module_name"]), pkg_dir)))
+    scans.append(("", _get_root_members(project_root)))
+    for module_name, members in scans:
         for entry in members["classes"] + members["functions"]:
-            qualified = f"{{ package_name }}.{mod['module_name']}.{entry['name']}"
+            qualified = _qualified_name(module_name, entry["name"])
             candidates.setdefault(entry["name"], []).append({
                 "qualified": qualified,
                 "origin": entry.get("origin"),
@@ -386,6 +435,18 @@ def _build_members_tables(package_name, module_name, members):
         return ""
 
     return "\n\n".join(sections)
+
+
+def _write_member_pages(generated_dir, page_template, module_name, members):
+    """Write one detail page per public class/function. Returns how many."""
+    written = 0
+    for kind in ("classes", "functions"):
+        for entry in members[kind]:
+            qualified = _qualified_name(module_name, entry["name"])
+            page = generated_dir / f"{qualified}.md"
+            page.write_text(page_template.format(name=entry["name"], qualified=qualified))
+            written += 1
+    return written
 
 
 def _generate_api_pages(project_root):
@@ -456,17 +517,13 @@ def _generate_api_pages(project_root):
         print(f"[hooks] generated api page: pages/api/{mod['module_name']}.md")
 
         # Generate per-class/function detail pages
-        for cls in members["classes"]:
-            qualified = f"{{ package_name }}.{mod['module_name']}.{cls['name']}"
-            page = generated_dir / f"{qualified}.md"
-            page.write_text(_page_template.format(name=cls["name"], qualified=qualified))
-            member_count += 1
+        member_count += _write_member_pages(generated_dir, _page_template, mod["module_name"], members)
 
-        for func in members["functions"]:
-            qualified = f"{{ package_name }}.{mod['module_name']}.{func['name']}"
-            page = generated_dir / f"{qualified}.md"
-            page.write_text(_page_template.format(name=func["name"], qualified=qualified))
-            member_count += 1
+    # Symbols exported only from the package root have no submodule and so no
+    # module page; they still need a detail page for the table and See Also to
+    # link at. Without this the link resolves to nothing and, being raw HTML,
+    # nothing validates it.
+    member_count += _write_member_pages(generated_dir, _page_template, "", _get_root_members(project_root))
 
     if member_count:
         print(f"[hooks] generated {member_count} API member pages in pages/api/generated/")
@@ -497,23 +554,27 @@ def _build_api_table_html(project_root, prefix):
     pkg_dir = project_root / "src" / "{{ package_name }}"
 
     rows = []
+    scans = []
     for mod in modules:
-        mod_file = pkg_dir / f"{mod['module_name']}.py"
-        if not mod_file.exists():
-            mod_file = pkg_dir / mod["module_name"] / "__init__.py"
+        mod_file = _module_source(pkg_dir, mod["module_name"])
         if not mod_file.exists():
             continue
+        scans.append((mod["module_name"], _get_public_members(mod_file, pkg_dir)))
+    # Symbols exported only from the package root belong to no submodule, so a
+    # loop over submodules alone leaves them out of the table entirely.
+    scans.append(("", _get_root_members(project_root)))
 
-        members = _get_public_members(mod_file, pkg_dir)
-        module_label = f"{{ package_name }}.{mod['module_name']}"
-        module_href = f"{prefix}pages/api/{mod['module_name']}/"
+    for module_name, members in scans:
+        module_label = _qualified_name(module_name, "").rstrip(".") or "{{ package_name }}"
+        # A root export has no module page to point at; the API index is its home.
+        module_href = f"{prefix}pages/api/{module_name}/" if module_name else f"{prefix}pages/api/"
 
         for cls in members["classes"]:
-            qualified = f"{{ package_name }}.{mod['module_name']}.{cls['name']}"
+            qualified = _qualified_name(module_name, cls["name"])
             rows.append((cls["name"], "Class", module_label, module_href, cls["doc"], qualified))
 
         for func in members["functions"]:
-            qualified = f"{{ package_name }}.{mod['module_name']}.{func['name']}"
+            qualified = _qualified_name(module_name, func["name"])
             rows.append((func["name"], "Function", module_label, module_href, func["doc"], qualified))
 
     rows.sort(key=lambda r: r[0].lower())
@@ -663,8 +724,15 @@ def _get_gallery_items(project_root):
             continue
 
         stem = notebook.stem
+        # The export is flat (docs/examples/<stem>/), so [View] keys on the stem.
+        # The playground is not: it reconstructs the real repo path from this URL,
+        # so it must carry the notebook's path relative to examples/. Building it
+        # from the stem assumes a flat examples/ dir and 404s for every notebook
+        # in a subdirectory -- 78 of yohou's 79. The link is generated rather than
+        # authored, so mkdocs never validates it and --strict stays green.
+        rel_parts = notebook.relative_to(examples_dir).with_suffix("").parts
         view_path = f"/examples/{stem}/"
-        open_path = f"/examples/{stem}/edit/"
+        open_path = "/examples/" + "/".join(rel_parts) + "/edit/"
 
         # api_references: absent (None) means "infer from imports"; an empty
         # list means "this notebook belongs on no API page" -- a deliberate
@@ -1162,6 +1230,24 @@ def _build_subpages_list(config, page, files):
         return "<!-- no subpages -->\n"
 
     entries = _nav_entries(config)
+
+    # The index enumerates sibling *files*; the sidebar comes from mkdocs.yml.
+    # When the two disagree the index quietly papers over it -- an entry dropped
+    # from the nav still appears here, so the page stays reachable by link while
+    # vanishing from navigation. mkdocs itself reports not-in-nav pages at INFO,
+    # which --strict does not fail on, so nothing else says a word. A copier
+    # update deleted a real nav entry exactly this way and every other guard
+    # passed it.
+    orphans = sorted(s.src_path for s in siblings if s.src_path not in entries)
+    if orphans:
+        log.warning(
+            "%s lists %s, which %s missing from the nav in mkdocs.yml -- the page is linked but "
+            "unreachable by navigation.",
+            src,
+            ", ".join(orphans),
+            "is" if len(orphans) == 1 else "are",
+        )
+
     rows = []
     for sibling in siblings:
         title, description = _page_title_and_description(sibling.abs_src_path)
@@ -2076,11 +2162,6 @@ def on_pre_build(config):
     # Generate per-submodule API reference pages
     _generate_api_pages(project_root)
 {% if include_examples %}
-    # Allow skipping slow notebook export during development
-    if os.environ.get("MKDOCS_SKIP_NOTEBOOKS"):
-        print("[hooks] MKDOCS_SKIP_NOTEBOOKS set, skipping notebook export")
-        return
-
     examples_dir = project_root / "examples"
 
     if not examples_dir.exists():
@@ -2093,6 +2174,33 @@ def on_pre_build(config):
         if "__marimo__" not in p.parts and "bugs" not in p.parts and "__init__" not in p.name
     ]
     if not notebooks:
+        return
+
+    # Checked before the skip below, not after: a stem collision is a property of
+    # the source tree, not of the export, and check_docs -- the only place a
+    # warning is fatal -- always sets MKDOCS_SKIP_NOTEBOOKS. Warning after the
+    # return would fire only where nothing listens.
+    #
+    # The export dir is keyed on the stem alone, so two notebooks with the same
+    # stem in different subdirectories write to one directory and the second
+    # rmtree's the first. Both gallery cards then point at whichever won, and the
+    # loser is unreachable with nothing said. The winner is filesystem-order
+    # dependent: this walk is unsorted while the gallery's is sorted.
+    seen_stems = {}
+    for notebook in sorted(notebooks):
+        first = seen_stems.setdefault(notebook.stem, notebook)
+        if first is not notebook:
+            log.warning(
+                "notebook stem %r is used by both %s and %s; they export to the same page and only "
+                "one survives. Rename one.",
+                notebook.stem,
+                first.relative_to(project_root),
+                notebook.relative_to(project_root),
+            )
+
+    # Allow skipping slow notebook export during development
+    if os.environ.get("MKDOCS_SKIP_NOTEBOOKS"):
+        print("[hooks] MKDOCS_SKIP_NOTEBOOKS set, skipping notebook export")
         return
 
     docs_examples = project_root / "docs" / "examples"

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -381,8 +381,8 @@ other_function : Another related object.
 ```
 
 Names are linked to their API pages automatically, whether or not you wrap them
-in backticks. Names that cannot be resolved — a private helper, or a concept
-rather than an API object — are left as plain text rather than failing the
+in backticks. Names that cannot be resolved (a private helper, or a concept
+rather than an API object) are left as plain text rather than failing the
 build, so you can reference anything that reads well.
 
 Fully qualified names work too (`{{ package_name }}.module.OtherClass`), and
@@ -411,9 +411,9 @@ turned into a link to its definition. The glossary page is the only place terms
 are listed, so a definition and its links cannot drift apart.
 
 Opting in is per term because defining a word and advertising it everywhere are
-different decisions: a glossary is free to define short, common words — `step`
-above — and auto-linking those wherever prose happens to use them is noise. Text
-inside code, headings and existing links is never touched.
+different decisions. A glossary is free to define short, common words such as
+`step` above, and auto-linking those wherever prose happens to use them is
+noise. Text inside code, headings and existing links is never touched.
 
 ### Documentation
 

--- a/template/docs/pages/how-to/troubleshooting.md.jinja
+++ b/template/docs/pages/how-to/troubleshooting.md.jinja
@@ -32,5 +32,5 @@ that was already broken, not a new one.
 
 **Fix:** Either point the include at a file that exists, or remove the include
 (and the page, if the include was all it contained). Include paths resolve
-relative to `docs/` first, then the repository root — so `--8<-- "CHANGELOG.md"`
+relative to `docs/` first, then the repository root, so `--8<-- "CHANGELOG.md"`
 finds the changelog at the top of the repo.

--- a/template/docs/pages/reference/index.md.jinja
+++ b/template/docs/pages/reference/index.md.jinja
@@ -2,7 +2,7 @@
 
 Information-oriented description of what {{ project_name }} provides: the API,
 its behaviour, and its release history. Reference material is for looking
-things up, not for learning — it describes the machinery and stays out of your
+things up, not for learning. It describes the machinery and stays out of your
 way.
 
 <!-- SUBPAGES -->

--- a/template/docs/pages/tutorials/getting-started.md.jinja
+++ b/template/docs/pages/tutorials/getting-started.md.jinja
@@ -1,7 +1,9 @@
 # Getting Started
 
 In this tutorial, we will install {{ project_name }} and run a first example.
-
+{% if include_examples %}
+<!-- COMPANION_NOTEBOOKS -->
+{% endif %}
 ## Installation
 
 Choose your preferred package manager:
@@ -38,9 +40,7 @@ Verify the installation:
 import {{ package_name }}
 print({{ package_name }}.__version__)
 ```
-{% if include_examples %}
-<!-- COMPANION_NOTEBOOKS -->
-{% endif %}
+
 ## Your First Example
 
 ```python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,22 @@ class CopierResult:
         self.exception = None
 
 
+@pytest.fixture(scope="session", autouse=True)
+def keep_uv_out_of_the_runner_venv():
+    """Stop `uv` subprocesses from re-syncing the venv the tests run in.
+
+    nox exports UV_PROJECT_ENVIRONMENT pointing at its session venv, and every
+    subprocess inherits it, so `uv sync` inside a generated project retargets the
+    runner's own venv instead of the project's: it installed test_project, marimo and
+    pandas into it and re-resolved Markdown out from under the suite. A worker that
+    imported markdown.extensions.toc during that swap died with ModuleNotFoundError.
+    Unset, uv falls back to the project's own .venv, which is what these tests mean.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+        yield
+
+
 @pytest.fixture(scope="session")
 def session_projects_dir(tmp_path_factory):
     """Session-scoped temp directory for generated projects.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3454,6 +3454,28 @@ def test_gallery_overflow_link_resolves_for_an_index_page(copie_session_default)
         _reset_gallery_caches(hooks)
 
 
+def test_docs_use_no_em_or_en_dashes(copie_session_default):
+    """Seeded prose punctuates without em or en dashes.
+
+    A house style rule, and the template is where it has to hold: its pages are
+    the first draft of every project's docs, so a dash seeded here is one every
+    project inherits and nobody re-reads. Ranges are not punctuation and are left
+    alone; this only catches the dash standing in for a comma, colon or bracket.
+    """
+    docs = copie_session_default.project_dir / "docs"
+    pages = sorted(p for p in docs.rglob("*.md") if "examples" not in p.relative_to(docs).parts)
+    assert pages, "no docs pages generated; this test would assert nothing"
+
+    offenders = []
+    for page in pages:
+        for lineno, line in enumerate(page.read_text(encoding="utf-8").splitlines(), 1):
+            for dash in ("\u2014", "\u2013"):
+                if dash in line:
+                    offenders.append(f"{page.relative_to(docs)}:{lineno}: {line.strip()}")
+
+    assert not offenders, "seeded docs punctuate with em/en dashes:\n" + "\n".join(offenders)
+
+
 def test_action_pins_are_consistent_and_current(copie_session_default):
     """Every workflow pins the same actions/checkout, and it is the one the fleet runs.
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3454,6 +3454,31 @@ def test_gallery_overflow_link_resolves_for_an_index_page(copie_session_default)
         _reset_gallery_caches(hooks)
 
 
+def test_action_pins_are_consistent_and_current(copie_session_default):
+    """Every workflow pins the same actions/checkout, and it is the one the fleet runs.
+
+    The template pinned @v6 while every generated repo had been dependabot-bumped
+    to @v7. That gap is not cosmetic: when a release inserts a job whose checkout
+    step is textually identical to an existing one, the patch aligns the repo's v7
+    line with the *inserted* job and pushes the template's v6 down into the old
+    one. Two repos hit exactly that. CI cannot catch it -- v6 works -- so it
+    reviews past as a version bump.
+
+    Pinned rather than merely self-consistent: consistency alone is satisfied by
+    the whole fleet drifting together, which is the state this fixes.
+    """
+    workflows = sorted((copie_session_default.project_dir / ".github" / "workflows").glob("*.yml"))
+    assert workflows, "no workflows generated"
+
+    pins = {}
+    for wf in workflows:
+        for match in re.finditer(r"uses:\s*actions/checkout@(\S+)", wf.read_text(encoding="utf-8")):
+            pins.setdefault(match.group(1), []).append(wf.name)
+
+    assert pins, "no actions/checkout usage found; this test would assert nothing"
+    assert set(pins) == {"v7"}, f"actions/checkout pins are {dict(pins)}; expected every one at v7"
+
+
 def test_nav_order_is_diataxis_with_reference_last(copie_session_default, copie_minimal):
     """The nav reads learn -> do -> see -> understand -> look up, in that order.
 
@@ -3526,29 +3551,31 @@ def test_examples_are_a_top_level_section(copie_session_default):
     assert not stale, f"these pages still link the old gallery path: {[str(p) for p in stale]}"
 
 
-def test_companion_card_follows_the_prerequisites_and_precedes_the_body(copie_session_default):
-    """The card comes after what you need to have done, and before the body.
+def test_companion_card_precedes_the_install_step(copie_session_default):
+    """The notebook is offered before the reader is asked to install anything.
 
-    Two orderings matter and they pull opposite ways. A reader decides whether to
-    run the notebook *instead of* reading, so the offer has to arrive before the
-    thing it is an alternative to -- it used to sit below "Next Steps" and "Get
-    help", past anyone who wanted it. But it must not precede the prerequisites,
-    or it invites you to run something you cannot run yet.
+    The card links a marimo playground whose dependencies are declared in the
+    notebook itself, so running it is an *alternative* to installing rather than
+    something installing unlocks. Offering it after the install step asks the
+    reader to do the work first and only then mentions they need not have.
 
-    The seeded tutorial has no "## Prerequisites" heading; installing is its
-    prerequisite, so the card follows Installation. Across the fleet the rule is
-    the same and every how-to already followed it -- the tutorials were the 15
-    pages that did not.
+    It still precedes the body: a reader decides whether to run the notebook
+    instead of reading the page, so the offer has to arrive before the thing it
+    is an alternative to -- it used to sit below "Next Steps" and "Get help",
+    past anyone who wanted it.
     """
     page = copie_session_default.project_dir / "docs" / "pages" / "tutorials" / "getting-started.md"
     text = page.read_text(encoding="utf-8")
     assert "<!-- COMPANION_NOTEBOOKS -->" in text, "the seeded tutorial offers no companion notebook"
 
     marker_at = text.index("<!-- COMPANION_NOTEBOOKS -->")
-    prerequisite_at = text.index("## Installation")
+    install_at = text.index("## Installation")
     body_at = text.index("## Your First Example")
 
-    assert prerequisite_at < marker_at, "the notebook is offered before the reader has been told how to install it"
+    assert marker_at < install_at, (
+        "the notebook is offered only after the reader has installed the package, "
+        "when running it in the browser is the alternative to installing"
+    )
     assert marker_at < body_at, "the companion offer comes after the page body instead of before it"
 
     tail = text[text.index("## Next Steps") :] if "## Next Steps" in text else ""
@@ -3581,6 +3608,139 @@ def test_misspelled_marker_warns_instead_of_shipping_blank_space(copie_session_d
     with caplog_at_warning() as records:
         hooks.on_page_markdown("# X\n\n<!-- prettier-ignore -->\n", page, {"repo_url": "https://x/y"}, [])
     assert not records, "an ordinary HTML comment was flagged as a broken marker"
+
+
+def test_nested_notebook_playground_link_keeps_its_subdirectory(copie_session_default):
+    """The marimo link points at the notebook's real path, not a flat guess.
+
+    The HTML export is flat (docs/examples/<stem>/), so [View] keys on the stem.
+    The playground is not: it reconstructs the repo path from this URL, so a URL
+    built from the stem alone 404s for every notebook in a subdirectory -- 78 of
+    yohou's 79. yohou's pre-de-fork hooks.py kept the subdirectory for exactly
+    this reason and the behaviour was lost when the fork was dropped.
+
+    The link is generated rather than authored, so mkdocs never validates it and
+    --strict stays green while every one of them is broken.
+    """
+    project_dir = copie_session_default.project_dir
+    nested = project_dir / "examples" / "data-features"
+    _write_sectioned_notebook(nested, "nested_demo", title="Nested Demo", section="data-features")
+    try:
+        hooks = _load_hooks(project_dir, "nested_playground")
+        _reset_gallery_caches(hooks)
+        item = next(i for i in hooks._get_gallery_items(project_dir) if i["stem"] == "nested_demo")
+
+        assert item["open_path"] == "/examples/data-features/nested_demo/edit/", (
+            f"playground url is {item['open_path']!r}; it drops the subdirectory and 404s"
+        )
+        # [View] keys on the stem because the export really is flat.
+        assert item["view_path"] == "/examples/nested_demo/"
+    finally:
+        (nested / "nested_demo.py").unlink()
+        nested.rmdir()
+
+
+def test_duplicate_notebook_stems_are_reported(copie_session_default):
+    """Two notebooks sharing a stem export to one page; the loser must not vanish quietly.
+
+    The export dir is keyed on the stem alone, so a second notebook rmtree's the
+    first and both gallery cards point at whichever won. yohou has exactly this:
+    data-features/signal_processing.py and visualization/signal_processing.py --
+    79 View links, 78 unique. The winner is filesystem-order dependent, since the
+    export walk is unsorted while the gallery's is sorted.
+    """
+    project_dir = copie_session_default.project_dir
+    a = project_dir / "examples" / "dir_a"
+    b = project_dir / "examples" / "dir_b"
+    _write_sectioned_notebook(a, "collide", title="A", section="a")
+    _write_sectioned_notebook(b, "collide", title="B", section="b")
+    try:
+        hooks = _load_hooks(project_dir, "stem_collision")
+        _reset_gallery_caches(hooks)
+        os.environ["MKDOCS_SKIP_NOTEBOOKS"] = "1"
+        with caplog_at_warning() as records:
+            hooks.on_pre_build({"docs_dir": str(project_dir / "docs")})
+        assert any("collide" in r for r in records), (
+            "two notebooks share a stem and overwrite each other's export, and nothing said so"
+        )
+    finally:
+        os.environ.pop("MKDOCS_SKIP_NOTEBOOKS", None)
+        for d in (a, b):
+            (d / "collide.py").unlink()
+            d.rmdir()
+
+
+def test_root_only_exports_reach_the_api(copie_session_minimal):
+    """A symbol exported only from the package root still gets a page and a table row.
+
+    _get_submodules skips every `_`-prefixed name -- right for private modules,
+    and it also excludes __init__.py itself. A package that keeps a base class in
+    _base.py and re-exports it from the root (an ordinary layout) therefore has a
+    public symbol belonging to no submodule, which reached no page and never
+    appeared in the table. yohou-nixtla ships 18 names in __all__ and listed 17.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = project_dir / "src" / "minimal_project"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "_base.py").write_text(
+        '"""Private module."""\n\n\nclass BaseThing:\n    """A public base class in a private module."""\n',
+        encoding="utf-8",
+    )
+    (pkg / "widgets.py").write_text('"""Widgets."""\n\n\nclass Widget:\n    """A widget."""\n', encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        '"""Pkg."""\n\nfrom minimal_project._base import BaseThing\n'
+        "from minimal_project.widgets import Widget\n\n"
+        '__all__ = ["BaseThing", "Widget"]\n',
+        encoding="utf-8",
+    )
+    hooks = _load_hooks(project_dir, "root_exports")
+    hooks._SUBMODULE_CACHE = None
+    hooks._API_NAME_LOOKUP_CACHE = None
+
+    html = hooks._build_api_table_html(project_dir, "")
+    assert "BaseThing" in html, "a symbol exported only from the package root is missing from the API table"
+    assert "minimal_project.BaseThing" in html, "the root export is not published at its public path"
+
+    # A name a real submodule publishes keeps its module path -- root adoption is
+    # for the homeless only, not a second home for everything.
+    roots = hooks._get_root_members(project_dir)
+    assert [c["name"] for c in roots["classes"]] == ["BaseThing"], (
+        f"root adoption swallowed a symbol that has a module: {[c['name'] for c in roots['classes']]}"
+    )
+
+    hooks._SUBMODULE_CACHE = None
+    hooks._API_NAME_LOOKUP_CACHE = None
+    assert hooks._get_api_name_lookup(project_dir).get("BaseThing") == "minimal_project.BaseThing", (
+        "See Also cannot resolve a root-exported symbol"
+    )
+
+
+def test_subpages_reports_a_sibling_missing_from_the_nav(copie_session_default):
+    """An index lists sibling files; the sidebar comes from mkdocs.yml. Disagreement is reported.
+
+    When a nav entry is dropped the index papers over it -- the page is still
+    listed and still linked, while vanishing from navigation. mkdocs reports
+    not-in-nav pages at INFO, which --strict does not fail on, so nothing else
+    says a word. A copier update deleted a real nav entry exactly this way and
+    every other guard passed it.
+    """
+    project_dir = copie_session_default.project_dir
+    docs = project_dir / "docs"
+    hooks = _load_hooks(project_dir, "subpages_orphan")
+    page = _FakePage("pages/how-to/index.md", "pages/how-to/index.html")
+    files = [
+        _FakeFile(f"pages/how-to/{n}.md", f"pages/how-to/{n}/index.html", str(docs / "pages" / "how-to" / f"{n}.md"))
+        for n in ("configure", "troubleshooting")
+    ]
+    # troubleshooting is deliberately absent from the nav.
+    config = {"nav": [{"How-to Guides": ["pages/how-to/index.md", {"Configuration": "pages/how-to/configure.md"}]}]}
+
+    with caplog_at_warning() as records:
+        hooks.on_page_markdown("# H\n\n<!-- SUBPAGES -->\n", page, config, files)
+
+    assert any("troubleshooting" in r for r in records), (
+        "a page missing from the nav is still listed by the index, and nothing reports it"
+    )
 
 
 def test_gallery_section_marker_renders_only_that_section(copie_session_default):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3984,6 +3984,27 @@ def test_subpage_index_summarises_each_page_from_its_own_source(copie_session_de
     assert "An admonition, not the summary." not in out, "an admonition was mistaken for the page's opening prose"
 
 
+def test_uv_subprocesses_cannot_retarget_the_runner_venv():
+    """No `uv` subprocess may resolve its project environment to the venv running the tests.
+
+    nox exports UV_PROJECT_ENVIRONMENT at its session venv, and the 17 `uv`/`uvx nox`
+    calls in this suite inherit it, so a `uv sync` meant for a generated project
+    re-syncs the runner's venv instead. One such test, with no xdist at all, installed
+    test_project and marimo into .nox/test-3-14 and re-resolved Markdown off the
+    version uv.lock pins. Under xdist that swap races every other worker: a worker
+    importing markdown.extensions.toc while Markdown was being replaced died with
+    ModuleNotFoundError, on 3.14 only, reproducibly, for a change that touched no code.
+
+    The effect is the wrong thing to assert on: which worker pollutes first is
+    scheduling-dependent, so this pins the cause instead.
+    """
+    assert os.environ.get("UV_PROJECT_ENVIRONMENT") is None, (
+        "UV_PROJECT_ENVIRONMENT points at the test runner's own venv, so any `uv sync` "
+        "a test runs inside a generated project will re-resolve the suite's packages "
+        "underneath it; conftest must unset it for the session"
+    )
+
+
 def test_docs_warnings_are_fatal_somewhere_automated(copie_session_default):
     """Something that runs on every PR must build the docs with warnings fatal.
 


### PR DESCRIPTION
## Summary

All five things you asked for, plus a **blocker** the v0.24.0 fan-out found in yohou.

## 1. The blocker: 78 of yohou's 79 "Open in marimo" links 404 — a regression I caused

The playground URL is built from the notebook's **stem**, which assumes a flat `examples/`. yohou nests its 79 notebooks in 6 subdirectories. yohou's **pre-de-fork** `hooks.py` preserved the subdirectory, with a comment saying exactly why — *"so the marimo-playground rewrite regex can reconstruct the real repo path"*. **That behaviour was lost when I eliminated the fork in v0.20.0**, and nothing noticed for five releases because the link is *generated, never authored*, so mkdocs never validates it and `--strict` stays green.

`[View]` still keys on the stem, because the export really is flat. Verified against yohou's real layout: `examples/data-features/feature_union.py` → `/examples/data-features/feature_union/edit/`.

## 2. Root-only exports never reached the API

`_get_submodules` skips every `_`-prefixed name — right for private modules, and it also excludes `__init__.py` itself. A package that keeps a base class in `_base.py` and re-exports it from the root (an ordinary layout — sklearn does it everywhere) has a public symbol belonging to **no submodule**: no table row, no page, nothing resolving it in See Also. **yohou-nixtla ships 18 names in `__all__` and lists 17.**

Their public path has no module segment (`pkg.Name`, not `pkg.module.Name`), which is precisely why code keyed on a submodule drops them. Reproduced in miniature and fixed: table 2 → 3 rows, page written, See Also resolves `rp.BaseThing`. Names a real submodule already publishes **keep their module path** — root adoption is for the homeless only, and the test pins that.

## 3. Stem collisions were silent

Two notebooks sharing a stem export to one directory; the second `rmtree`s the first, both cards point at the winner, and the loser is unreachable. yohou has exactly this (`data-features/signal_processing.py` vs `visualization/signal_processing.py` — 79 View links, 78 unique), and the winner is filesystem-order dependent since the export walk is unsorted while the gallery's is sorted.

Now warns — and **checked before the `MKDOCS_SKIP_NOTEBOOKS` return**. That ordering is the point: a collision is a property of the source tree, and `check_docs` — the only place a warning is fatal — always sets that variable. My first version warned after the return, where nothing listens. The test caught it.

## 4. `<!-- SUBPAGES -->` masked a dropped nav entry

The index enumerates sibling **files**; the sidebar comes from **`mkdocs.yml`**. When a nav entry is dropped the index papers over it — page still listed, still linked, gone from navigation. mkdocs reports not-in-nav pages at **INFO**, which `--strict` doesn't fail on. A copier update deleted a real nav entry exactly this way and **every other guard passed it**. Now reported.

## 5. The card precedes the install step

The card links a playground whose dependencies are declared in the notebook, so running it is an **alternative** to installing — not something installing unlocks. Offering it afterwards asks the reader to do the work and only then mentions they needn't have. Rendered: `Getting Started → Try it interactively → Installation → Your First Example`.

## 6. `actions/checkout` pinned at v7

The template sat at v6 while every repo had been dependabot-bumped to v7. When a release inserts a job whose checkout step is textually identical to an existing one, the patch aligns the repo's v7 line with the **inserted** job and strands v6 on the old one. Two repos hit it. **CI cannot catch it — v6 works** — so it reviews past as a version bump.

## Tests

Each confirmed to fail against v0.24.0 first:

| mutation | test |
|---|---|
| playground url back to stem-only | `test_nested_notebook_playground_link_keeps_its_subdirectory` |
| remove the collision warning | `test_duplicate_notebook_stems_are_reported` |
| drop root-export adoption | `test_root_only_exports_reach_the_api` |
| remove the nav-orphan warning | `test_subpages_reports_a_sibling_missing_from_the_nav` |
| card back after install | `test_companion_card_precedes_the_install_step` |
| any checkout back to v6 | `test_action_pins_are_consistent_and_current` |

The checkout mutation **survived the first pass** — nothing pinned it — so a test was added and the mutation re-run until it failed. The v0.20.1 `ruff-format` guard also fired on a list comprehension that formats differently once `{{ package_name }}` renders; that's the guard working.

318 fast tests pass; `nox -s check_docs` builds strict-clean; pre-commit clean.

## Still open (not in this release)

- **`mkdocs.yml` is unprotectable** and the clobber **produces the correct order** while deleting entries — three agents proved it independently. Only per-section counts catch it.
- `_build_gallery_html` hardcodes `## Tutorials`/`## How-to Guides`, so on yohou's single sectioned index they render as *siblings* of the section headings. Needs a `heading_level` argument.
- `contribute.md.jinja:579` still tells contributors to hand-add index bullets, contradicting auto-discovery.
