### PR TITLE
docs(skill): stop telling every agent to install a browser

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -227,11 +227,28 @@ Binaries are the exception: copier rewrites them regardless of delta, so "the ol
 overwrote it, the new one didn't" *is* a valid A/B on identical inputs.
 
 **Verify by rendering, not by reading.** Count in the built HTML, scoped to `<article>` —
-the ToC sidebar inflates counts ~3×. For JS behaviour (the DataTables API filter) drive a
-real headless browser; note DataTables **2.x** uses `.dt-search`, not 1.x's
-`#api-table_filter`, and two agents nearly reported a missing filter box over that alone.
+the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits
 multi-line `title=` attributes and the split cuts inside the tag, silently dropping entries.
+And do not key a See Also audit on `<details class="see-also">` in *final* HTML: there is
+none, because `_process_api_page_content` dissolves that container. Zero hits reads as a
+clean pass and is total blindness — two agents found this independently. The real markup is
+a heading with `id="see-also"` (h3 generated, h2 hand-written), and the surfaces do not
+share a shape: h2/h3 are `<ul><li>`, `details.see-also` is `<p>` plus newlines, so a
+single-shape counter silently collapses each list to one entry. **Make the audit abort on
+zero rather than report all-clear.**
+
+**Do NOT drive a headless browser for the DataTables filter.** An earlier version of this
+file said to, and every agent that read it dutifully installed one — seven browsers per
+release, to re-verify the same code. DataTables is **pinned at 2.2.2** and jQuery at 3.7.1
+in `mkdocs.yml`, the init script is emitted by `hooks.py`, and `hooks.py` is Tier 1 and
+already verified byte-identical everywhere. So the JS is pinned, template-owned and
+identical in all seven repos. The `.dt-search` vs 1.x `#api-table_filter` incident that
+produced that advice was agents using **1.x selectors against a 2.x pin** — a checker bug,
+not a drift risk; the pin is the guard. Check it statically instead: `<table id="api-table">`
+present, the init script emitted, the pinned CDN URLs returning 200 — and say plainly that
+this does **not** prove the JS executes. That is the honest limit, and the right trade.
+If the pin is ever bumped, that is when a real browser check earns its cost.
 
 **Prefer a no-op to churn.** If a repo already satisfies the change, say so plainly and
 push nothing.

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -227,11 +227,28 @@ Binaries are the exception: copier rewrites them regardless of delta, so "the ol
 overwrote it, the new one didn't" *is* a valid A/B on identical inputs.
 
 **Verify by rendering, not by reading.** Count in the built HTML, scoped to `<article>` —
-the ToC sidebar inflates counts ~3×. For JS behaviour (the DataTables API filter) drive a
-real headless browser; note DataTables **2.x** uses `.dt-search`, not 1.x's
-`#api-table_filter`, and two agents nearly reported a missing filter box over that alone.
+the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits
 multi-line `title=` attributes and the split cuts inside the tag, silently dropping entries.
+And do not key a See Also audit on `<details class="see-also">` in *final* HTML: there is
+none, because `_process_api_page_content` dissolves that container. Zero hits reads as a
+clean pass and is total blindness — two agents found this independently. The real markup is
+a heading with `id="see-also"` (h3 generated, h2 hand-written), and the surfaces do not
+share a shape: h2/h3 are `<ul><li>`, `details.see-also` is `<p>` plus newlines, so a
+single-shape counter silently collapses each list to one entry. **Make the audit abort on
+zero rather than report all-clear.**
+
+**Do NOT drive a headless browser for the DataTables filter.** An earlier version of this
+file said to, and every agent that read it dutifully installed one — seven browsers per
+release, to re-verify the same code. DataTables is **pinned at 2.2.2** and jQuery at 3.7.1
+in `mkdocs.yml`, the init script is emitted by `hooks.py`, and `hooks.py` is Tier 1 and
+already verified byte-identical everywhere. So the JS is pinned, template-owned and
+identical in all seven repos. The `.dt-search` vs 1.x `#api-table_filter` incident that
+produced that advice was agents using **1.x selectors against a 2.x pin** — a checker bug,
+not a drift risk; the pin is the guard. Check it statically instead: `<table id="api-table">`
+present, the init script emitted, the pinned CDN URLs returning 200 — and say plainly that
+this does **not** prove the JS executes. That is the honest limit, and the right trade.
+If the pin is ever bumped, that is when a real browser check earns its cost.
 
 **Prefer a no-op to churn.** If a repo already satisfies the change, say so plainly and
 push nothing.


### PR DESCRIPTION
## Description

**This file told every agent to install a browser, and they did** — seven per release, each re-verifying the same code. That advice was mine and it was overfit to a single incident.

DataTables is **pinned at 2.2.2** (jQuery at 3.7.1) in `mkdocs.yml`, the init script is emitted by `hooks.py`, and `hooks.py` is Tier 1 and already verified byte-identical in every repo every release. So the JS is pinned, template-owned and identical fleet-wide — a per-repo browser run proves nothing a single check wouldn't.

The `.dt-search` vs 1.x `#api-table_filter` incident that produced the advice was agents using **1.x selectors against a 2.x pin**: a checker bug, not a drift risk. **The pin is the guard.** A bump is when a real browser check would earn its cost.

The replacement is the static check — `<table id="api-table">` present, init script emitted, pinned CDN URLs returning 200 — and it **says plainly that this does not prove the JS executes**. That's the honest limit of the cheap check, not a claim to have replaced the browser.

Also records the See Also audit trap **two agents found independently**: keying on `<details class="see-also">` in *final* HTML returns zero on every page, because `_process_api_page_content` dissolves that container before the end. Zero reads as a clean pass and is total blindness — so the audit must **abort on zero**. And the surfaces don't share a shape: h2/h3 are `<ul><li>` while `details.see-also` is `<p>` plus newlines, so a single-shape counter silently collapses each list to one entry (one agent's first count came out 63/17 instead of 129/129 that way).

## Type of Change

- [x] Documentation

## Verification

- `test_the_two_skill_mirrors_stay_byte_identical` passes; both mirrors updated together.
- `pre-commit` clean on a cold `.rumdl_cache`.
- The pin claim is measured from `template/mkdocs.yml.jinja`, not recalled: `cdn.datatables.net/2.2.2/js/dataTables.min.js` and `code.jquery.com/jquery-3.7.1.min.js`.

## Caveat

The static check is **strictly weaker** than a browser: it cannot catch a JS exception or a class rename. The argument is that the pin plus Tier 1 byte-identity makes that an acceptable trade — not that the risk is zero.
