### PR TITLE
fix(template): cover project-owned docs scripts in the ruff ignores

### DIFF
--- a/template/noxfile.py.jinja
+++ b/template/noxfile.py.jinja
@@ -277,9 +277,16 @@ def fix(session: nox.Session) -> None:
     )
 
 
-@nox.session(venv_backend="uv")
+@nox.session(python=PYTHON_VERSIONS[0], venv_backend="uv")
 def build_steps(session: nox.Session) -> None:
     """Run the documentation build steps without building the site.
+
+    Pinned to the lowest supported Python for the same reason ``check_docs`` is:
+    an unpinned session takes whatever interpreter the caller happens to have,
+    which can sit outside ``requires-python`` and die in ``uv sync`` before any
+    step runs. Two projects in this fleet cap at 3.13, so on a machine defaulting
+    to 3.14 an unpinned session fails for a reason that has nothing to do with
+    the docs.
 
     ``docs/hooks.py`` calls these from ``on_pre_build``/``on_post_build`` so that
     ``mkdocs serve`` regenerates on a source edit, but none of them needs a theme,

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -128,17 +128,20 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["ARG", "S101", "T201", "PLR2004"]  # Allow assert statements, prints, and magic values in tests
-# The hooks implement signatures they do not choose -- mkdocs' event hooks --
-# so an unused parameter is the interface, not an oversight. ARG002 is the
-# method-level twin of ARG001. SIM108 was dropped when the build steps moved out:
-# nothing in this file trips it any more, and an ignore for a rule that no longer
-# fires reads as "this file needs an exemption" long after it stopped being true.
-"docs/hooks.py" = ["T201", "ARG001", "ARG002", "PLW0603", "SIM105"]  # Allow prints, unused args, globals, and simplifiable patterns in documentation hooks
-# The extracted build steps are ordinary modules -- they implement no signature
-# anyone imposed on them, so they get no ARG exemption and an unused parameter
-# there really is an oversight. What they do need is prints (build progress) and
-# module-level per-build caches.
-"docs/_*.py" = ["T201", "PLW0603"]  # Allow prints and per-build cache globals in the extracted build steps
+# Every script under docs/ prints build progress and may hold per-build caches.
+#
+# Deliberately `docs/*.py`, NOT `docs/_*.py`. A project is free to keep its own
+# script here -- yohou has `docs/precache_datasets.py` -- and the narrower glob
+# silently dropped its exemption, removing lint coverage without removing the
+# lint. That is the failure shape this fleet specialises in, so the pattern
+# matches what the directory is for rather than what the template happens to ship.
+"docs/*.py" = ["T201", "PLW0603"]  # Allow prints and per-build cache globals in every docs script
+# The hooks ADDITIONALLY implement signatures they do not choose -- mkdocs' event
+# hooks -- so an unused parameter there is the interface, not an oversight. ARG002
+# is the method-level twin of ARG001. ruff merges per-file-ignores across every
+# matching pattern, so hooks.py gets these on top of the line above; the extracted
+# build steps impose no signature on anyone and correctly do not get them.
+"docs/hooks.py" = ["ARG001", "ARG002", "SIM105"]  # Plus unused args and simplifiable patterns, for mkdocs' imposed hook signatures
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ package_name }}"]

--- a/tests/test_propagated_features.py
+++ b/tests/test_propagated_features.py
@@ -31,12 +31,30 @@ class TestPyprojectNewDeps:
         assert "[tool.rumdl.per-file-ignores]" in content
 
     def test_ruff_docs_per_file_ignores_expanded(self, copie_session_default):
-        """Test that ruff per-file-ignores for docs/ includes PLW0603, SIM105, SIM108."""
+        """The docs per-file-ignores carry the exemptions those files actually need.
+
+        Asserts against the parsed ignore lists, not a substring sweep of the whole
+        file. The previous version checked `"SIM108" in content` and stayed green
+        for a release after SIM108 had been removed from every list -- the only
+        remaining match was the *comment* explaining that it had been dropped. A
+        check that a comment can satisfy is not checking the configuration.
+        """
+        import tomllib
+
         result = copie_session_default
         content = (result.project_dir / "pyproject.toml").read_text()
-        assert "PLW0603" in content
-        assert "SIM105" in content
-        assert "SIM108" in content
+        ignores = tomllib.loads(content)["tool"]["ruff"]["lint"]["per-file-ignores"]
+
+        # Every script under docs/ prints build progress and may hold per-build caches.
+        assert "T201" in ignores["docs/*.py"]
+        assert "PLW0603" in ignores["docs/*.py"]
+        # The hooks additionally implement mkdocs' imposed event signatures.
+        assert "SIM105" in ignores["docs/hooks.py"]
+        assert "ARG001" in ignores["docs/hooks.py"]
+        # SIM108 is deliberately absent: nothing under docs/ trips it since the
+        # build steps moved out, and an ignore for a rule that no longer fires
+        # reads as "this file needs an exemption" long after it stopped being true.
+        assert not any("SIM108" in v for v in ignores.values()), "SIM108 is unused; do not re-add it"
 
 
 class TestMkdocsYmlFeatures:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -203,17 +203,27 @@ def test_pyproject_ruff_ignores_docs_directory(copie):
     # Should have per-file-ignores covering both docs/ populations
     assert "[tool.ruff.lint.per-file-ignores]" in content
     # The hooks implement mkdocs' event signatures, so they need the unused-argument
-    # exemptions. The extracted build steps implement no imposed signature and
-    # deliberately do NOT get them -- an unused parameter there is a real defect,
+    # exemptions. Everything else under docs/ implements no imposed signature and
+    # deliberately does NOT get them -- an unused parameter there is a real defect,
     # and this test would pass on a single broad "docs/**/*" glob that hid it.
     assert '"docs/hooks.py"' in content
-    assert '"docs/_*.py"' in content
     assert "T201" in content  # Print statement
     assert "ARG001" in content  # Unused function argument
     hooks_ignores = content.split('"docs/hooks.py"')[1].split("\n")[0]
-    steps_ignores = content.split('"docs/_*.py"')[1].split("\n")[0]
+    docs_ignores = content.split('"docs/*.py"')[1].split("\n")[0]
     assert "ARG001" in hooks_ignores, "hooks lost its event-signature exemption"
-    assert "ARG001" not in steps_ignores, "the build steps must not get a blanket unused-argument exemption"
+    assert "ARG001" not in docs_ignores, "docs scripts must not get a blanket unused-argument exemption"
+
+    # The glob must match a PROJECT-OWNED script, not just the ones the template
+    # ships. v0.27.2 used "docs/_*.py", which silently dropped lint coverage for
+    # yohou's docs/precache_datasets.py -- removing the exemption without removing
+    # the lint. Assert the pattern, because the failure is a missing match and a
+    # test that only checks the template's own files cannot see it.
+    assert '"docs/*.py"' in content, (
+        'the docs glob must be "docs/*.py", not "docs/_*.py" -- a project-owned '
+        "script under docs/ would otherwise lose its print exemption"
+    )
+    assert '"docs/_*.py"' not in content, 'the narrow "docs/_*.py" glob was replaced by "docs/*.py"'
 
 
 def test_generated_project_has_correct_license(copie):


### PR DESCRIPTION
Two defects in v0.27.2, both found by its own fan-out rather than by the test suite.

## 1. The docs glob was too narrow

v0.27.2 replaced `"docs/**/*"` with `"docs/hooks.py"` + `"docs/_*.py"`, so the extracted build steps would stop inheriting the hooks' unused-argument exemption. That intent was right; the glob was wrong.

A project is free to keep its own script under `docs/`, and `docs/_*.py` does not match one. **yohou has `docs/precache_datasets.py`**, which silently lost its `T201` exemption — lint coverage removed without the lint being removed. Its fan-out agent patched it locally and flagged it for upstreaming.

Fixed by widening the first pattern to `docs/*.py`. ruff **merges** per-file-ignores across every matching pattern, so `hooks.py` now carries only what is specific to it and picks up the shared exemptions from the wider glob:

```toml
"docs/*.py"     = ["T201", "PLW0603"]              # every docs script
"docs/hooks.py" = ["ARG001", "ARG002", "SIM105"]   # plus mkdocs' imposed signatures
```

**Verified the narrowing still bites**, rather than assuming it:

| file | unused argument | result |
|---|---|---|
| `docs/_api_pages.py` | added | **ARG001 reported** |
| `docs/hooks.py` | added | exempt |
| `docs/precache_datasets.py` | prints | clean (was failing) |

## 2. `build_steps` took the ambient interpreter

Pinned to the lowest supported Python, for the reason `check_docs` already documents in its own docstring: an unpinned session takes whatever interpreter the caller happens to have, which can sit outside `requires-python` and die in `uv sync` before any step runs. **Two projects in this fleet cap at 3.13**, so on a 3.14 machine the session failed for a reason unrelated to the docs.

I copied `build_docs`' shape when I added the session. `check_docs` was the right sibling to copy — the lesson was already written down, one function away.

## The test was green for the wrong reason

`test_ruff_docs_per_file_ignores_expanded` asserted `"SIM108" in content` — a substring sweep over the whole file. SIM108 was dropped from every ignore list in v0.27.2, and the test stayed green because the only remaining match was **the comment explaining that it had been dropped**.

It now parses the TOML and asserts against the actual lists, plus asserts SIM108 stays absent. The docs-glob test also asserts the pattern itself, because the failure mode here is a *missing match* and a test that only exercises the template's own files cannot see it.

## Scope

No change to generated output beyond the two config lines. `docs/hooks.py` and the three build-step modules are untouched.

- 333 fast tests pass · `prek` clean
- Renders and lints clean under both `include_examples` values

## Fan-out

The seven v0.27.2 PRs are open and green but **not yet merged**. Rather than merging them and running a second wave, this will be folded into the same open PRs — so the fleet never sits on a release with a known lint bug, and yohou never needs to carry its local workaround.