### PR TITLE
fix(template): make both release jobs read the same version

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -113,7 +113,7 @@ jobs:
         run: |
           # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0")
           PR_TITLE="{% raw %}${{ github.event.pull_request.title }}{% endraw %}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -4025,6 +4025,36 @@ def test_subpage_index_summarises_each_page_from_its_own_source(copie_session_de
     assert "An admonition, not the summary." not in out, "an admonition was mistaken for the page's opening prose"
 
 
+def test_release_jobs_agree_on_the_version_they_are_shipping(copie_session_default):
+    """Both publish-release jobs must read the same version out of the same PR title.
+
+    create-release used a pre-release-aware pattern and pypi-publish a plain one, so
+    for `v1.2.0-alpha.1` the first cut a release for v1.2.0-alpha.1 while the second
+    went looking for v1.2.0's artifacts and found nothing. Nothing catches it until a
+    project ships its first pre-release, and sklearn-optuna carries a local patch to
+    the second job -- which means every generated project needs the same patch.
+
+    Runs the patterns rather than comparing them: two different spellings of a correct
+    regex are fine, and one spelling used twice is not the property under test.
+    """
+    workflow = copie_session_default.project_dir / ".github" / "workflows" / "publish-release.yml"
+    assert workflow.is_file(), "no publish-release workflow; this test would assert nothing"
+
+    patterns = re.findall(r"grep -oP '([^']+)'", workflow.read_text(encoding="utf-8"))
+    assert patterns, "no version-extraction pattern found; this test would assert nothing"
+
+    title = "chore(release): update CHANGELOG.md for v1.2.0-alpha.1"
+    extracted = set()
+    for pattern in patterns:
+        found = re.search(pattern.replace(r"\.", r"\."), title)
+        extracted.add(found.group(0) if found else None)
+
+    assert extracted == {"v1.2.0-alpha.1"}, (
+        f"the release jobs disagree about which version this PR ships: {extracted}. A job that "
+        f"reads v1.2.0 will look for artifacts the job that read v1.2.0-alpha.1 never published"
+    )
+
+
 def test_nightly_tests_the_pythons_the_project_supports(copie):
     """The nightly matrix follows the answers, like every other matrix does.
 


### PR DESCRIPTION
## Description

Found by the v0.25.2 fan-out. `publish-release.yml` extracts the release version **twice, with two different regexes**:

| job | pattern | reads `v1.2.0-alpha.1` as |
|---|---|---|
| `create-release` | `v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?` | `v1.2.0-alpha.1` |
| `pypi-publish` | `v[0-9]+\.[0-9]+\.[0-9]+` | **`v1.2.0`** |

So on a pre-release, `create-release` cuts a release for `v1.2.0-alpha.1` while `pypi-publish` goes looking for `v1.2.0`'s artifacts and finds nothing. Nothing catches it until a project ships its first pre-release — and **sklearn-optuna already carries a local patch to the second job**, which is the tell: every generated project needs the same patch, so the fix belongs upstream.

## Type of Change

- [x] Bug fix
- [x] Test coverage

## Verification

- Mutation-verified: restoring the pre-release-blind regex in `pypi-publish` alone fails the test; aligned passes.
- The test **runs** both patterns against a realistic pre-release PR title rather than comparing them as strings. Two different spellings of a correct regex are both fine, and "one spelling used twice" is not the property under test — the property is that both jobs resolve the same version.
- Full suite 333 passed / 4 skipped; `pre-commit` clean on a cold `.rumdl_cache`.
