### PR TITLE
fix(template)!: pin every action to what the fleet actually runs

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
@@ -101,7 +101,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: {% raw %}${{ env.dists-artifact-name }}{% endraw %}
           path: dist/*

--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -36,7 +36,7 @@ jobs:
         run: nox -s test_docstrings
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: {% raw %}${{ matrix.python-version == '3.12' && env.CODECOV_TOKEN != '' }}{% endraw %}
         with:
           token: {% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Create issue on failure
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const title = '🔴 Nightly build failed';

--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -74,7 +74,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Download release artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: changelog.yml
           name: {% raw %}${{ env.dists-artifact-name }}{% endraw %}
@@ -123,7 +123,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download release artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: changelog.yml
           name: {% raw %}${{ env.dists-artifact-name }}{% endraw %}

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -134,7 +134,7 @@ jobs:
           file: {% raw %}'${{ github.workspace }}/junit.${{ matrix.python-version }}.xml'{% endraw %}
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         if: {% raw %}${{ matrix.python-version == '{% endraw %}{{ min_python_version }}{% raw %}' && env.CODECOV_TOKEN != '' }}{% endraw %}
         with:
           token: {% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3476,29 +3476,65 @@ def test_docs_use_no_em_or_en_dashes(copie_session_default):
     assert not offenders, "seeded docs punctuate with em/en dashes:\n" + "\n".join(offenders)
 
 
+# What the fleet actually runs, verified against all seven generated repos. A pin the
+# fleet does not run is not a stale version number, it is a permanent local delta in
+# every repo that copier must replay on every release -- see the test below.
+EXPECTED_ACTION_PINS = {
+    "actions/checkout": "v7",
+    "actions/github-script": "v9",
+    "actions/upload-artifact": "v7",
+    "amannn/action-semantic-pull-request": "v6",
+    "astral-sh/setup-uv": "v7",
+    "codecov/codecov-action": "v7",
+    "codecov/test-results-action": "v1",
+    "dawidd6/action-download-artifact": "v21",
+    "peter-evans/create-pull-request": "v8",
+    "pypa/gh-action-pypi-publish": "release/v1",
+    "taiki-e/install-action": "v2",
+}
+
+
 def test_action_pins_are_consistent_and_current(copie_session_default):
-    """Every workflow pins the same actions/checkout, and it is the one the fleet runs.
+    """Every workflow pins one version per action, and it is the one the fleet runs.
 
-    The template pinned @v6 while every generated repo had been dependabot-bumped
-    to @v7. That gap is not cosmetic: when a release inserts a job whose checkout
-    step is textually identical to an existing one, the patch aligns the repo's v7
-    line with the *inserted* job and pushes the template's v6 down into the old
-    one. Two repos hit exactly that. CI cannot catch it -- v6 works -- so it
-    reviews past as a version bump.
+    A pin the fleet does not run is not a stale version number. Dependabot bumps the
+    repo, so the difference becomes a local delta copier must replay on every release,
+    and when a release touches that workflow the hunk can fail and take the repo's own
+    bump down with it -- silently, because the older version still works and CI stays
+    green. The template pinned checkout @v6 against a fleet on @v7 and two repos had
+    the pin stranded on the wrong job. Then v0.25.0 fixed checkout alone, and the very
+    next fan-out found `github-script` doing it again in two more repos: the repo's
+    v8->v9 bump shared a hunk with its v6->v7 checkout bump, the hunk stopped applying
+    once the template shipped v7 itself, and github-script silently fell back to v8.
 
-    Pinned rather than merely self-consistent: consistency alone is satisfied by
-    the whole fleet drifting together, which is the state this fixes.
+    This asserted only actions/checkout while four other pins matched no repo in the
+    fleet, which is why it passed throughout. Checking every action is the point: a
+    partial check that reads as a complete one is worse than none.
+
+    Pinned rather than merely self-consistent: consistency alone is satisfied by the
+    whole fleet drifting together, which is the state this fixes.
     """
     workflows = sorted((copie_session_default.project_dir / ".github" / "workflows").glob("*.yml"))
     assert workflows, "no workflows generated"
 
     pins = {}
     for wf in workflows:
-        for match in re.finditer(r"uses:\s*actions/checkout@(\S+)", wf.read_text(encoding="utf-8")):
-            pins.setdefault(match.group(1), []).append(wf.name)
+        for match in re.finditer(r"uses:\s*([\w./-]+)@(\S+)", wf.read_text(encoding="utf-8")):
+            pins.setdefault(match.group(1), {}).setdefault(match.group(2), []).append(wf.name)
 
-    assert pins, "no actions/checkout usage found; this test would assert nothing"
-    assert set(pins) == {"v7"}, f"actions/checkout pins are {dict(pins)}; expected every one at v7"
+    assert pins, "no `uses:` action pins found at all; this test would assert nothing"
+
+    split = {a: {v: sorted(f) for v, f in vs.items()} for a, vs in pins.items() if len(vs) > 1}
+    assert not split, f"these actions are pinned at more than one version: {split}"
+
+    actual = {action: next(iter(versions)) for action, versions in pins.items()}
+    unknown = sorted(set(actual) - set(EXPECTED_ACTION_PINS))
+    assert not unknown, (
+        f"new actions {unknown} are pinned but absent from EXPECTED_ACTION_PINS; check what the "
+        f"fleet runs and record it, rather than letting a fresh pin drift from day one"
+    )
+    wrong = {a: (v, EXPECTED_ACTION_PINS[a]) for a, v in actual.items() if EXPECTED_ACTION_PINS[a] != v}
+    assert not wrong, f"pins disagree with what the fleet runs (action: template -> expected): {wrong}"
 
 
 def test_nav_order_is_diataxis_with_reference_last(copie_session_default, copie_minimal):


### PR DESCRIPTION
## Description

v0.25.0 pinned `actions/checkout` to the fleet's v7 and stopped there. The very next fan-out found the identical bug in **four more repos**, on a different action.

Each repo's dependabot bump of `github-script` v8→v9 shared a hunk with its own v6→v7 checkout bump. Once v0.25.0 shipped checkout v7 itself, that hunk no longer applied, was rejected, and took the github-script bump down with it — silently falling back to v8. kedro-dagster lost `codecov` v7→v5 **and its entire `test-versions` job** the same way. Four agents hit this independently; none of it was visible in the update's own hunks, only in a whole-file diff against baseline.

**A pin the fleet does not run is not a stale version number.** Dependabot bumps the repo, so the gap becomes a permanent local delta that copier must replay on *every* release, and each replay is a chance to strand it. CI cannot catch it, because the older version still works.

| action | template | fleet runs | now |
|---|---|---|---|
| `actions/github-script` | v8 | **v9** (7/7) | v9 |
| `actions/upload-artifact` | v6 | **v7** (7/7) | v7 |
| `codecov/codecov-action` | v5 | v7 (5), v6 (2) | v7 |
| `dawidd6/action-download-artifact` | v6 | v21 (5), v20 (2) | v21 |

`pypa/gh-action-pypi-publish@release/v1` was already correct — an earlier sweep of mine truncated it to `release` with a regex that stopped at the slash, and the new test caught my own bad measurement.

## Type of Change

- [x] Bug fix
- [x] Test coverage

## Verification

- Every `with:` block is byte-identical to what yohou and kedro-dagster already run green at these versions, so this removes a delta rather than introducing risk.
- `test_action_pins_are_consistent_and_current` asserted **only** `actions/checkout` while four other pins matched no repo in the fleet — which is exactly why it stayed green while this shipped. It now checks every action, rejects an action pinned at two versions, and fails on a new unrecorded action so a fresh pin cannot drift from day one.
- Mutation-verified: reverting github-script to v8 fails it; pinning one action at two versions fails it; reverting codecov to v5 fails it; aligned pins pass.
- Full suite 329 passed / 4 skipped; `pre-commit` clean on a cold `.rumdl_cache`.
