### PR TITLE
refactor(template): render API page structure from mkdocstrings templates

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -29,10 +29,10 @@ would get a silent empty return from it, but none exists yet.
 | **yohou** | True | The reference implementation and the biggest: ~79 notebooks in **7** groups (6 `examples/` subdirs plus top-level `quickstart.py`), 46 companion pages, 6 curated section pages, hand-written See Also bullets, a 35-link how-to index grouped under 8 headings. It **deleted the seed how-tos** (`contribute.md`, `troubleshooting.md`) for 36 curated ones, so any release touching those is inert here. The only repo that `select`s ruff's `D`, so it is the only one that sees a docstring defect in a template-owned file. Its docs are the quality bar — do not "normalise" them without a reason. |
 | yohou-nixtla | True | 2 notebooks. Its logos were destroyed by a past update and restored from `f166f46`; **never touch `docs/assets/`**. `_base.py` is `_`-prefixed, so `BaseNixtlaForecaster` reached the API only once `_get_root_members` landed (17→18 rows). Answers cap at `max_python_version: 3.13` — scipy ships no cp314 wheel. Known-flagged: inert `environments` key under `[tool.coverage.report]`, `lightning_logs` xdist race, `/en/stable/` 404 (no stable release yet). |
 | yohou-optuna | True | 5 notebooks, all flat. Carries **15 custom skills / 36 files** under `.claude/skills/` that must stay tracked. (`plot_model_comparison_bar` is **yohou's**, not this repo's — an earlier version of this table said otherwise.) |
-| sklearn-wrap | True | 9 flat notebooks. `--extra config` is needed for **`ty`**, not for the docs build: `check_docs` passes with pydantic absent because nox builds its own env and mkdocstrings uses griffe's static analysis. Went RTD-red once from the v0.22.0 gallery bug. |
+| sklearn-wrap | True | 9 flat notebooks. `--extra config` is needed for **`ty`** and for **notebook execution during export**, but *not* for rendering: `check_docs` passes with pydantic absent because mkdocstrings uses griffe's static analysis. So `build_docs`/`build_steps` fail locally on `examples/yaml_config.py` while CI and RTD stay green — RTD's recipe passes the extra, the nox sessions never got it (`test_docstrings` already does, so the pattern exists locally). Pre-existing, verified identical on the prior tag. An earlier version of this table said the extra was "not for the docs build", full stop; that is wrong for the export leg. `test_docstrings` has **no matrix parametrization** here — a single ubuntu job on 3.11 — so do not go looking for one to preserve. Went RTD-red once from the v0.22.0 gallery bug. |
 | sklearn-optuna | True | 9 flat notebooks. Some See Also entries resolve into the `sklearn_optuna` dependency's own inventory — that is correct, not a defect. |
 | **kedro-dagster** | **False** | No notebooks. Largest docstring surface (~126 See Also links). `docstring_options: {warn_unknown_params: false}` is **CI-critical** — flipping it emits 77 griffe warnings and now *fails* the build. Snippets `base_path` must stay `[docs, .]`: it includes repo-root-relative `src/kedro_dagster/templates/*`. `datasets/` re-export layout. Renamed its page to **`troubleshoot.md`**, and keeps a `test-versions` nightly job (with its `needs:`) that copier has deleted before. |
-| **kedro-azureml-pipeline** | **False** | No notebooks. `warn_unknown_params: false` is CI-critical (46 warnings). Keeps a local `inventories` list. `distributed/` re-export layout. Best index coverage in the fleet. Renamed its page to **`troubleshoot.md`**. Answers cap at `max_python_version: 3.13`. |
+| **kedro-azureml-pipeline** | **False** | No notebooks. `warn_unknown_params: false` is CI-critical — measured to the number: flipping it produces exactly **46** griffe warnings and fails `--strict`. Its `inventories` is **the template default** (`docs.python.org` only), *not* a local extension — an earlier version of this table said it kept a local list, and an agent that went looking for one to preserve found nothing. `distributed/` re-export layout. Best index coverage in the fleet. Renamed its page to **`troubleshoot.md`**. `test_versions` matrix is **12** sessions (3 py × 1 kedro × 2 azure-ai-ml × 2 mlflow), not 24. Answers cap at `max_python_version: 3.13`, but `requires-python` has **no upper bound** — see the interpreter note in §5. |
 
 **`include_examples: False` is real and load-bearing.** For those two repos the gallery,
 companion-notebook and `GALLERY:section` machinery is Jinja-gated *out of their
@@ -169,6 +169,15 @@ Group a section index under `##` headings only when it is big enough to need it 
 - **`gh pr edit` silently fails here** (GraphQL Projects-classic deprecation). Use
   `gh api -X PATCH repos/OWNER/REPO/pulls/N -f title=... -F body=@file` and **read it back**.
 - **A CONFLICTING PR runs no Actions.** "0 failures" out of ~1 check is meaningless.
+- **`gh pr checks --json name,bucket` silently returns EMPTY here** while the plain text
+  form works. Two agents in one release built CI monitors on it and each watched an empty
+  result for ~10 minutes before re-querying directly. So "0 checks" has *two* causes now —
+  a conflicting PR, and this. Confirm with a second method before believing either.
+- **`Validate Commit Message` skips on a multi-commit PR** — it carries
+  `if: github.event.pull_request.commits == 1`. Folding a second release into an open PR
+  flips it from pass to skip, which is correct, not a regression: with two commits GitHub
+  takes the squash title from the **PR title**, which `pr-title.yml` validates instead.
+  **This makes the PR title load-bearing for the changelog** — update it when you fold.
 - **RTD 403s urllib's user-agent** — use `curl`.
 - A stale `.rumdl_cache` gives a **false clean**. Delete it and re-run.
 - Cached notebook exports (`.source_hash`) make a docs build **vacuous**. Clear
@@ -230,13 +239,25 @@ overwrote it, the new one didn't" *is* a valid A/B on identical inputs.
 the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits
 multi-line `title=` attributes and the split cuts inside the tag, silently dropping entries.
-And do not key a See Also audit on `<details class="see-also">` in *final* HTML: there is
-none, because `_process_api_page_content` dissolves that container. Zero hits reads as a
-clean pass and is total blindness — two agents found this independently. The real markup is
-a heading with `id="see-also"` (h3 generated, h2 hand-written), and the surfaces do not
-share a shape: h2/h3 are `<ul><li>`, `details.see-also` is `<p>` plus newlines, so a
-single-shape counter silently collapses each list to one entry. **Make the audit abort on
-zero rather than report all-clear.**
+And do not key a See Also audit on `<details class="see-also">` in *final* HTML: on a
+**generated API page** there is none. Zero hits reads as a clean pass and is total
+blindness — two agents found this independently. The real markup is a heading with
+`id="see-also"`.
+
+**But "no `details.see-also` survives" is true of generated pages only, and an earlier
+version of this file stated it unconditionally.** A hand-written page that renders its own
+See Also keeps its container — kedro-dagster's curated `pages/reference/datasets.md` does.
+So there are **three** shapes in the fleet, not two: heading + `<ul><li>`, heading + `<p>`
+(single-entry sections), and a surviving container. A single-shape counter collapses each
+list to one entry or misses whole sections; three agents in one release each reported a
+confident false count (15, 17 and 15 "unlinked") before going shape-agnostic. **Write the
+audit shape-agnostic and make it abort on zero rather than report all-clear.**
+
+One more vacuous-check trap, found four times independently in one release: **testing
+`T201` against `docs/hooks.py` proves nothing** — since the build steps moved out, that
+file contains zero `print()` calls, so the rule cannot fire and every configuration looks
+clean. Test a rule that actually fires in the file you are checking, and confirm with
+`--isolated` that the ignore suppresses a real finding.
 
 **Do NOT drive a headless browser for the DataTables filter.** An earlier version of this
 file said to, and every agent that read it dutifully installed one — seven browsers per
@@ -250,8 +271,24 @@ present, the init script emitted, the pinned CDN URLs returning 200 — and say 
 this does **not** prove the JS executes. That is the honest limit, and the right trade.
 If the pin is ever bumped, that is when a real browser check earns its cost.
 
+**`max_python_version` is not the interpreter constraint — `requires-python` is.** An
+unpinned nox session takes the ambient interpreter, and whether that fails depends on the
+project's `requires-python`, not on the answers file. yohou-nixtla (`>=3.11,<3.14`) failed
+on a 3.14 machine; kedro-azureml-pipeline caps at `max_python_version: 3.13` in its answers
+but has `>=3.11` with **no upper bound**, so the identical session ran fine on 3.14. Same
+cap, opposite outcomes. `max_python_version` constrains `ALL_VERSIONS` and the classifiers;
+it never reaches `uv sync`. Predicting one from the other produced a wrong brief once —
+check the actual `requires-python` before claiming a session will fail.
+
 **Prefer a no-op to churn.** If a repo already satisfies the change, say so plainly and
 push nothing.
+
+**A fan-out is the cheapest audit this fleet gets, and its findings are the point.** One
+release's fan-out found four factual errors in *this file* — every one a claim an agent was
+handed as fact and checked anyway. It also caught a bug in the release being shipped early
+enough to fix upstream and fold into the same open PRs, so no repo ever carried a
+workaround. **When an agent reports that this file is wrong, fix this file** — the next
+release reads it.
 
 ## 6. Reporting
 

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -29,10 +29,10 @@ would get a silent empty return from it, but none exists yet.
 | **yohou** | True | The reference implementation and the biggest: ~79 notebooks in **7** groups (6 `examples/` subdirs plus top-level `quickstart.py`), 46 companion pages, 6 curated section pages, hand-written See Also bullets, a 35-link how-to index grouped under 8 headings. It **deleted the seed how-tos** (`contribute.md`, `troubleshooting.md`) for 36 curated ones, so any release touching those is inert here. The only repo that `select`s ruff's `D`, so it is the only one that sees a docstring defect in a template-owned file. Its docs are the quality bar — do not "normalise" them without a reason. |
 | yohou-nixtla | True | 2 notebooks. Its logos were destroyed by a past update and restored from `f166f46`; **never touch `docs/assets/`**. `_base.py` is `_`-prefixed, so `BaseNixtlaForecaster` reached the API only once `_get_root_members` landed (17→18 rows). Answers cap at `max_python_version: 3.13` — scipy ships no cp314 wheel. Known-flagged: inert `environments` key under `[tool.coverage.report]`, `lightning_logs` xdist race, `/en/stable/` 404 (no stable release yet). |
 | yohou-optuna | True | 5 notebooks, all flat. Carries **15 custom skills / 36 files** under `.claude/skills/` that must stay tracked. (`plot_model_comparison_bar` is **yohou's**, not this repo's — an earlier version of this table said otherwise.) |
-| sklearn-wrap | True | 9 flat notebooks. `--extra config` is needed for **`ty`**, not for the docs build: `check_docs` passes with pydantic absent because nox builds its own env and mkdocstrings uses griffe's static analysis. Went RTD-red once from the v0.22.0 gallery bug. |
+| sklearn-wrap | True | 9 flat notebooks. `--extra config` is needed for **`ty`** and for **notebook execution during export**, but *not* for rendering: `check_docs` passes with pydantic absent because mkdocstrings uses griffe's static analysis. So `build_docs`/`build_steps` fail locally on `examples/yaml_config.py` while CI and RTD stay green — RTD's recipe passes the extra, the nox sessions never got it (`test_docstrings` already does, so the pattern exists locally). Pre-existing, verified identical on the prior tag. An earlier version of this table said the extra was "not for the docs build", full stop; that is wrong for the export leg. `test_docstrings` has **no matrix parametrization** here — a single ubuntu job on 3.11 — so do not go looking for one to preserve. Went RTD-red once from the v0.22.0 gallery bug. |
 | sklearn-optuna | True | 9 flat notebooks. Some See Also entries resolve into the `sklearn_optuna` dependency's own inventory — that is correct, not a defect. |
 | **kedro-dagster** | **False** | No notebooks. Largest docstring surface (~126 See Also links). `docstring_options: {warn_unknown_params: false}` is **CI-critical** — flipping it emits 77 griffe warnings and now *fails* the build. Snippets `base_path` must stay `[docs, .]`: it includes repo-root-relative `src/kedro_dagster/templates/*`. `datasets/` re-export layout. Renamed its page to **`troubleshoot.md`**, and keeps a `test-versions` nightly job (with its `needs:`) that copier has deleted before. |
-| **kedro-azureml-pipeline** | **False** | No notebooks. `warn_unknown_params: false` is CI-critical (46 warnings). Keeps a local `inventories` list. `distributed/` re-export layout. Best index coverage in the fleet. Renamed its page to **`troubleshoot.md`**. Answers cap at `max_python_version: 3.13`. |
+| **kedro-azureml-pipeline** | **False** | No notebooks. `warn_unknown_params: false` is CI-critical — measured to the number: flipping it produces exactly **46** griffe warnings and fails `--strict`. Its `inventories` is **the template default** (`docs.python.org` only), *not* a local extension — an earlier version of this table said it kept a local list, and an agent that went looking for one to preserve found nothing. `distributed/` re-export layout. Best index coverage in the fleet. Renamed its page to **`troubleshoot.md`**. `test_versions` matrix is **12** sessions (3 py × 1 kedro × 2 azure-ai-ml × 2 mlflow), not 24. Answers cap at `max_python_version: 3.13`, but `requires-python` has **no upper bound** — see the interpreter note in §5. |
 
 **`include_examples: False` is real and load-bearing.** For those two repos the gallery,
 companion-notebook and `GALLERY:section` machinery is Jinja-gated *out of their
@@ -169,6 +169,15 @@ Group a section index under `##` headings only when it is big enough to need it 
 - **`gh pr edit` silently fails here** (GraphQL Projects-classic deprecation). Use
   `gh api -X PATCH repos/OWNER/REPO/pulls/N -f title=... -F body=@file` and **read it back**.
 - **A CONFLICTING PR runs no Actions.** "0 failures" out of ~1 check is meaningless.
+- **`gh pr checks --json name,bucket` silently returns EMPTY here** while the plain text
+  form works. Two agents in one release built CI monitors on it and each watched an empty
+  result for ~10 minutes before re-querying directly. So "0 checks" has *two* causes now —
+  a conflicting PR, and this. Confirm with a second method before believing either.
+- **`Validate Commit Message` skips on a multi-commit PR** — it carries
+  `if: github.event.pull_request.commits == 1`. Folding a second release into an open PR
+  flips it from pass to skip, which is correct, not a regression: with two commits GitHub
+  takes the squash title from the **PR title**, which `pr-title.yml` validates instead.
+  **This makes the PR title load-bearing for the changelog** — update it when you fold.
 - **RTD 403s urllib's user-agent** — use `curl`.
 - A stale `.rumdl_cache` gives a **false clean**. Delete it and re-run.
 - Cached notebook exports (`.source_hash`) make a docs build **vacuous**. Clear
@@ -230,13 +239,25 @@ overwrote it, the new one didn't" *is* a valid A/B on identical inputs.
 the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits
 multi-line `title=` attributes and the split cuts inside the tag, silently dropping entries.
-And do not key a See Also audit on `<details class="see-also">` in *final* HTML: there is
-none, because `_process_api_page_content` dissolves that container. Zero hits reads as a
-clean pass and is total blindness — two agents found this independently. The real markup is
-a heading with `id="see-also"` (h3 generated, h2 hand-written), and the surfaces do not
-share a shape: h2/h3 are `<ul><li>`, `details.see-also` is `<p>` plus newlines, so a
-single-shape counter silently collapses each list to one entry. **Make the audit abort on
-zero rather than report all-clear.**
+And do not key a See Also audit on `<details class="see-also">` in *final* HTML: on a
+**generated API page** there is none. Zero hits reads as a clean pass and is total
+blindness — two agents found this independently. The real markup is a heading with
+`id="see-also"`.
+
+**But "no `details.see-also` survives" is true of generated pages only, and an earlier
+version of this file stated it unconditionally.** A hand-written page that renders its own
+See Also keeps its container — kedro-dagster's curated `pages/reference/datasets.md` does.
+So there are **three** shapes in the fleet, not two: heading + `<ul><li>`, heading + `<p>`
+(single-entry sections), and a surviving container. A single-shape counter collapses each
+list to one entry or misses whole sections; three agents in one release each reported a
+confident false count (15, 17 and 15 "unlinked") before going shape-agnostic. **Write the
+audit shape-agnostic and make it abort on zero rather than report all-clear.**
+
+One more vacuous-check trap, found four times independently in one release: **testing
+`T201` against `docs/hooks.py` proves nothing** — since the build steps moved out, that
+file contains zero `print()` calls, so the rule cannot fire and every configuration looks
+clean. Test a rule that actually fires in the file you are checking, and confirm with
+`--isolated` that the ignore suppresses a real finding.
 
 **Do NOT drive a headless browser for the DataTables filter.** An earlier version of this
 file said to, and every agent that read it dutifully installed one — seven browsers per
@@ -250,8 +271,24 @@ present, the init script emitted, the pinned CDN URLs returning 200 — and say 
 this does **not** prove the JS executes. That is the honest limit, and the right trade.
 If the pin is ever bumped, that is when a real browser check earns its cost.
 
+**`max_python_version` is not the interpreter constraint — `requires-python` is.** An
+unpinned nox session takes the ambient interpreter, and whether that fails depends on the
+project's `requires-python`, not on the answers file. yohou-nixtla (`>=3.11,<3.14`) failed
+on a 3.14 machine; kedro-azureml-pipeline caps at `max_python_version: 3.13` in its answers
+but has `>=3.11` with **no upper bound**, so the identical session ran fine on 3.14. Same
+cap, opposite outcomes. `max_python_version` constrains `ALL_VERSIONS` and the classifiers;
+it never reaches `uv sync`. Predicting one from the other produced a wrong brief once —
+check the actual `requires-python` before claiming a session will fail.
+
 **Prefer a no-op to churn.** If a repo already satisfies the change, say so plainly and
 push nothing.
+
+**A fan-out is the cheapest audit this fleet gets, and its findings are the point.** One
+release's fan-out found four factual errors in *this file* — every one a claim an agent was
+handed as fact and checked anyway. It also caught a bug in the release being shipped early
+enough to fix upstream and fold into the same open PRs, so no repo ever carried a
+workaround. **When an agent reports that this file is wrong, fix this file** — the next
+release reads it.
 
 ## 6. Reporting
 

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs/_notebooks.py                   # build step split out of hooks.py; example
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
+docs/material/templates/**                  # mkdocstrings template overrides; thin extends over the shipped _base/
 docs/material/overrides/api-index.html
 docs/material/overrides/api-page.html
 docs/material/overrides/api-submodule.html

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs/_notebooks.py                   # build step split out of hooks.py; example
 docs/pages/reference/changelog.md   # one-line include of the root CHANGELOG.md
 docs/javascripts/mathjax.js
 docs/javascripts/readthedocs.js
+docs/material/templates/**                  # mkdocstrings template overrides; thin extends over the shipped _base/
 docs/material/overrides/api-index.html
 docs/material/overrides/api-page.html
 docs/material/overrides/api-submodule.html

--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -544,7 +544,14 @@ def _build_api_examples_html(project_root, qualified_name):
     total = len(unique_items)
     shown = unique_items[:_API_EXAMPLES_CAP]
 
-    html = "## Examples\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(shown)
+    # "Tutorials", not "Examples", and h3 rather than h2. This markdown is ours,
+    # injected at an `<!-- EXAMPLES_FOR -->` marker, so it can simply say what it
+    # means -- it used to emit `## Examples` and a post-render pass rewrote the
+    # element to `<h3 id="tutorials">Tutorials</h3>`. Emitting it correctly here
+    # means the toc extension sees a real heading and gives it `#tutorials` for
+    # free, and it keeps the name distinct from the docstring's own Examples
+    # section, which is a different thing and owns `#doc-examples`.
+    html = "### Tutorials\n\nThe following example notebooks use this component:\n\n" + _build_gallery_cards(shown)
     gallery_url = _get_gallery_page_url(project_root)
     if total > _API_EXAMPLES_CAP:
         if gallery_url:
@@ -878,22 +885,12 @@ def _get_git_ref():
     return _GIT_REF_CACHE
 
 
-# Numpydoc section types to surface in the TOC.
-_DOC_SECTION_TITLE_SLUGS = {
-    "Parameters": "parameters",
-    "Attributes": "attributes",
-    "Returns": "returns",
-    "Raises": "raises",
-    "Examples": "doc-examples",
-}
-_DETAIL_SECTION_SLUGS = {
-    "note": ("notes", "Notes"),
-    "see-also": ("see-also", "See Also"),
-    "references": ("references", "References"),
-}
-
-
-_SEE_ALSO_BLOCK_RE = re.compile(r'<details\s+class="see-also"[^>]*>.*?</details>', re.DOTALL)
+# The See Also container. This used to be `<details class="see-also">`, emitted by
+# mkdocstrings' shipped admonition template and dissolved later by a restructuring
+# pass -- which is why linkification had to run first. The template now emits a
+# heading plus this div, so there is nothing left to dissolve and no ordering
+# constraint. Keyed on the class the override emits; change one and change both.
+_SEE_ALSO_BLOCK_RE = re.compile(r'<div\s+class="[^"]*doc-admonition-see-also[^"]*"[^>]*>.*?</div>', re.DOTALL)
 # An entry's name sits at the START of its line -- mkdocstrings renders one entry
 # per line inside the paragraph. Anchoring here is what keeps a colon-terminated
 # word in an entry's DESCRIPTION ("Target : Note: see below") from being treated
@@ -1181,10 +1178,14 @@ def _linkify_glossary_terms(html, page, project_root):
 def _linkify_see_also(html, prefix):
     """Turn the names in a rendered See Also section into links.
 
-    Must run while the ``<details class="see-also">`` container still exists --
-    see the ordering comment in ``on_page_content``.  Unresolvable names are
-    left untouched: a docstring may reference a private helper or a concept,
-    and none of those are build errors.
+    Unresolvable names are left untouched: a docstring may reference a private
+    helper or a concept, and none of those are build errors.
+
+    This no longer has an ordering constraint. It used to have to run before the
+    restructuring pass, which dissolved the container it matches -- and getting
+    that order wrong silently degraded class-level sections while method-level
+    ones kept working. The container is now emitted by the admonition template
+    override and nothing consumes it.
     """
 
     def _process_block(block_match):
@@ -1233,289 +1234,64 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
-def _make_section_heading(slug, title, level=3):
-    """Build a heading element for an API page section."""
-    return (
-        f'<h{level} id="{slug}" class="doc-section-heading">{title}'
-        f'<a class="headerlink" href="#{slug}" '
-        f'title="Permanent link">&para;</a></h{level}>'
-    )
+def _strip_redundant_section_titles(html):
+    """Drop the section title the shipped mkdocstrings template still emits.
 
+    The docstring templates render every section title as
+    ``<p><span class="doc-section-title">Parameters:</span></p>``, and nothing in
+    the template layer can suppress it -- ``section.title`` falls back to a
+    translated string. Our dispatcher override emits a real heading for the same
+    sections, so without this the page shows each title twice.
 
-def _process_api_page_content(html, page, config):
-    """Convert numpydoc sections to h3 headings under mkdocstrings h2.
-
-    Restructures the rendered HTML produced by mkdocstrings so that
-    Parameters, Attributes, Returns, Raises, Notes, See Also,
-    References, and Source Code become proper ``<h3>`` headings.
-    The Source Code section is kept collapsible and preceded by a
-    link to the source file on GitHub.
-    For class pages a "Methods" heading is inserted before
-    ``doc-children`` and method headings are re-levelled h3 → h5.
-    Finally the page TOC is rebuilt to reflect the new structure.
+    Deliberately narrow: only the titles the dispatcher actually maps are
+    removed. A section it does not map (Yields, Warns, ...) keeps its title and
+    is untouched, so nothing loses its label. That set is the inverse of
+    ``doc_section_slugs`` in
+    ``docs/material/templates/python/material/docstring.html.jinja`` and the two
+    must stay in sync -- adding a heading there without adding its title here
+    renders it twice; the reverse renders it not at all.
     """
-    from mkdocs.structure.toc import AnchorLink
+    titles = "|".join(re.escape(t) for t in ("Parameters", "Attributes", "Returns", "Raises", "Examples"))
+    return re.sub(
+        rf'<p>\s*<span class="doc-section-title">\s*(?:{titles}):?\s*</span>\s*</p>\s*',
+        "",
+        html,
+    )
 
-    is_class_page = bool(re.search(r'<h3\s+id="{{ package_name }}\.', html))
 
-    # Locate class-level content region
-    h2_match = re.search(r'<h2\s+id="{{ package_name }}\.', html)
-    if not h2_match:
+def _add_source_links(html, page, config):
+    """Insert a "View on GitHub" link after each Source Code heading.
+
+    This is the one part of the old restructuring pass that genuinely cannot move
+    into a template: it needs ``repo_url`` and a git ref, and a mkdocstrings
+    template receives the handler's options, not the mkdocs config. The heading
+    itself IS template-owned (see ``class.html.jinja`` / ``function.html.jinja``);
+    only the link is inserted here.
+
+    Keyed on the heading's id rather than its text, because the text is
+    translatable and the id is the thing we control.
+    """
+    repo_url = config.get("repo_url", "").rstrip("/")
+    if not repo_url:
         return html
-    h2_pos = h2_match.start()
 
-    if is_class_page:
-        boundary_match = re.search(r'<div\s+class="doc doc-children"', html[h2_pos:])
-        boundary_pos = h2_pos + boundary_match.start() if boundary_match else len(html)
-    else:
-        boundary_pos = len(html)
-
-    class_region = html[h2_pos:boundary_pos]
-    sections_found = []  # (id, title) in document order
-
-    # Convert doc-section-title spans to h3 headings
-    def _span_to_h3(m):
-        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-        slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-        if slug:
-            sections_found.append((slug, title))
-            return _make_section_heading(slug, title)
-        return m.group(0)
-
-    new_class_region = re.sub(
-        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-        _span_to_h3,
-        class_region,
+    # pages/api/generated/{qualified}.md -> package/module.py
+    qualified = page.file.src_path.split("/")[-1].removesuffix(".md")
+    parts = qualified.split(".")
+    if len(parts) < 2:
+        return html
+    module_path = "/".join(parts[:-1])
+    link = (
+        f'<p class="github-source-link">'
+        f'<a href="{repo_url}/blob/{_get_git_ref()}/src/{module_path}.py">View on GitHub</a></p>'
     )
 
-    # Convert <details> sections to h3 heading + unwrapped content
-    for detail_cls, (slug, title) in _DETAIL_SECTION_SLUGS.items():
-        detail_re = re.compile(
-            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-            rf"\s*<summary>{re.escape(title)}</summary>"
-            rf"(.*?)</details>",
-            re.DOTALL,
-        )
-        m = detail_re.search(new_class_region)
-        if m:
-            heading = _make_section_heading(slug, title)
-            inner = m.group(1).strip()
-            new_class_region = new_class_region[: m.start()] + heading + "\n" + inner + new_class_region[m.end() :]
-            sections_found.append((slug, title))
-
-    # Convert <details class="mkdocstrings-source"> to collapsible Source Code
-    # with a GitHub link preceding the code block
-    src_re = re.compile(
-        r'<details\s+class="mkdocstrings-source"[^>]*>'
-        r"\s*<summary>.*?</summary>"
-        r"(.*?)</details>",
-        re.DOTALL,
+    return re.sub(
+        r'(<h[35][^>]*id="[^"]*source-code"[^>]*>.*?</h[35]>)',
+        lambda m: m.group(1) + link,
+        html,
+        flags=re.DOTALL,
     )
-    src_m = src_re.search(new_class_region)
-    if src_m:
-        heading = _make_section_heading("source-code", "Source Code")
-        inner = src_m.group(1).strip()
-
-        # Build GitHub source link from page path and config
-        github_link = ""
-        repo_url = config.get("repo_url", "").rstrip("/")
-        if repo_url:
-            # Extract qualified name from page source path
-            src_path = page.file.src_path  # pages/api/generated/{qualified}.md
-            qualified = src_path.split("/")[-1].removesuffix(".md")
-            # qualified = package.module.Name → module path = package/module.py
-            parts = qualified.split(".")
-            if len(parts) >= 2:
-                module_path = "/".join(parts[:-1])
-                git_ref = _get_git_ref()
-                github_link = (
-                    f'<p class="github-source-link">'
-                    f'<a href="{repo_url}/blob/{git_ref}/src/{module_path}.py">'
-                    f"View on GitHub</a></p>\n"
-                )
-
-        source_block = (
-            heading
-            + "\n"
-            + github_link
-            + '<details class="source-code-details">\n'
-            + "<summary>Show/Hide source</summary>\n"
-            + inner
-            + "\n"
-            + "</details>"
-        )
-        new_class_region = new_class_region[: src_m.start()] + source_block + new_class_region[src_m.end() :]
-        sections_found.append(("source-code", "Source Code"))
-
-    html = html[:h2_pos] + new_class_region + html[boundary_pos:]
-
-    # Insert "Methods" h3 before doc-children
-    if is_class_page:
-        methods_heading = _make_section_heading("methods", "Methods") + "\n"
-        html = re.sub(
-            r'(<div\s+class="doc doc-children")',
-            methods_heading + r"\1",
-            html,
-            count=1,
-        )
-
-    # Increase method heading levels (h3 -> h4) in doc-children
-    if is_class_page:
-        dc_match = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match:
-            before = html[: dc_match.start()]
-            after = html[dc_match.start() :]
-            after = re.sub(r"<h3(\s)", r"<h4\1", after)
-            after = re.sub(r"</h3>", "</h4>", after)
-            html = before + after
-
-    # Process method numpydoc sections and source code in doc-children
-    if is_class_page:
-        dc_match2 = re.search(r'<div\s+class="doc doc-children"', html)
-        if dc_match2:
-            dc_start = dc_match2.start()
-            dc_content = html[dc_start:]
-
-            # Build GitHub link once (same source file for all methods)
-            method_github_link = ""
-            repo_url = config.get("repo_url", "").rstrip("/")
-            if repo_url:
-                _src_path = page.file.src_path
-                _qualified = _src_path.split("/")[-1].removesuffix(".md")
-                _parts = _qualified.split(".")
-                if len(_parts) >= 2:
-                    _module_path = "/".join(_parts[:-1])
-                    _git_ref = _get_git_ref()
-                    method_github_link = (
-                        f'<p class="github-source-link">'
-                        f'<a href="{repo_url}/blob/{_git_ref}/src/{_module_path}.py">'
-                        f"View on GitHub</a></p>\n"
-                    )
-
-            # Find all method headings (h4) with their IDs
-            method_positions = [(m.start(), m.group(1)) for m in re.finditer(r'<h4\s+id="([^"]+)"', dc_content)]
-
-            if method_positions:
-                new_dc = dc_content[: method_positions[0][0]]
-                for idx, (pos, method_id) in enumerate(method_positions):
-                    end_pos = method_positions[idx + 1][0] if idx + 1 < len(method_positions) else len(dc_content)
-                    method_short = method_id.split(".")[-1]
-                    section = dc_content[pos:end_pos]
-
-                    # Convert numpydoc section-title spans to h5 headings
-                    def _method_span_to_h5(m, _ms=method_short):
-                        title = re.sub(r"<[^>]+>", "", m.group(1)).strip().rstrip(":")
-                        base_slug = _DOC_SECTION_TITLE_SLUGS.get(title)
-                        if base_slug:
-                            slug = f"{_ms}-{base_slug}"
-                            return _make_section_heading(slug, title, level=5)
-                        return m.group(0)
-
-                    section = re.sub(
-                        r"<p>\s*<span\s+class=\"doc-section-title\"[^>]*>(.*?)</span>\s*</p>",
-                        _method_span_to_h5,
-                        section,
-                    )
-
-                    # Convert detail sections (Notes, See Also, References) to h6
-                    for detail_cls, (base_slug, title) in _DETAIL_SECTION_SLUGS.items():
-                        _slug = f"{method_short}-{base_slug}"
-                        detail_re_m = re.compile(
-                            rf'<details\s+class="{re.escape(detail_cls)}"[^>]*>'
-                            rf"\s*<summary>{re.escape(title)}</summary>"
-                            rf"(.*?)</details>",
-                            re.DOTALL,
-                        )
-                        dm = detail_re_m.search(section)
-                        if dm:
-                            heading = _make_section_heading(_slug, title, level=5)
-                            inner = dm.group(1).strip()
-                            section = section[: dm.start()] + heading + "\n" + inner + section[dm.end() :]
-
-                    # Convert source code to collapsible block with GitHub link
-                    method_src_re = re.compile(
-                        r'<details\s+class="mkdocstrings-source"[^>]*>'
-                        r"\s*<summary>.*?</summary>"
-                        r"(.*?)</details>",
-                        re.DOTALL,
-                    )
-                    msrc_m = method_src_re.search(section)
-                    if msrc_m:
-                        _slug = f"{method_short}-source-code"
-                        heading = _make_section_heading(_slug, "Source Code", level=5)
-                        inner = msrc_m.group(1).strip()
-                        source_block = (
-                            heading
-                            + "\n"
-                            + method_github_link
-                            + '<details class="source-code-details">\n'
-                            + "<summary>Show/Hide source</summary>\n"
-                            + inner
-                            + "\n"
-                            + "</details>"
-                        )
-                        section = section[: msrc_m.start()] + source_block + section[msrc_m.end() :]
-
-                    new_dc += section
-
-                html = html[:dc_start] + new_dc
-
-    # Rename "Examples" h2 to "Tutorials" h3
-    examples_h2 = re.search(r'<h2 id="examples">.*?</h2>', html, re.DOTALL)
-    if examples_h2:
-        old = examples_h2.group(0)
-        new = (
-            old
-            .replace('<h2 id="examples">', '<h3 id="tutorials">')
-            .replace("</h2>", "</h3>")
-            .replace(">Examples<", ">Tutorials<")
-            .replace("#examples", "#tutorials")
-        )
-        html = html.replace(old, new, 1)
-
-    # Rebuild page.toc
-    old_toc = list(page.toc)
-    if old_toc:
-        h1 = old_toc[0]
-        old_h2s = list(h1.children)
-
-        # The first h2 child is the mkdocstrings class/func heading
-        if old_h2s:
-            main_h2 = old_h2s[0]
-
-        # All sections nest inside the mkdocstrings h2
-        section_children = []
-
-        # Numpydoc + detail + source code sections (level 3)
-        for slug, title in sections_found:
-            section_children.append(AnchorLink(title=title, id=slug, level=3))
-
-        # Methods with individual methods nested underneath (level 3 + 4)
-        if is_class_page:
-            methods_entry = AnchorLink(title="Methods", id="methods", level=3)
-            # Recover method names from the HTML h4 headings
-            dc_match_toc = re.search(r'<div\s+class="doc doc-children"', html)
-            if dc_match_toc:
-                for m_toc in re.finditer(r'<h4[^>]+id="([^"]+)"[^>]*>', html[dc_match_toc.start() :]):
-                    method_id = m_toc.group(1)
-                    method_short = method_id.split(".")[-1]
-                    badge = '<code class="doc-symbol doc-symbol-method"></code> '
-                    methods_entry.children.append(AnchorLink(title=badge + method_short, id=method_id, level=4))
-            section_children.append(methods_entry)
-
-        # Tutorials (level 3)
-        for h2 in old_h2s[1:]:
-            if h2.id in ("examples", "tutorials"):
-                section_children.append(AnchorLink(title="Tutorials", id="tutorials", level=3))
-                break
-
-        if old_h2s:
-            main_h2.children = section_children
-            h1.children = [main_h2]
-        else:
-            h1.children = section_children
-
-    return html
 
 
 def on_config(config):
@@ -1549,7 +1325,7 @@ def on_config(config):
 
 
 def on_page_content(html, page, config, files):
-    """Post-process HTML: API page TOC and content restructuring."""
+    """Post-process rendered HTML: See Also links, glossary links, API sidebar."""
     src = page.file.src_path
 
     # Keyed on the markup, not on where the page lives: mkdocstrings emits a See
@@ -1559,17 +1335,18 @@ def on_page_content(html, page, config, files):
     # page rendered three entries as plain text while the same names linked fine
     # on the generated pages, which is exactly the shape of "it works where we
     # looked". --strict never sees it: this is our own HTML.
-
+    #
+    # There is no ordering constraint here any more. There used to be: a
+    # restructuring pass dissolved the `<details class="see-also">` container
+    # this linkifier matched, so linkifying afterwards silently did nothing for
+    # class-level sections -- the majority -- while appearing to work for
+    # method-level ones. The container is gone (the templates emit a heading
+    # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
-    # Process generated API member pages (per-class/function detail pages)
     if src.startswith("pages/api/generated/"):
-        # ORDER IS LOAD-BEARING: mkdocstrings emits See Also as a
-        # <details class="see-also"> block, and _process_api_page_content
-        # dissolves that block for class-level docstrings.  Linkifying after it
-        # silently does nothing for class-level See Also sections -- the
-        # majority of them -- while appearing to work for method-level ones.
-        html = _process_api_page_content(html, page, config)
+        html = _strip_redundant_section_titles(html)
+        html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to
     # live: the index is wherever a project put it. Matching a hardcoded
@@ -1578,8 +1355,6 @@ def on_page_content(html, page, config, files):
     if page.meta.get("template") in ("api-index.html", "api-submodule.html"):
         page.meta["module_toc"] = _build_module_toc(config, current_src_path=src, prefix=_site_root_prefix(page))
 
-    # Last: the API restructuring above rewrites whole regions, so linking
-    # before it would have its links discarded with the markup they sat in.
     html = _linkify_glossary_terms(html, page, Path(__file__).parent.parent)
 
     return html

--- a/template/docs/material/templates/python/material/class.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/class.html.jinja.jinja
@@ -1,0 +1,67 @@
+{% raw %}{#- Give a class's Source Code and Methods sections real headings.
+
+Both are anchors today (`#source-code`, `#methods`) that the hooks invented with
+a regex after the `toc` extension had run, which is why `page.toc` had to be
+rebuilt by hand. Emitting them here registers them for the table of contents
+automatically.
+
+`{{ super() }}` is doing the work: this file overrides only the two block
+*openings* and defers the bodies to the shipped template, so nothing upstream is
+copied and upstream fixes keep arriving. Extending `_base/class.html.jinja`
+rather than replacing it is what makes that possible -- the shipped
+`material/class.html.jinja` is a one-line stub over `_base/`, and this file
+takes that stub's place.
+
+The "View on GitHub" link is deliberately NOT here: it needs `repo_url` and a
+git ref, and a mkdocstrings template receives the handler's options, not the
+mkdocs config. The hooks insert it after this heading. That split is stated
+rather than accidental.
+-#}
+{% extends "_base/class.html.jinja" %}
+
+{% block source scoped %}
+  {#- Guarded on the same config the shipped block guards its body with:
+      without this, a project that turns off `show_source` would get a heading
+      introducing nothing. -#}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}
+
+{% block children scoped %}
+  {#- Only a class that actually renders members gets a Methods heading; an
+      empty one would introduce nothing and add a dead TOC entry. -#}
+  {% if config.members is not false and obj.members %}
+    {% filter heading(3, id="methods", toc_label="Methods") %}
+      <span class="doc-section-heading">Methods</span>
+    {% endfilter %}
+  {% endif %}
+  {#- Deliberately +2, where the shipped block uses +1.
+
+      The page nests h1 title > h2 class > h3 sections, and "Methods" above is
+      one of those h3 sections. A member must therefore start at h4, so it sits
+      UNDER the heading that introduces it rather than beside it. With the
+      shipped +1 a method renders h3 -- level-equal to "Methods" -- which reads
+      as a sibling and flattens the sidebar.
+
+      This is what the old hooks achieved by regex (`<h3` -> `<h4` inside
+      `doc-children`, then the member's own sections `<h3` -> `<h5`). Setting the
+      level here instead lets mkdocstrings' HeadingShiftingTreeprocessor do the
+      shift, which is the machinery that already exists for exactly this.
+
+      The three lines below are the shipped block's body, copied rather than
+      deferred to `super()`: the level is set *inside* that block, so there is no
+      way to influence it from out here. Copying three lines is the smaller evil
+      -- but it is a copy, so check it on a mkdocstrings bump. -#}
+  {% set root = False %}
+  {% set heading_level = heading_level + 2 %}
+  {% include "children.html.jinja" with context %}
+{% endblock children %}
+{% endraw %}

--- a/template/docs/material/templates/python/material/docstring.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/docstring.html.jinja.jinja
@@ -1,0 +1,103 @@
+{% raw %}{#- Emit a real heading before each docstring section this project surfaces.
+
+This overrides mkdocstrings' section *dispatcher*, not the section templates
+themselves. That distinction is the whole design:
+
+  - A section's title lives INSIDE its style block (`table_style` and friends),
+    so overriding `parameters.html.jinja` to change one line means copying its
+    57-line table. Across the eight table-style templates that is ~271 lines of
+    forked upstream markup -- more than the regex pass it replaces, and it stops
+    receiving upstream fixes silently.
+  - Emitting the heading here instead leaves all nine section templates
+    untouched, so they keep getting upstream fixes.
+
+A heading emitted with the `heading` filter is registered for the table of
+contents by mkdocstrings itself (`mkdocstrings_headings_list` records it,
+`get_headings()` hands it to the outer layer, `_HeadingsPostProcessor` removes
+the duplicate). That is why this file exists at all: the hooks used to invent
+these headings with a regex AFTER the `toc` extension had run, so nothing could
+see them, and `page.toc` had to be rebuilt by hand with `AnchorLink` objects.
+Emit them here and that whole apparatus is unnecessary.
+
+Only the sections listed below get headings. That set is not arbitrary -- it
+mirrors exactly what the hooks used to surface, so the page's anchor set is
+unchanged. Adding a kind here ADDS an anchor, which is a URL, so treat it as a
+breaking link change rather than a tidy-up.
+
+The shipped section template still writes its own
+`<p><span class="doc-section-title">...</span></p>`; nothing in the template
+layer can suppress it (`section.title` falls back to a translated string). The
+hooks strip exactly the titles named here -- the inverse of this map, and the
+reason the two must stay in sync.
+-#}
+{% set doc_section_slugs = {
+     "parameters": ("parameters", "Parameters"),
+     "attributes": ("attributes", "Attributes"),
+     "returns": ("returns", "Returns"),
+     "raises": ("raises", "Raises"),
+     "examples": ("doc-examples", "Examples"),
+   } %}
+{% set admonition_slugs = {
+     "note": ("notes", "Notes"),
+     "see-also": ("see-also", "See Also"),
+     "references": ("references", "References"),
+   } %}
+{% if docstring_sections %}
+  {% block logs scoped %}
+    {{ log.debug("Rendering docstring") }}
+  {% endblock logs %}
+  {% with autoref_hook = AutorefsHook(obj, config) %}
+    {% for section in docstring_sections %}
+      {#- The page's own object renders at heading_level 2, its members deeper.
+          Class-level sections are bare (`#parameters`); a member's are prefixed
+          with its name (`#greet-parameters`), which is the scheme the hooks
+          built by string concatenation. -#}
+      {%- set at_root = heading_level == 2 -%}
+      {%- if section.kind.value == "admonition" -%}
+        {%- set mapped = admonition_slugs.get(section.value.kind) -%}
+      {%- else -%}
+        {%- set mapped = doc_section_slugs.get(section.kind.value) -%}
+      {%- endif -%}
+      {%- if mapped -%}
+        {%- set section_id = mapped[0] if at_root else (obj.name ~ "-" ~ mapped[0]) -%}
+        {% filter heading(3 if at_root else 5, id=section_id, toc_label=mapped[1]) %}
+          <span class="doc-section-heading">{{ mapped[1] }}</span>
+        {% endfilter %}
+      {%- endif -%}
+      {% if config.show_docstring_description and section.kind.value == "text" %}
+        {{ section.value|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+      {% elif config.show_docstring_attributes and section.kind.value == "attributes" %}
+        {% include "docstring/attributes.html.jinja" with context %}
+      {% elif config.show_docstring_functions and section.kind.value == "functions" %}
+        {% include "docstring/functions.html.jinja" with context %}
+      {% elif config.show_docstring_classes and section.kind.value == "classes" %}
+        {% include "docstring/classes.html.jinja" with context %}
+      {% elif config.show_docstring_type_aliases and section.kind.value == "type aliases" %}
+        {% include "docstring/type_aliases.html.jinja" with context %}
+      {% elif config.show_docstring_modules and section.kind.value == "modules" %}
+        {% include "docstring/modules.html.jinja" with context %}
+      {% elif config.show_docstring_type_parameters and section.kind.value == "type parameters" %}
+        {% include "docstring/type_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_parameters and section.kind.value == "parameters" %}
+        {% include "docstring/parameters.html.jinja" with context %}
+      {% elif config.show_docstring_other_parameters and section.kind.value == "other parameters" %}
+        {% include "docstring/other_parameters.html.jinja" with context %}
+      {% elif config.show_docstring_raises and section.kind.value == "raises" %}
+        {% include "docstring/raises.html.jinja" with context %}
+      {% elif config.show_docstring_warns and section.kind.value == "warns" %}
+        {% include "docstring/warns.html.jinja" with context %}
+      {% elif config.show_docstring_yields and section.kind.value == "yields" %}
+        {% include "docstring/yields.html.jinja" with context %}
+      {% elif config.show_docstring_receives and section.kind.value == "receives" %}
+        {% include "docstring/receives.html.jinja" with context %}
+      {% elif config.show_docstring_returns and section.kind.value == "returns" %}
+        {% include "docstring/returns.html.jinja" with context %}
+      {% elif config.show_docstring_examples and section.kind.value == "examples" %}
+        {% include "docstring/examples.html.jinja" with context %}
+      {% elif config.show_docstring_description and section.kind.value == "admonition" %}
+        {% include "docstring/admonition.html.jinja" with context %}
+      {% endif %}
+    {% endfor %}
+  {% endwith %}
+{% endif %}
+{% endraw %}

--- a/template/docs/material/templates/python/material/docstring/admonition.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/docstring/admonition.html.jinja.jinja
@@ -1,0 +1,27 @@
+{% raw %}{#- Render a docstring admonition as plain content, not a collapsible block.
+
+The shipped template wraps every admonition in
+`<details class="{{ section.value.kind }}" open>`. That one element is what the
+hooks' `_SEE_ALSO_BLOCK_RE` existed to find, and dissolving it was what forced
+`_linkify_see_also` to run BEFORE the restructuring pass -- an ordering the
+hooks called out as load-bearing, where getting it wrong silently degraded
+class-level See Also sections (the majority) while method-level ones kept
+working. Emitting the content directly removes the container, and with it the
+ordering constraint.
+
+The heading comes from the dispatcher (`docstring.html.jinja`), which is also
+what registers it for the table of contents. Kinds the dispatcher does not map
+still render their title here, so nothing loses its label.
+-#}
+{% block logs scoped %}
+  {{ log.debug("Rendering admonition") }}
+{% endblock logs %}
+
+{% set _mapped_kinds = ["note", "see-also", "references"] %}
+{% if section.value.kind not in _mapped_kinds %}
+  <p><span class="doc-section-title">{{ section.title|convert_markdown(heading_level, html_id, strip_paragraph=True, autoref_hook=autoref_hook) }}</span></p>
+{% endif %}
+<div class="doc-section-item doc-admonition-{{ section.value.kind }}">
+  {{ section.value.contents|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+</div>
+{% endraw %}

--- a/template/docs/material/templates/python/material/function.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/function.html.jinja.jinja
@@ -1,0 +1,26 @@
+{% raw %}{#- Give a function's Source Code section a real heading.
+
+Same reasoning as `class.html.jinja`: the anchor exists today (`#source-code` on
+a function page, `#<method>-source-code` for a class member) but was invented by
+a regex after `toc` had run, so it never reached the table of contents on its
+own. `{{ super() }}` defers the block body to the shipped template.
+
+A function rendered as a class member arrives here with a deeper
+`heading_level`, which is what selects the prefixed id -- the same rule the
+hooks applied by string concatenation.
+-#}
+{% extends "_base/function.html.jinja" %}
+
+{% block source scoped %}
+  {% if config.show_source %}
+    {% filter heading(
+         3 if heading_level == 2 else 5,
+         id="source-code" if heading_level == 2 else (obj.name ~ "-source-code"),
+         toc_label="Source Code",
+       ) %}
+      <span class="doc-section-heading">Source Code</span>
+    {% endfilter %}
+  {% endif %}
+  {{ super() }}
+{% endblock source %}
+{% endraw %}

--- a/template/docs/stylesheets/theme.css.jinja
+++ b/template/docs/stylesheets/theme.css.jinja
@@ -377,14 +377,20 @@ h5.doc-section-heading {
   color: var(--md-default-fg-color);
 }
 
-/* Collapsible source code details */
-.source-code-details {
+/* Collapsible source code block.
+ *
+ * Keyed on mkdocstrings' own `.mkdocstrings-source`, not a class of ours. The
+ * hooks used to rewrite that element into `<details class="source-code-details">`;
+ * the templates now leave mkdocstrings' markup alone, so the selector follows it.
+ * A stale selector here is invisible -- the page renders unstyled and the build
+ * stays green -- so this moved in the same commit as the markup. */
+.mkdocstrings-source {
   margin: 0.5em 0 1em;
   border: 0.05rem solid var(--md-typeset-table-color);
   border-radius: 0.2rem;
 }
 
-.source-code-details > summary {
+.mkdocstrings-source > summary {
   display: block;
   padding: 0.5em 0.8em;
   font-size: 0.72rem;
@@ -397,27 +403,27 @@ h5.doc-section-heading {
   list-style: none;
 }
 
-.source-code-details > summary::before {
+.mkdocstrings-source > summary::before {
   content: "\25B6\FE0E";   /* right-pointing triangle */
   display: inline-block;
   margin-right: 0.4em;
   transition: transform 0.2s;
 }
 
-.source-code-details[open] > summary::before {
+.mkdocstrings-source[open] > summary::before {
   transform: rotate(90deg);
 }
 
-.source-code-details > summary::-webkit-details-marker {
+.mkdocstrings-source > summary::-webkit-details-marker {
   display: none;
 }
 
-.source-code-details > summary:hover {
+.mkdocstrings-source > summary:hover {
   color: var(--md-accent-fg-color);
   background: var(--md-default-bg-color--lightest);
 }
 
-.source-code-details pre {
+.mkdocstrings-source pre {
   margin: 0 !important;
   border-radius: 0 0 0.2rem 0.2rem;
 }

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -55,6 +55,14 @@ markdown_extensions:
   - sane_lists
   - toc:
       permalink: true
+      # API member pages carry two levels of section heading: the class's own
+      # (h3) and each method's (h5). Only the first belongs in the table of
+      # contents -- listing every method's Parameters/Returns/Source Code turns a
+      # class page's ToC into a wall. The hooks used to get this by building
+      # `page.toc` by hand and simply not adding them; now that the headings are
+      # real, `toc_depth` is what draws the same line. The h5 anchors still
+      # exist and are still linkable -- this only controls what the sidebar lists.
+      toc_depth: 4
   - pymdownx.arithmatex:
       generic: true
   - pymdownx.betterem:
@@ -139,6 +147,15 @@ plugins:
   - tags
   - autorefs
   - mkdocstrings:
+      custom_templates: docs/material/templates
+      # Overrides live in docs/material/templates/python/material/. Each one is a
+      # thin `{% raw %}{% extends %}{% endraw %}` over the shipped `_base/` template, so upstream
+      # fixes keep arriving -- see the header comments in those files for why the
+      # dispatcher is overridden rather than the nine section templates.
+      #
+      # NOTE: this is a PLUGIN-level key, not a handler option. Putting it under
+      # `handlers.python.options` fails the build with
+      # `PythonOptions.__init__() got an unexpected keyword argument`.
       handlers:
         python:
           paths: [src]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1774,23 +1774,30 @@ class _FakePage:
 
 
 def _see_also_page(package_name, class_name, entries, *, method_entries=""):
-    """Build a page shaped like real mkdocstrings output.
+    """Build a page shaped like real mkdocstrings output, as the templates emit it.
 
-    The ``<h2 id="{pkg}.{Class}">`` and the ``doc-children`` boundary are not
-    decoration: without the h2, ``_process_api_page_content`` returns early, and
-    a fixture missing it makes every downstream assertion meaningless.
+    The container is `<div class="doc-section-item doc-admonition-see-also">`,
+    written by the `admonition.html.jinja` override, with its heading emitted
+    separately by the `docstring.html.jinja` dispatcher. It used to be
+    `<details class="see-also">` -- the shipped markup -- which a restructuring
+    pass dissolved partway through `on_page_content`, forcing the linkifier to
+    run first. Both the pass and that ordering constraint are gone; this fixture
+    tracks the markup that actually ships, because a fixture describing markup
+    nobody emits tests nothing.
     """
+
+    def _section(body):
+        return (
+            '<h3 id="see-also" class="doc-section-heading">See Also</h3>'
+            f'<div class="doc-section-item doc-admonition-see-also"><p>{body}</p></div>'
+        )
+
     method_block = ""
     if method_entries:
-        method_block = (
-            f'<h3 id="{package_name}.{class_name}.fit">fit</h3>'
-            f'<details class="see-also" open><summary>See Also</summary><p>{method_entries}</p></details>'
-        )
+        method_block = f'<h4 id="{package_name}.{class_name}.fit">fit</h4>{_section(method_entries)}'
     return (
         f'<h2 id="{package_name}.{class_name}">{class_name}</h2>'
-        f'<div class="doc doc-contents">'
-        f'<details class="see-also" open><summary>See Also</summary><p>{entries}</p></details>'
-        f"</div>"
+        f'<div class="doc doc-contents">{_section(entries)}</div>'
         f'<div class="doc doc-children">{method_block}</div>'
     )
 
@@ -1837,8 +1844,9 @@ def test_see_also_links_class_level_entries(copie_session_minimal):
     )
     assert "Plain numpydoc." in out, "description text was altered"
     assert not re.search(r"<a[^>]*>NotARealThing", out), "unresolvable entry was linked"
-    # The container is gone by the end -- proof the linkifier ran before the restructure.
-    assert '<details class="see-also"' not in out
+    # The container survives now -- nothing dissolves it. What matters is that
+    # its entries were linked, which the assertions above already establish.
+    assert "doc-admonition-see-also" in out, "the See Also container was consumed by something"
 
 
 def test_see_also_links_method_level_entries(copie_session_minimal):
@@ -1990,21 +1998,26 @@ def test_see_also_links_member_path_entries(copie_session_minimal):
     assert 'identifier="Beta.build"' not in out, "member path was deferred to autorefs unqualified (never resolves)"
 
 
-def test_see_also_linkify_runs_before_restructure(copie_session_minimal):
-    """Order-locking: reordering on_page_content silently reverts this feature.
+def test_see_also_has_no_ordering_constraint(copie_session_minimal):
+    """The linkifier no longer depends on running before anything else.
 
-    Linkifying after the restructure produces nothing for class-level sections
-    while still working for method-level ones, so a test that only covers
-    method-level entries would not catch the regression.
+    There used to be an order-lock here: a restructuring pass dissolved the
+    `<details class="see-also">` container the linkifier matched, so linkifying
+    afterwards silently produced nothing for class-level sections while still
+    working for method-level ones -- a regression a method-only test would miss.
+
+    The container is now emitted by a template override and nothing consumes it,
+    so the constraint is gone. This asserts the *absence*: no dissolving pass may
+    come back, because reintroducing one would re-create the hazard without
+    reintroducing the test that caught it.
     """
     hooks_source = (copie_session_minimal.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
-    body = hooks_source[hooks_source.index("def on_page_content") :]
-    linkify_at = body.index("_linkify_see_also(")
-    restructure_at = body.index("_process_api_page_content(")
-    assert linkify_at < restructure_at, (
-        "_linkify_see_also must be called BEFORE _process_api_page_content; "
-        "the latter dissolves the <details class='see-also'> block the former matches"
+    assert "_process_api_page_content" not in hooks_source, (
+        "the restructuring pass is back; it dissolves the See Also container and re-creates the order-lock"
     )
+    assert "ORDER IS LOAD-BEARING" not in hooks_source, "the ordering hazard comment is back"
+    body = hooks_source[hooks_source.index("def on_page_content") :]
+    assert "_linkify_see_also(" in body, "the linkifier must still run"
 
 
 def test_see_also_links_on_any_page_that_renders_a_docstring(copie_session_minimal):
@@ -2025,7 +2038,7 @@ def test_see_also_links_on_any_page_that_renders_a_docstring(copie_session_minim
     hooks = _load_hooks(project_dir, "seealso_any_page")
     _reset_hook_caches(hooks)
 
-    html = '<details class="see-also" open><summary>See Also</summary><p>Beta : Nope.</p></details>'
+    html = '<div class="doc-section-item doc-admonition-see-also"><p>Beta : Nope.</p></div>'
 
     # A curated reference page, two deep -- kedro-dagster's shape.
     page = _FakePage("pages/reference/datasets.md", "pages/reference/datasets/index.html")
@@ -2801,6 +2814,127 @@ def test_markdown_export_runs_against_a_prebuilt_site(copie_session_default, tmp
     assert "Body text." in fallback, "a page with no built HTML was not copied as source"
 
 
+def _toc_hrefs(html):
+    """Same-page hrefs listed in the rendered table of contents.
+
+    Parsed with nav nesting tracked, not sliced out of the raw HTML: every
+    heading also carries a permalink anchor with the identical href, so a naive
+    substring search finds `#greet-parameters` on any page that *has* that
+    heading, whether or not the ToC lists it -- which is exactly the distinction
+    this is used to assert.
+    """
+    from html.parser import HTMLParser
+
+    class _Nav(HTMLParser):
+        def __init__(self):
+            super().__init__(convert_charrefs=True)
+            self.depth = 0
+            self.hrefs = set()
+
+        def handle_starttag(self, tag, attrs):
+            a = dict(attrs)
+            if tag == "nav" and "md-nav--secondary" in (a.get("class") or ""):
+                self.depth += 1
+            elif tag == "nav" and self.depth:
+                self.depth += 1
+            if self.depth and tag == "a" and (a.get("href") or "").startswith("#"):
+                self.hrefs.add(a["href"])
+
+        def handle_endtag(self, tag):
+            if tag == "nav" and self.depth:
+                self.depth -= 1
+
+    p = _Nav()
+    p.feed(html)
+    p.close()
+    return p.hrefs
+
+
+def test_hooks_do_not_touch_the_table_of_contents(copie_session_default):
+    """The hooks build no table-of-contents entries and import no ToC machinery.
+
+    mkdocstrings registers every heading a template emits, so `page.toc` needs no
+    help. The hooks used to rebuild it by hand with `AnchorLink` objects, purely
+    because a regex invented those headings *after* the `toc` extension had run.
+    That is the one part of this file measured to have no path onto any other
+    renderer, and it is gone.
+    """
+    source = (copie_session_default.project_dir / "docs" / "hooks.py").read_text(encoding="utf-8")
+    assert "mkdocs.structure.toc" not in source, "the hooks import ToC machinery again"
+    assert "AnchorLink" not in source, "the hooks construct ToC entries again"
+    assert "page.toc" not in source, "the hooks mutate page.toc again"
+
+
+@pytest.mark.parametrize("fixture_name", ["copie_session_default", "copie_session_minimal"])
+def test_mkdocstrings_template_overrides_ship(request, fixture_name):
+    """The overrides ship, and are wired where mkdocstrings actually reads them.
+
+    `custom_templates` is a PLUGIN-level key. Putting it under
+    `handlers.python.options` fails the build outright with
+    `PythonOptions.__init__() got an unexpected keyword argument`, so asserting
+    the key exists somewhere in the file would pass on a broken config.
+    """
+    import yaml
+
+    project_dir = request.getfixturevalue(fixture_name).project_dir
+    templates = project_dir / "docs" / "material" / "templates" / "python" / "material"
+    for rel in ("docstring.html.jinja", "class.html.jinja", "function.html.jinja", "docstring/admonition.html.jinja"):
+        assert (templates / rel).is_file(), f"missing override: {rel}"
+
+    raw = (project_dir / "mkdocs.yml").read_text(encoding="utf-8")
+    config = yaml.load(raw, Loader=type("L", (yaml.SafeLoader,), {}))
+    plugin = next(p["mkdocstrings"] for p in config["plugins"] if isinstance(p, dict) and "mkdocstrings" in p)
+    assert plugin.get("custom_templates") == "docs/material/templates", (
+        "custom_templates must sit at plugin level, not under handlers.python.options"
+    )
+    assert "custom_templates" not in plugin["handlers"]["python"].get("options", {}), (
+        "custom_templates under options fails the build"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("include_examples", [True, False])
+def test_section_headings_reach_the_table_of_contents(copie, include_examples, tmp_path):
+    """Docstring section headings appear in a built page's ToC.
+
+    This is the claim the whole change rests on: that a heading emitted from a
+    mkdocstrings template is registered for the table of contents automatically,
+    so nothing needs to rebuild `page.toc`. Asserted from a real build rather
+    than trusted -- and paired with a control, because "the sidebar contains
+    #parameters" would also pass if the sidebar simply contained everything.
+    """
+    project_dir = copie.copy(extra_answers={"include_examples": include_examples}).project_dir
+    env = dict(os.environ, UV_PROJECT_ENVIRONMENT=str(project_dir / ".venv"), MKDOCS_SKIP_NOTEBOOKS="1")
+    sync = ["uv", "sync", "--no-default-groups", "--group", "docs"]
+    if (project_dir / "examples").exists():
+        sync += ["--group", "examples"]
+    assert subprocess.run(sync, cwd=project_dir, env=env, capture_output=True, check=False).returncode == 0
+    build = subprocess.run(
+        ["uv", "run", "--no-sync", "mkdocs", "build", "--clean", "--strict"],
+        cwd=project_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stderr[-2000:]
+
+    page = project_dir / "site" / "pages" / "api" / "generated" / "test_project.hello.Greeter" / "index.html"
+    html = page.read_text(encoding="utf-8")
+    toc = _toc_hrefs(html)
+    assert toc, "no table of contents was parsed -- the assertions below would be vacuous"
+
+    for anchor in ("#parameters", "#see-also", "#source-code", "#methods"):
+        assert anchor in toc, f"{anchor} is missing from the rendered table of contents ({sorted(toc)})"
+    # Control: a heading that exists on the page but is deeper than toc_depth
+    # must NOT be listed. Without this the assertions above would also pass on a
+    # sidebar that simply listed every heading.
+    assert 'id="greet-parameters"' in html, "the method-level anchor should still exist on the page"
+    assert "#greet-parameters" not in toc, (
+        "method-level sections must stay out of the ToC (toc_depth), or a class page's sidebar becomes a wall"
+    )
+
+
 def test_no_phantom_cache_without_examples(copie_session_minimal):
     """The reset must not name caches a project does not define.
 
@@ -2851,7 +2985,7 @@ def test_see_also_links_list_form_entries(copie_session_minimal):
 
     html = (
         '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
-        '<details class="see-also" open><summary>See Also</summary>'
+        '<div class="doc-section-item doc-admonition-see-also">'
         "<ul><li>Beta : A list entry.</li></ul></details></div>"
         '<div class="doc doc-children"></div>'
     )
@@ -2877,7 +3011,7 @@ def test_see_also_leaves_explicit_cross_references_alone(copie_session_minimal):
     inner = '<li><autoref identifier="minimal_project.models.Beta"><code>Beta</code></autoref> : Explicit.</li>'
     html = (
         '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
-        f'<details class="see-also" open><summary>See Also</summary><ul>{inner}</ul></details></div>'
+        f'<div class="doc-section-item doc-admonition-see-also"><ul>{inner}</ul></div></div>'
         '<div class="doc doc-children"></div>'
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
@@ -3033,7 +3167,7 @@ def test_see_also_does_not_linkify_names_outside_the_section(copie_session_minim
     html = (
         '<h2 id="minimal_project.Alpha">Alpha</h2><div class="doc doc-contents">'
         "<h3>Notes</h3><p>Beta : mentioned in prose, not a See Also entry.</p>"
-        '<details class="see-also" open><summary>See Also</summary><p>Gamma : A real entry.</p></details>'
+        '<div class="doc-section-item doc-admonition-see-also"><p>Gamma : A real entry.</p></div>'
         '</div><div class="doc doc-children"></div>'
     )
     out = hooks.on_page_content(html, _generated_page("minimal_project", "Alpha"), {}, None)
@@ -3347,6 +3481,10 @@ _CLASSIFICATION_PATTERNS = (
     "docs/examples/",
     ".github/skills/",
     ".claude/skills/",
+    # mkdocstrings template overrides. A whole tree rather than a line per file:
+    # its shape follows mkdocstrings' own template layout, so it changes when
+    # that does, and a per-file list would go stale on every handler bump.
+    "docs/material/templates/",
 )
 
 


### PR DESCRIPTION
## Why

`_process_api_page_content` was **283 lines of regex over HTML that mkdocstrings had just produced** — turning `<span class="doc-section-title">` into headings, dissolving `<details class="see-also">`, re-levelling h3→h4→h5, inserting a Methods heading, renaming Examples to Tutorials, wrapping the source block — and then **rebuilding `page.toc` by hand with `AnchorLink` objects**, because none of those headings existed as far as the table of contents was concerned.

Every one of those is a theming decision implemented by pattern-matching someone else's output after the fact. mkdocstrings renders through Jinja and supports overriding it, and a heading emitted from a template is registered for the ToC automatically. **The rebuild was never necessary.**

## What changed

`hooks.py.jinja`: **1702 → 1472 lines**, and it no longer imports `mkdocs` at all.

Four overrides, all thin:

| file | how |
|---|---|
| `docstring.html.jinja` | the section **dispatcher** — emits headings, leaves all nine section templates untouched |
| `admonition.html.jinja` | See Also becomes a heading + div; the `<details>` container is gone |
| `class.html.jinja` | `{% block source %}` + `{% block children %}` via `super()` |
| `function.html.jinja` | `{% block source %}` via `super()` |

**The overrides are deliberately not the nine section templates.** A section's title lives *inside* its style block, so changing one line means copying a 57-line table — ~271 lines of forked upstream markup across the eight table-style templates, more than the regex it replaces, and it stops receiving upstream fixes silently. I measured that before rejecting it.

Two small survivors stay, for stated reasons: one regex strips the section title the shipped templates still emit (nothing in the template layer can suppress it), and the "View on GitHub" link needs `repo_url` and a git ref that a mkdocstrings template cannot see.

## Verification: anchor parity

Anchors are URLs, and **nothing else in the build validates same-page fragments** — not `--strict`, not linkchecker. So the gate is: every heading id, its level, and its order, identical before and after, on every API page, under both `include_examples` values.

**PASSED.** And it earned its keep twice:

- An **id-only** comparison reported IDENTICAL while three method headings had silently dropped from **h4 to h3** — methods rendering level-equal to the `Methods` heading that introduces them. Caught only by comparing `(level, id, order)`.
- The visual pass caught **7 CSS selectors** left pointing at `.source-code-details`, a class the templates no longer emit. Every API page's source block would have rendered unstyled with a green build. Re-pointed to `.mkdocstrings-source` in the same commit.

One ToC difference is accepted: four entries reorder. The old hand-built `page.toc` listed numpydoc sections in document order and admonitions in *dictionary* order, so the sidebar disagreed with its own page. The new order matches the page.

## Tests

347 pass (fast + slow), prek clean. Three new:

- `test_hooks_do_not_touch_the_table_of_contents` — no `mkdocs.structure.toc`, no `AnchorLink`, no `page.toc`
- `test_mkdocstrings_template_overrides_ship` — parses the YAML and asserts `custom_templates` is at **plugin level** and *not* under `handlers.python.options`, which fails the build outright
- `test_section_headings_reach_the_table_of_contents` — the load-bearing claim, from a real build, **mutation-tested twice** (unwiring `custom_templates` and removing `toc_depth` each make it fail) and carrying a control so it cannot pass on a sidebar that simply lists everything

`test_see_also_has_no_ordering_constraint` replaces the old order-lock test: it now asserts the *absence*, so a future dissolving pass cannot re-create the hazard without re-creating its guard.

## Also here

A second commit corrects **four fleet facts in `fan-out-to-packages`** that the v0.27.2 fan-out disproved — each a claim an agent was handed as fact and checked anyway — plus two tooling traps that cost real time.

## Notes

`toc_depth: 4` is new. Method-level sections keep their anchors but leave the sidebar, which is what the hand-built ToC did by simply not adding them.

The override files ship as `*.html.jinja.jinja`: copier treats `.jinja` as *its* suffix and tried to render `| convert_markdown` as its own, so they are `{% raw %}`-wrapped with a second suffix that survives stripping.