### PR TITLE
fix(template): repair five defects the v0.28.0 fan-out found

### DIFF
--- a/template/docs/hooks.py.jinja
+++ b/template/docs/hooks.py.jinja
@@ -1234,6 +1234,36 @@ def _linkify_see_also(html, prefix):
     return _SEE_ALSO_BLOCK_RE.sub(_process_block, html)
 
 
+def _dedupe_heading_ids(html):
+    """Make repeated heading ids unique, keeping the first occurrence bare.
+
+    A page documenting more than one object -- a curated reference page with
+    several ``:::`` directives -- renders each of them at the same depth, so the
+    section templates give every one of them the same ids: two ``#see-also``,
+    two ``#parameters``. That is invalid HTML and makes the fragment ambiguous.
+
+    The templates cannot prevent it. Each ``:::`` is rendered independently and a
+    template has no way to know another object shares its page. Qualifying every
+    id with the object path would fix it and break every existing deep link into
+    the generated pages, which are single-object and vastly more numerous.
+
+    So the first occurrence keeps the bare id -- preserving those links -- and
+    later ones get a numeric suffix, which is what Python-Markdown's own toc
+    extension does for repeated markdown headings. Pages without duplicates are
+    returned unchanged, so this is inert for the single-object case.
+    """
+    seen = {}
+
+    def _rewrite(match):
+        prefix, hid, suffix = match.group(1), match.group(2), match.group(3)
+        seen[hid] = seen.get(hid, 0) + 1
+        if seen[hid] == 1:
+            return match.group(0)
+        return f"{prefix}{hid}_{seen[hid] - 1}{suffix}"
+
+    return re.sub(r'(<h[1-6][^>]*\sid=")([^"]+)(")', _rewrite, html)
+
+
 def _strip_redundant_section_titles(html):
     """Drop the section title the shipped mkdocstrings template still emits.
 
@@ -1344,8 +1374,19 @@ def on_page_content(html, page, config, files):
     # instead), so nothing downstream can consume the markup out from under it.
     html = _linkify_see_also(html, _site_root_prefix(page))
 
+    # NOT gated on `pages/api/generated/`. The templates render wherever a `:::`
+    # directive appears, including a curated reference page, so the duplicate
+    # title and the repeated ids appear there too. Gating these to the generated
+    # pages left a curated page showing each section title twice and carrying
+    # ambiguous fragments -- the same "it works where we looked" shape that once
+    # left See Also unlinked on exactly those pages. Both are no-ops on a page
+    # with no mkdocstrings output.
+    html = _strip_redundant_section_titles(html)
+    html = _dedupe_heading_ids(html)
+
+    # Still gated: this one derives the module path from the page's own filename
+    # (`pages/api/generated/{qualified}.md`), so it is meaningless elsewhere.
     if src.startswith("pages/api/generated/"):
-        html = _strip_redundant_section_titles(html)
         html = _add_source_links(html, page, config)
 
     # Keyed on the template a page declares, not on where the page happens to

--- a/template/docs/material/templates/python/material/class.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/class.html.jinja.jinja
@@ -36,9 +36,29 @@ rather than accidental.
 {% endblock source %}
 
 {% block children scoped %}
-  {#- Only a class that actually renders members gets a Methods heading; an
-      empty one would introduce nothing and add a dead TOC entry. -#}
-  {% if config.members is not false and obj.members %}
+  {#- Only a class that actually renders methods gets a Methods heading.
+
+      `obj.members` is the WRONG set to test and was the first guard here: it is
+      the pre-filter membership and counts attributes, so every attributes-only
+      class -- a pydantic config model, an Enum, a dataclass -- got a heading
+      introducing nothing plus a dead ToC entry. Measured at 12 of 25 class pages
+      in one repo before this was fixed. `--strict` cannot see it: the anchor
+      resolves, it just leads nowhere.
+
+      This mirrors what `children.html.jinja` actually renders: functions after
+      `filter_objects`, minus `__init__` when it is merged into the class. A
+      namespace is needed because a `{% set %}` inside `{% if %}` is scoped to
+      the branch and would not update the outer name. -#}
+  {% set _ns = namespace(methods=obj.functions|filter_objects(
+       filters=config.filters,
+       members_list=none,
+       inherited_members=config.inherited_members,
+       keep_no_docstrings=config.show_if_no_docstring,
+     )|list) %}
+  {% if config.merge_init_into_class %}
+    {% set _ns.methods = _ns.methods|rejectattr("name", "equalto", "__init__")|list %}
+  {% endif %}
+  {% if config.members is not false and _ns.methods %}
     {% filter heading(3, id="methods", toc_label="Methods") %}
       <span class="doc-section-heading">Methods</span>
     {% endfilter %}
@@ -64,4 +84,4 @@ rather than accidental.
   {% set heading_level = heading_level + 2 %}
   {% include "children.html.jinja" with context %}
 {% endblock children %}
-{% endraw %}
+{%- endraw %}

--- a/template/docs/material/templates/python/material/docstring.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/docstring.html.jinja.jinja
@@ -100,4 +100,4 @@ reason the two must stay in sync.
     {% endfor %}
   {% endwith %}
 {% endif %}
-{% endraw %}
+{%- endraw %}

--- a/template/docs/material/templates/python/material/docstring/admonition.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/docstring/admonition.html.jinja.jinja
@@ -24,4 +24,4 @@ still render their title here, so nothing loses its label.
 <div class="doc-section-item doc-admonition-{{ section.value.kind }}">
   {{ section.value.contents|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
 </div>
-{% endraw %}
+{%- endraw %}

--- a/template/docs/material/templates/python/material/function.html.jinja.jinja
+++ b/template/docs/material/templates/python/material/function.html.jinja.jinja
@@ -23,4 +23,4 @@ hooks applied by string concatenation.
   {% endif %}
   {{ super() }}
 {% endblock source %}
-{% endraw %}
+{%- endraw %}

--- a/template/docs/stylesheets/theme.css.jinja
+++ b/template/docs/stylesheets/theme.css.jinja
@@ -370,8 +370,19 @@ div.dt-container .dt-paging .dt-paging-button.disabled:active {
   color: var(--md-accent-fg-color);
 }
 
-/* Override Material h5 styling for API doc section headings */
-h5.doc-section-heading {
+/* Override Material's h5 styling for API doc section headings.
+ *
+ * A DESCENDANT selector, not `h5.doc-section-heading`. The class used to sit on
+ * the heading itself, when a hook synthesised the element; the templates that
+ * replaced it wrap the text in `<h5 id="..."><span class="doc-section-heading">`,
+ * so the old selector matched nothing and Material's default
+ * `.md-typeset h5 {text-transform: uppercase; font-size: .8em}` reasserted on
+ * every method-level section heading -- 40 of them on two pages in one repo,
+ * with a green build and no warning, because CSS that matches nothing is silent.
+ *
+ * Both forms are matched so this does not depend on where the class lands. */
+h5.doc-section-heading,
+h5 .doc-section-heading {
   text-transform: none;
   font-size: 1em;
   color: var(--md-default-fg-color);

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -123,6 +123,14 @@ exclude_docs: |
   # four modules instead of one, which is what made it visible.
   *.py
   __pycache__/
+  # Same reason, one directory over: `docs/material/templates/` holds
+  # mkdocstrings template overrides, which are build tooling, not pages. Without
+  # this they are published as static assets -- confirmed live, `class.html.jinja`
+  # served 200 from the docs site. `material/overrides/*.html` leaks the same way
+  # and is excluded here too; `api-submodule.html` above was the one instance of
+  # this that had been noticed before, handled one file at a time.
+  *.jinja
+  material/overrides/*.html
 {% if include_examples %}  examples/**/CLAUDE.md
 {% endif %}
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2892,6 +2892,41 @@ def test_mkdocstrings_template_overrides_ship(request, fixture_name):
     )
 
 
+@pytest.mark.parametrize("fixture_name", ["copie_session_default", "copie_session_minimal"])
+def test_no_rendered_file_ends_in_a_blank_line(request, fixture_name):
+    """No generated text file ends in a blank line.
+
+    This is a lint rule the template imposes on generated projects and then
+    broke itself. v0.28.0 shipped four `.jinja.jinja` overrides whose bodies are
+    wrapped in `{% raw %}...{% endraw %}`; with copier's `keep_trailing_newline`
+    the newline after `{% endraw %}` was emitted on top of the body's own, so
+    every rendered override ended in a blank line and the generated project's
+    `end-of-file-fixer` failed. Seven repos went CI-red on the same commit.
+
+    It shipped through a green suite because every check looked at the SOURCE
+    file, which is correctly one newline -- the defect exists only after
+    rendering. So this test asserts on the rendered tree, and asserts it for
+    every text file rather than the four that happened to be wrong: the next
+    instance will not be in the same place.
+    """
+    project_dir = request.getfixturevalue(fixture_name).project_dir
+    suffixes = {".py", ".md", ".yml", ".yaml", ".toml", ".css", ".js", ".jinja", ".cfg", ".txt", ".html"}
+    # Only what the template renders. A fixture that has been built or synced
+    # carries `.venv/` and `site/`, and third-party packages ship files ending in
+    # a blank line -- 29 of them in one measurement, which would bury the four
+    # that matter. Scoping this keeps a failure readable and about our own files.
+    ignored = {".git", ".venv", "site", "__pycache__", ".nox", "node_modules"}
+    offenders = sorted(
+        str(p.relative_to(project_dir))
+        for p in project_dir.rglob("*")
+        if p.is_file()
+        and p.suffix in suffixes
+        and not ignored & set(p.relative_to(project_dir).parts)
+        and p.read_bytes().endswith(b"\n\n")
+    )
+    assert not offenders, f"rendered files ending in a blank line: {offenders}"
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("include_examples", [True, False])
 def test_section_headings_reach_the_table_of_contents(copie, include_examples, tmp_path):


### PR DESCRIPTION
Rolling v0.28.0 to all seven packages surfaced five defects. One turned the
whole fleet's CI red; the other four were silent in a green build, which is
this fleet's usual shape.

Each fix was reproduced against v0.28.0 first, then the reproduction re-run
against this branch. The controls are below because three of these defects
were things a plausible check reported as fine.

## 1. Rendered overrides ended in a blank line — blocking, fleet-wide

Every generated project's `end-of-file-fixer` failed on the four overrides, so
`Lint and format` went red in all seven repos on the same commit.

The four sources wrap their bodies in `{% raw %}…{% endraw %}`. With copier's
`keep_trailing_newline`, the newline *after* `{% endraw %}` was emitted on top
of the body's own. Closing with `{%- endraw %}` strips the duplicate.

**Why a 347-test suite shipped it:** every check read the *source* file, which
is correctly one newline. The defect exists only after rendering. My own
pre-release verification made exactly this mistake and reported the fix
working when it was not in at all.

The regression test therefore asserts on the **rendered** tree, and over every
text file rather than the four that happened to be wrong:

```
PRE-FIX  render: 4 offenders  (the four overrides)
POST-FIX render: 0 offenders
```

## 2. Overrides published to the docs site

`class.html.jinja` served **200** from a live preview — raw template source as
a static asset. This is the leak v0.27.2 closed for `*.py`, via an extension it
did not anticipate. `exclude_docs` now covers `*.jinja` and
`material/overrides/*.html` (the latter was already leaking, pre-existing).

Verified on a render: `jinja files in site/: 0`, `files under site/material/: 0`.

## 3. Empty `Methods` heading

The guard tested `obj.members` — the **pre-filter** membership, which counts
attributes. So every attributes-only class got a heading introducing nothing
plus a dead ToC entry: pydantic models, Enums, dataclasses. Measured at 12 of
25 class pages in one repo. `--strict` cannot see it; the anchor resolves, it
just leads nowhere.

It now mirrors what `children.html.jinja` actually renders — `obj.functions`
after `filter_objects`, minus `__init__` when merged into the class.

```
                     v0.28.0        this branch
Config  (dataclass)  WRONG          OK
Flavour (Enum)       WRONG          OK
Worker  (methods)    OK             OK   <- must KEEP its heading
```

## 4. Duplicate heading ids, and a wrongly-gated strip

Pages with more than one `:::` directive emitted repeated ids, and
`_strip_redundant_section_titles` was gated on `pages/api/generated/` so
curated reference pages kept their leftover title spans. The templates render
wherever a directive appears — neither behaviour is generated-page-specific.

```
v0.28.0:     duplicate id groups: 5   leftover spans: 2
this branch: duplicate id groups: 0   leftover spans: 0
```

Single-object pages are unaffected: anchors **UNCHANGED** across the pair.

## 5. `h5.doc-section-heading` matched nothing

The class used to sit on the heading, when a hook synthesised it. The
templates that replaced the hook wrap the text in an inner `<span>`, so the
selector went dead and Material's default `text-transform: uppercase;
font-size: .8em` reasserted on **40 headings across two pages** — with a green
build, because CSS that matches nothing is silent.

```
class ON h5:            0
class in inner span:   10   <- the descendant selector is the one that matches
```

Now matches both shapes, so it does not depend on where the class lands.

## Verification

`349 passed, 4 skipped` (2 new tests); `prek run --all-files` clean; a real
docs build after the whitespace change is anchor-identical.

## A correction to this PR's earlier body

An earlier version of this description said `_get_submodules` still misses
symbols exported only from the package's top-level `__init__.py`, citing
yohou-nixtla's 17-rows-against-18-symbols. **That was stale and I should have
checked before writing it.** `_get_root_members` fixes it, is called at both
generation sites, and is covered by a test that asserts its fixture genuinely
has a root export so it cannot pass over an empty set.

The claim came from the fan-out skill, whose hazards section called it unfixed
while its own fleet table three sections up recorded it as fixed. Both the
skill and this body are now corrected.
