### PR TITLE
fix(template): link See Also everywhere it renders, and stop root exports 404ing

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -111,7 +111,7 @@ jobs:
       - name: Find release tag
         id: find_tag
         run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0")
+          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
           PR_TITLE="{% raw %}${{ github.event.pull_request.title }}{% endraw %}"
           VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -1426,7 +1426,7 @@ def _split_see_also_entries(inner):
     return [" ".join(parts) for parts in entries]
 
 
-def _resolve_see_also_url(name):
+def _resolve_see_also_url(name, prefix):
     """Resolve a See Also entry naming a project symbol to a URL, or None.
 
     A dotted name whose leading segment is not this package is external and is
@@ -1436,6 +1436,12 @@ def _resolve_see_also_url(name):
     lookup is keyed by *short* name, so a dotted external name always misses it,
     and stripping the qualifier first would let ``sklearn.linear_model.Ridge``
     collide with a project symbol called ``Ridge``.
+
+    The URL is built from *prefix* rather than a bare ``../``. A See Also block
+    renders on any page carrying a docstring, not only under
+    ``pages/api/generated/``, and ``../`` is the right answer from exactly one
+    depth. Same reasoning as ``_site_root_prefix``, which says it plainly: a
+    hardcoded prefix silently 404s every link once the page moves.
     """
     package = "{{ package_name }}"
     if "." in name and name.split(".", 1)[0] != package:
@@ -1444,7 +1450,7 @@ def _resolve_see_also_url(name):
     short_name = name.rsplit(".", 1)[-1]
     project_root = Path(__file__).parent.parent
     qualified = _get_api_name_lookup(project_root).get(short_name)
-    return f"../{qualified}/" if qualified is not None else None
+    return f"{prefix}pages/api/generated/{qualified}/" if qualified is not None else None
 
 
 def _external_autoref(name, title):
@@ -1496,9 +1502,9 @@ def _resolve_member_identifier(name):
     return f"{qualified_head}.{rest}"
 
 
-def _link_entry(name, title, colon, entry):
+def _link_entry(name, title, colon, entry, prefix):
     """Render one See Also entry: project link, deferred external ref, or as-is."""
-    url = _resolve_see_also_url(name)
+    url = _resolve_see_also_url(name, prefix)
     if url:
         return f'<a href="{url}">{title}</a>{colon}'
     member_identifier = _resolve_member_identifier(name)
@@ -1665,7 +1671,7 @@ def _linkify_glossary_terms(html, page, project_root):
     return linker.get_html()
 
 
-def _linkify_see_also(html):
+def _linkify_see_also(html, prefix):
     """Turn the names in a rendered See Also section into links.
 
     Must run while the ``<details class="see-also">`` container still exists --
@@ -1684,7 +1690,7 @@ def _linkify_see_also(html):
             code_match = re.fullmatch(r"<code>([^<]+)</code>", token)
             name = code_match.group(1) if code_match else token
             title = f"<code>{name}</code>" if code_match else name
-            return lead + _link_entry(name, title, colon, token + colon) + rest
+            return lead + _link_entry(name, title, colon, token + colon, prefix) + rest
 
         def _linkify_inner(inner):
             # Leave an author's explicit [Name][target] reference alone: they have
@@ -2034,6 +2040,16 @@ def on_page_content(html, page, config, files):
     """Post-process HTML: API page TOC and content restructuring."""
     src = page.file.src_path
 
+    # Keyed on the markup, not on where the page lives: mkdocstrings emits a See
+    # Also block wherever a docstring is rendered, and a project is free to put
+    # ::: directives on a curated reference page. Gating this on
+    # `pages/api/generated/` left those blocks raw -- kedro-dagster's datasets
+    # page rendered three entries as plain text while the same names linked fine
+    # on the generated pages, which is exactly the shape of "it works where we
+    # looked". --strict never sees it: this is our own HTML.
+
+    html = _linkify_see_also(html, _site_root_prefix(page))
+
     # Process generated API member pages (per-class/function detail pages)
     if src.startswith("pages/api/generated/"):
         # ORDER IS LOAD-BEARING: mkdocstrings emits See Also as a
@@ -2041,7 +2057,6 @@ def on_page_content(html, page, config, files):
         # dissolves that block for class-level docstrings.  Linkifying after it
         # silently does nothing for class-level See Also sections -- the
         # majority of them -- while appearing to work for method-level ones.
-        html = _linkify_see_also(html)
         html = _process_api_page_content(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -566,8 +566,12 @@ def _build_api_table_html(project_root, prefix):
 
     for module_name, members in scans:
         module_label = _qualified_name(module_name, "").rstrip(".") or "{{ package_name }}"
-        # A root export has no module page to point at; the API index is its home.
-        module_href = f"{prefix}pages/api/{module_name}/" if module_name else f"{prefix}pages/api/"
+        # A root export has no module page, and there is nothing to link it to: this
+        # pointed at pages/api/, which is only a directory of generated module pages
+        # and has no index of its own, so every root export's Module cell was a 404.
+        # Nothing catches that -- the cell is raw HTML from this hook, which --strict
+        # never validates, and only a project with a root-only export renders one.
+        module_href = f"{prefix}pages/api/{module_name}/" if module_name else None
 
         for cls in members["classes"]:
             qualified = _qualified_name(module_name, cls["name"])
@@ -588,11 +592,12 @@ def _build_api_table_html(project_root, prefix):
     for name, kind, module_label, module_href, desc, qualified in rows:
         href = f"{prefix}pages/api/generated/{qualified}/"
         badge_cls = _type_badge_cls.get(kind, "")
+        module_cell = f'<a href="{module_href}">{module_label}</a>' if module_href else module_label
         tbody_lines.append(
             f"      <tr>"
             f'<td><a href="{href}"><code>{name}</code></a></td>'
             f'<td><span class="api-badge {badge_cls}">{kind}</span></td>'
-            f'<td><a href="{module_href}">{module_label}</a></td>'
+            f"<td>{module_cell}</td>"
             f"<td>{desc}</td>"
             f"</tr>"
         )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3732,6 +3732,54 @@ def test_duplicate_notebook_stems_are_reported(copie_session_default):
             d.rmdir()
 
 
+def test_api_table_module_links_point_at_pages_that_exist(copie_session_minimal):
+    """Every Module cell links to a module page that is generated, or does not link.
+
+    A root export belongs to no submodule and has no module page. The cell pointed at
+    `pages/api/` regardless -- but that is only the directory the generated module
+    pages live in; it has no index of its own, so the link 404'd. yohou-nixtla found
+    it in production on `BaseNixtlaForecaster`, its one root export.
+
+    Nothing catches this: the cell is raw HTML this hook emits, which mkdocs --strict
+    never validates, and only a project that has a root-only export renders such a
+    row at all. So the check is that every Module href corresponds to a module the
+    hook actually generates a page for -- not that this one string is gone.
+    """
+    project_dir = copie_session_minimal.project_dir
+    pkg = project_dir / "src" / "minimal_project"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "_base.py").write_text(
+        '"""Private module."""\n\n\nclass BaseThing:\n    """A public base class in a private module."""\n',
+        encoding="utf-8",
+    )
+    (pkg / "widgets.py").write_text('"""Widgets."""\n\n\nclass Widget:\n    """A widget."""\n', encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        '"""Pkg."""\n\nfrom minimal_project._base import BaseThing\n'
+        "from minimal_project.widgets import Widget\n\n"
+        '__all__ = ["BaseThing", "Widget"]\n',
+        encoding="utf-8",
+    )
+    hooks = _load_hooks(project_dir, "api_module_links")
+    hooks._SUBMODULE_CACHE = None
+    hooks._API_NAME_LOOKUP_CACHE = None
+
+    html = hooks._build_api_table_html(project_dir, "")
+    assert "BaseThing" in html, "no root export rendered; this test would assert nothing"
+
+    generated = {mod["module_name"] for mod in hooks._get_submodules(project_dir)}
+    assert generated, "no submodules found; this test would assert nothing"
+
+    # The Name cell links too, at pages/api/generated/<qualified>/, and wraps its
+    # label in <code>. Only the Module cell does not, which is what separates them.
+    module_links = re.findall(r'<td><a href="pages/api/([^"]*)">(?!<code>)', html)
+    assert module_links, "no Module cell links at all; the row shape changed and this asserts nothing"
+    for target in module_links:
+        assert target.strip("/") in generated, (
+            f"a Module cell links to pages/api/{target}, which the hook generates no page for; "
+            f"it generates pages only for {sorted(generated)}"
+        )
+
+
 def test_root_only_exports_reach_the_api(copie_session_minimal):
     """A symbol exported only from the package root still gets a page and a table row.
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1693,8 +1693,12 @@ def test_see_also_links_class_level_entries(copie_session_minimal):
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "plain entry not linked"
-    assert '<a href="../minimal_project.models.Gamma/"><code>Gamma</code></a>' in out, "code-span entry not linked"
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out, (
+        "plain entry not linked"
+    )
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Gamma/"><code>Gamma</code></a>' in out, (
+        "code-span entry not linked"
+    )
     assert "Plain numpydoc." in out, "description text was altered"
     assert not re.search(r"<a[^>]*>NotARealThing", out), "unresolvable entry was linked"
     # The container is gone by the end -- proof the linkifier ran before the restructure.
@@ -1712,7 +1716,9 @@ def test_see_also_links_method_level_entries(copie_session_minimal):
     html = _see_also_page("minimal_project", "Alpha", "Beta : Class level.", method_entries="Gamma : Method level.")
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "method-level entry not linked"
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Gamma/">Gamma</a>' in out, (
+        "method-level entry not linked"
+    )
 
 
 def _write_glossary(project_dir, extra=""):
@@ -1867,19 +1873,40 @@ def test_see_also_linkify_runs_before_restructure(copie_session_minimal):
     )
 
 
-def test_see_also_scoped_to_generated_api_pages(copie_session_minimal):
-    """A See Also block on a non-generated page is not rewritten."""
+def test_see_also_links_on_any_page_that_renders_a_docstring(copie_session_minimal):
+    """A See Also block is linkified wherever it renders, not only under pages/api/generated/.
+
+    mkdocstrings emits the block wherever a docstring is rendered, and a project is
+    free to put ::: directives on a curated reference page. This was gated on the
+    src_path, so those blocks stayed raw: kedro-dagster's datasets page rendered
+    three entries as plain text while the same names linked correctly on the
+    generated pages -- the exact shape of "it works everywhere we looked". Nothing
+    catches it, because the block is our own HTML and --strict does not check it.
+
+    The URL must come from the page's own depth. `../` is right from exactly one
+    place, so ungating without that would have turned unlinked text into 404s.
+    """
     project_dir = copie_session_minimal.project_dir
     _write_models_module(project_dir, "minimal_project")
-    hooks = _load_hooks(project_dir, "seealso_scope")
+    hooks = _load_hooks(project_dir, "seealso_any_page")
     hooks._API_NAME_LOOKUP_CACHE = None
     hooks._SUBMODULE_CACHE = None
 
     html = '<details class="see-also" open><summary>See Also</summary><p>Beta : Nope.</p></details>'
-    page = _FakePage("pages/api/models.md", "pages/api/models/index.html")
-    out = hooks.on_page_content(html, page, {}, None)
 
-    assert out == html, "linkification leaked outside pages/api/generated/"
+    # A curated reference page, two deep -- kedro-dagster's shape.
+    page = _FakePage("pages/reference/datasets.md", "pages/reference/datasets/index.html")
+    out = hooks.on_page_content(html, page, {}, None)
+    assert '<a href="../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out, (
+        "a See Also block on a curated page was left raw, so its entries render as plain text"
+    )
+
+    # The same block, rendered deeper, must resolve to the same page from its own depth.
+    deep = _FakePage("pages/api/generated/minimal_project.models.Alpha.md", "pages/api/generated/x/index.html")
+    out_deep = hooks.on_page_content(html, deep, {}, None)
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out_deep, (
+        "the See Also URL is not built from the page's own depth, so it 404s once the page moves"
+    )
 
 
 def test_see_also_external_name_defers_to_autorefs(copie_session_minimal):
@@ -1903,7 +1930,7 @@ def test_see_also_external_name_defers_to_autorefs(copie_session_minimal):
         "external name was not deferred to autorefs"
     )
     # The project symbol is still resolved here, against the page set we own.
-    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out
 
 
 def test_see_also_bare_unresolvable_name_is_left_alone(copie_session_minimal):
@@ -1936,9 +1963,9 @@ def test_see_also_qualified_name_matches_bare_form(copie_session_minimal):
     html = _see_also_page("minimal_project", "Alpha", "minimal_project.models.Beta : Qualified.")
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Beta/">minimal_project.models.Beta</a>' in out, (
-        "qualified project name did not resolve to the same page as the bare form"
-    )
+    assert (
+        '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">minimal_project.models.Beta</a>' in out
+    ), "qualified project name did not resolve to the same page as the bare form"
 
 
 def _write_notebook(project_dir, stem, gallery_body, imports=""):
@@ -2553,7 +2580,9 @@ def test_see_also_links_list_form_entries(copie_session_minimal):
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "list-form entry was not linked"
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out, (
+        "list-form entry was not linked"
+    )
 
 
 def test_see_also_leaves_explicit_cross_references_alone(copie_session_minimal):
@@ -2699,7 +2728,9 @@ def test_see_also_leaves_description_text_alone(copie_session_minimal):
     html = _see_also_page("minimal_project", "Alpha", "Beta : Note: a colon-terminated word in the description.")
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Beta/">Beta</a>' in out, "the entry name was not linked"
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Beta/">Beta</a>' in out, (
+        "the entry name was not linked"
+    )
     assert not re.search(r"<a[^>]*>Note</a>", out), "a word in the description was linkified as an entry"
     assert "Note: a colon-terminated word in the description." in out, "description text was altered"
 
@@ -2736,7 +2767,9 @@ def test_see_also_does_not_linkify_names_outside_the_section(copie_session_minim
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
 
-    assert '<a href="../minimal_project.models.Gamma/">Gamma</a>' in out, "the See Also entry was not linked"
+    assert '<a href="../../../../pages/api/generated/minimal_project.models.Gamma/">Gamma</a>' in out, (
+        "the See Also entry was not linked"
+    )
     assert not re.search(r"<a[^>]*>Beta</a>", out), "a name outside the See Also section was linkified"
 
 
@@ -3318,7 +3351,7 @@ def test_multiple_see_also_entries_render_one_per_line(copie_session_minimal):
 
     entries = "Alpha : The first one.\nBeta : The second one.\nGamma : The third one."
     html = _see_also_page("minimal_project", "Widget", entries)
-    out = hooks._linkify_see_also(html)
+    out = hooks._linkify_see_also(html, "../../../../")
 
     items = re.findall(r"<li>(.*?)</li>", out, re.DOTALL)
     assert len(items) == 3, f"3 See Also entries rendered as {len(items)} list item(s); they run together on one line"
@@ -3334,7 +3367,7 @@ def test_a_single_see_also_entry_is_not_made_a_list(copie_session_minimal):
     _write_models_module(project_dir, "minimal_project")
     hooks = _load_hooks(project_dir, "see_also_single")
 
-    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", "Alpha : Only one."))
+    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", "Alpha : Only one."), "../../../../")
     assert "<li>" not in out, "a lone See Also entry was turned into a single-item list"
     assert "Alpha" in out
 
@@ -3351,7 +3384,7 @@ def test_see_also_description_wrapping_onto_a_second_line_stays_one_entry(copie_
     hooks = _load_hooks(project_dir, "see_also_wrapped")
 
     entries = "Alpha : A description long enough that it\n    wraps onto a second line.\nBeta : Short."
-    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", entries))
+    out = hooks._linkify_see_also(_see_also_page("minimal_project", "Widget", entries), "../../../../")
 
     items = re.findall(r"<li>(.*?)</li>", out, re.DOTALL)
     assert len(items) == 2, f"a wrapped description split into extra entries: {len(items)} items"


### PR DESCRIPTION
## Description

Three defects the v0.26.0 fan-out surfaced in production. All three are in HTML this hook emits, which `mkdocs --strict` never validates — so every one of them shipped green.

**1. See Also was only linkified on generated API pages.** mkdocstrings emits the block wherever a docstring renders, and a project may put `:::` directives on a curated reference page. The gate was `src_path.startswith("pages/api/generated/")`, so those blocks stayed raw: kedro-dagster's `datasets` page rendered three entries as plain text while *the same names linked correctly on the generated pages*. That's the shape of "it works everywhere we looked."

**2. The See Also URL hardcoded its depth.** `../{qualified}/` is right from exactly one place, so fixing (1) alone would have turned unlinked text into 404s. It now builds from `_site_root_prefix`, whose own docstring already made this argument for every other link this file injects: *"a hardcoded `../../` only works if the page never moves."* The two are coupled and land together.

**3. Root exports linked to a page that is never built.** A root export belongs to no submodule and has no module page, but the API table's Module cell pointed at `pages/api/` — only the *directory* the generated pages live in, with no index of its own. yohou-nixtla found it on `BaseNixtlaForecaster` (RTD: `pages/api/` → 404, `pages/api/stats/` → 200). It reproduces in the template's own render, and is invisible because only a project *with* a root-only export renders such a row. Root exports now render their module as plain text, which is what it is.

Also aligns the comment above `pypi-publish`'s version regex with `create-release`'s. v0.26.0 matched the regexes and not the comments, so the jobs documented different formats while behaving identically — and the mismatch **reverted sklearn-optuna's own corrected comment** on update.

## Type of Change

- [x] Bug fix
- [x] Test coverage

## Verification

- Mutation-verified, each independently: re-gating the linkifier fails the new test; restoring the `pages/api/` href fails the Module-link test; both pass fixed.
- The Module-link test asserts **every** Module href names a module the hook generates a page for, not that one string is gone. Writing it exposed that a row has *two* links into `pages/api/` — the Name cell also points there, told apart only by its `<code>` wrapper.
- The new See Also test drives a curated page (depth 3) *and* a generated page (depth 4) and requires each to resolve to the same target from its own depth — the property that (2) broke.
- Full suite 334 passed / 4 skipped; `pre-commit` clean on a cold `.rumdl_cache`.

## A test I replaced, deliberately

`test_see_also_scoped_to_generated_api_pages` asserted the gate itself — *"A See Also block on a non-generated page is not rewritten"* — with no reason given. It restated the code, and the code was wrong. Contrast the skills-mirror tests, which explain *why* and which I left alone after trying to change them. Ordering inside `on_page_content` is unchanged and still covered: linkify must precede `_process_api_page_content`, which dissolves the block it matches.
