### PR TITLE
docs(skill): correct the fan-out skill, and enforce the skill mirror

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -47,11 +47,23 @@ a template bug: report it, do not accommodate it.
 2. **Diff the two pristine renders across the version pair, per `include_examples` value.**
    This tells you what each repo will actually receive, and it is the only thing that makes
    a later "untouched!" result meaningful. Do it before writing the briefs.
-3. **Give each agent a scratch directory unique to its repo.** Agents have collided at the
-   shared scratchpad root and overwritten each other's scripts. One even found a foreign
-   script pointed at another repo's clone and correctly refused to run it.
-4. **Assume the clones are gone.** The scratchpad is wiped between sessions. Have each
-   agent clone fresh from its PR branch; the work lives on GitHub, not on disk.
+3. **Give each agent a scratch directory unique to its repo, and tell it to keep every file
+   it writes inside that directory.** A unique directory is necessary but not sufficient:
+   agents have still collided at the shared scratchpad root. One had a sibling overwrite its
+   script mid-run, and the rewritten script cheerfully reported `LOST: NONE` — out of two
+   empty lists. Another found a foreign script pointed at a different repo's clone and
+   correctly refused to run it. Tell each agent to distrust any file it did not write.
+4. **Do not assume the scratchpad is empty, and do not assume it is wiped.** It is *not*
+   wiped between sessions — agents have found their previous clones intact, at the previous
+   release's ref. That is the more dangerous direction: a stale clone updates from the wrong
+   baseline and every later measurement is against a fiction. Have each agent clone fresh,
+   and verify the ref it actually landed on rather than the ref it asked for. The work lives
+   on GitHub, not on disk.
+5. **Check where each repo's PR branch actually sits, not where `main` sits.** This fleet
+   carries one long-lived `template-update/*` PR per repo whose branch name is frozen at the
+   release that created it; the content advances every release while `main` stays behind. The
+   branch name is not evidence of its version — read `_commit` from `.copier-answers.yml` on
+   the branch and resolve it against the tag list.
 
 ## 3. What every repo must satisfy (the invariants)
 

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -47,11 +47,23 @@ a template bug: report it, do not accommodate it.
 2. **Diff the two pristine renders across the version pair, per `include_examples` value.**
    This tells you what each repo will actually receive, and it is the only thing that makes
    a later "untouched!" result meaningful. Do it before writing the briefs.
-3. **Give each agent a scratch directory unique to its repo.** Agents have collided at the
-   shared scratchpad root and overwritten each other's scripts. One even found a foreign
-   script pointed at another repo's clone and correctly refused to run it.
-4. **Assume the clones are gone.** The scratchpad is wiped between sessions. Have each
-   agent clone fresh from its PR branch; the work lives on GitHub, not on disk.
+3. **Give each agent a scratch directory unique to its repo, and tell it to keep every file
+   it writes inside that directory.** A unique directory is necessary but not sufficient:
+   agents have still collided at the shared scratchpad root. One had a sibling overwrite its
+   script mid-run, and the rewritten script cheerfully reported `LOST: NONE` — out of two
+   empty lists. Another found a foreign script pointed at a different repo's clone and
+   correctly refused to run it. Tell each agent to distrust any file it did not write.
+4. **Do not assume the scratchpad is empty, and do not assume it is wiped.** It is *not*
+   wiped between sessions — agents have found their previous clones intact, at the previous
+   release's ref. That is the more dangerous direction: a stale clone updates from the wrong
+   baseline and every later measurement is against a fiction. Have each agent clone fresh,
+   and verify the ref it actually landed on rather than the ref it asked for. The work lives
+   on GitHub, not on disk.
+5. **Check where each repo's PR branch actually sits, not where `main` sits.** This fleet
+   carries one long-lived `template-update/*` PR per repo whose branch name is frozen at the
+   release that created it; the content advances every release while `main` stays behind. The
+   branch name is not evidence of its version — read `_commit` from `.copier-answers.yml` on
+   the branch and resolve it against the tag list.
 
 ## 3. What every repo must satisfy (the invariants)
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3984,6 +3984,39 @@ def test_subpage_index_summarises_each_page_from_its_own_source(copie_session_de
     assert "An admonition, not the summary." not in out, "an admonition was mistaken for the page's opening prose"
 
 
+def test_the_two_skill_mirrors_stay_byte_identical():
+    """.claude/skills and .github/skills are one skill set read by two tools.
+
+    CLAUDE.md tells contributors to edit both, and nothing enforced it. A convention
+    that lives only in prose is how this repo lost its logos for months: the guard was
+    a heading in a markdown file, and the logos burned underneath it. These two mirrors
+    have already drifted in a way that reddened CI, when .github/skills carried an
+    MD007 exemption that .claude/skills did not and byte-identical files linted
+    differently.
+
+    Tracked files only: the openspec-* skills under .claude/skills are gitignored and
+    deliberately unmirrored, so walking the directory would compare a set that is not
+    supposed to match.
+    """
+    root = Path(__file__).parent.parent
+
+    def tracked(rel):
+        out = subprocess.run(
+            ["git", "ls-files", rel], cwd=root, capture_output=True, text=True, check=True
+        ).stdout.split()
+        return {path[len(rel) + 1 :]: (root / path).read_bytes() for path in out}
+
+    claude, github = tracked(".claude/skills"), tracked(".github/skills")
+
+    assert claude, "no tracked files under .claude/skills; this test would assert nothing"
+    assert set(claude) == set(github), (
+        f"the skill mirrors hold different files: only in .claude/skills "
+        f"{sorted(set(claude) - set(github))}, only in .github/skills {sorted(set(github) - set(claude))}"
+    )
+    differing = sorted(name for name, blob in claude.items() if github[name] != blob)
+    assert not differing, f"these skills have drifted between the two mirrors: {differing}"
+
+
 def test_uv_subprocesses_cannot_retarget_the_runner_venv():
     """No `uv` subprocess may resolve its project environment to the venv running the tests.
 


### PR DESCRIPTION
## Description

Two fixes to how this repo carries its own conventions. Neither touches `template/`, so no generated project is affected and no release is needed.

**The fan-out skill was wrong about the scratchpad.** It said the scratchpad is wiped between sessions. It is not — agents have found their previous clones intact, at the *previous* release's ref. That is the more dangerous direction: a stale clone updates from the wrong baseline and every measurement taken afterwards is against a fiction. The skill also implied a per-repo scratch directory was sufficient; it isn't. A sibling still overwrote one agent's script mid-run, and the rewritten script reported `LOST: NONE` out of two empty lists.

Also adds the fleet's PR-branch model, which cost real time this release: each repo carries one long-lived `template-update/*` PR whose branch name is frozen at the release that created it, while `main` stays behind. `template-update/v0.19.2` currently holds v0.24.0 content. The branch name is not evidence of its version.

**The skill mirror had no enforcement.** `CLAUDE.md` tells contributors to edit `.claude/skills` and `.github/skills` together, and nothing checked it. A convention that lives only in prose is how this repo lost its logos for months — the guard was a heading in a markdown file. These two have already drifted in a way that reddened CI, when `.github/skills` carried an MD007 exemption that `.claude/skills` did not and byte-identical files linted differently.

The new test compares **tracked files only**: the `openspec-*` skills under `.claude/skills` are gitignored and deliberately unmirrored, so walking the directory would compare a set that is not supposed to match.

## Type of Change

- [x] Documentation
- [x] Test coverage

## Verification

- Mutation-verified both ways: content drift (one appended byte) fails it, and a file present in only one mirror fails it. It also caught a real drift while being written — a `git checkout` during the mutation run reverted one mirror to HEAD and the test named the exact file.
- Full suite: 330 passed, 4 skipped (fresh venv, 4 workers, matching CI).
- `pre-commit run --all-files` clean on a cold `.rumdl_cache` (a stale cache gives a false clean).
