### PR TITLE
fix(template): install git hooks with `prek install -f`

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -312,6 +312,41 @@ number to zero and said why — the right call, and it means **a brief's accepta
 are themselves claims to be checked**, not instructions to satisfy. Tell agents that
 explicitly.
 
+**An anchored conflict-marker regex is a false-clean generator.**
+`^(<<<<<<<|>>>>>>>|=======)$` matches only a bare `=======` and **misses**
+`<<<<<<< HEAD` and `>>>>>>> theirs` — one of three injected markers caught. It fails in
+the direction that matters: real conflicts slip through while the check reports clean.
+Use `^(<<<<<<<|>>>>>>>|=======)( |$)`. This matters more since copier started delivering
+conflicts inline rather than as `.rej` files. And when a sweep does hit a marker, check
+whether the file is *documentation about* conflicts before reporting it — one repo's own
+`update-from-template` skill contains marker examples in a prose table.
+
+**Never falsify against a live working file.** An agent appended a synthetic conflict
+marker to a real `pyproject.toml` to test its detector, then ran `git checkout` to clean
+up — reverting the release's actual change along with the marker, and only noticing
+because it grepped for the new content afterwards. Falsify against a scratch copy.
+
+**`INFO -` is not a liveness probe for an mkdocs build log.** mkdocs emits nothing below
+WARNING at default verbosity, so "I found INFO lines, therefore my grep works" proves
+nothing about a WARNING pattern. Prove the format by injecting a real broken link and
+resting the result on the demonstrated non-zero exit.
+
+**A byte-identity comparison of built trees is coincidentally true before you commit.**
+Generated member pages embed the commit SHA in their "View on GitHub" permalink, so a
+tree diff taken pre-commit compares two builds at the same SHA and reads clean; after
+committing, every generated page differs. Two agents hit this independently in one round
+and both had to correct a "byte-identical" claim. Normalise every 40-hex SHA before
+diffing — and falsify the normaliser against an injected content change, so it is not
+just masking everything.
+
+**A correct measurement does not validate the remedy you inferred from it.** Two agents
+measured, accurately, that declaring `griffe` pulls two extra distributions, and both
+proposed `griffelib` instead. Neither checked what `griffelib` does in a project whose
+mkdocstrings still resolves to griffe 1.x: that distribution *owns* the `griffe/` import
+path which griffelib also provides, so the "fix" risks two distributions owning one path.
+The diagnosis was right and the prescription was worse than the disease. **Test the
+alternative's failure mode before recommending it**, and say which half you measured.
+
 **Verify by rendering, not by reading.** Count in the built HTML, scoped to `<article>` —
 the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -312,6 +312,41 @@ number to zero and said why — the right call, and it means **a brief's accepta
 are themselves claims to be checked**, not instructions to satisfy. Tell agents that
 explicitly.
 
+**An anchored conflict-marker regex is a false-clean generator.**
+`^(<<<<<<<|>>>>>>>|=======)$` matches only a bare `=======` and **misses**
+`<<<<<<< HEAD` and `>>>>>>> theirs` — one of three injected markers caught. It fails in
+the direction that matters: real conflicts slip through while the check reports clean.
+Use `^(<<<<<<<|>>>>>>>|=======)( |$)`. This matters more since copier started delivering
+conflicts inline rather than as `.rej` files. And when a sweep does hit a marker, check
+whether the file is *documentation about* conflicts before reporting it — one repo's own
+`update-from-template` skill contains marker examples in a prose table.
+
+**Never falsify against a live working file.** An agent appended a synthetic conflict
+marker to a real `pyproject.toml` to test its detector, then ran `git checkout` to clean
+up — reverting the release's actual change along with the marker, and only noticing
+because it grepped for the new content afterwards. Falsify against a scratch copy.
+
+**`INFO -` is not a liveness probe for an mkdocs build log.** mkdocs emits nothing below
+WARNING at default verbosity, so "I found INFO lines, therefore my grep works" proves
+nothing about a WARNING pattern. Prove the format by injecting a real broken link and
+resting the result on the demonstrated non-zero exit.
+
+**A byte-identity comparison of built trees is coincidentally true before you commit.**
+Generated member pages embed the commit SHA in their "View on GitHub" permalink, so a
+tree diff taken pre-commit compares two builds at the same SHA and reads clean; after
+committing, every generated page differs. Two agents hit this independently in one round
+and both had to correct a "byte-identical" claim. Normalise every 40-hex SHA before
+diffing — and falsify the normaliser against an injected content change, so it is not
+just masking everything.
+
+**A correct measurement does not validate the remedy you inferred from it.** Two agents
+measured, accurately, that declaring `griffe` pulls two extra distributions, and both
+proposed `griffelib` instead. Neither checked what `griffelib` does in a project whose
+mkdocstrings still resolves to griffe 1.x: that distribution *owns* the `griffe/` import
+path which griffelib also provides, so the "fix" risks two distributions owning one path.
+The diagnosis was right and the prescription was worse than the disease. **Test the
+alternative's failure mode before recommending it**, and say which half you measured.
+
 **Verify by rendering, not by reading.** Count in the built HTML, scoped to `<article>` —
 the ToC sidebar inflates counts ~3×.
 Do not derive See Also counts by splitting final HTML on newlines: mkdocstrings emits

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -47,7 +47,7 @@ cd python-package-copier
 uv sync --group test --group docs
 
 # Install the git hooks (required)
-uv run prek install
+uv run prek install -f
 ```
 
 ## Test Template Changes
@@ -203,7 +203,7 @@ Maintainers: see [About the Release Process](../explanation/release-process.md) 
 : Install uv first: `curl -LsSf https://astral.sh/uv/install.sh | sh`. Nox is run via `uvx`, not installed globally.
 
 **Problem: Hooks fail on first run**
-: Run `uv sync --group test` first to install all dependencies, then `uv run prek install`.
+: Run `uv sync --group test` first to install all dependencies, then `uv run prek install -f`.
 
 **Problem: Tests pass locally but fail in CI**
 : Check the Python version matrix. CI tests across 3.11–3.14 and multiple operating systems. Your local Python may differ.

--- a/docs/pages/tutorials/quickstart.md
+++ b/docs/pages/tutorials/quickstart.md
@@ -43,7 +43,7 @@ cd my-package
 uv sync --group dev
 
 # Set up the git hooks
-uv run prek install
+uv run prek install -f
 ```
 
 ## Verify Setup

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests with parallel execution
 test:

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -35,7 +35,7 @@ uv sync --group dev
 4. Install the git hooks (required):
 
 ```bash
-uv run prek install
+uv run prek install -f
 ```
 
 ## Development Workflow

--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Every place that tells someone to install git hooks was missing the flag that makes
the command do what the docs claim — in this repo and in the template.

## What a bare `prek install` does

Against a checkout predating v0.27.0, it does **not** replace the old pre-commit shim.
It chains it:

```
Hook already exists at `.git/hooks/pre-commit`, moved it to `.git/hooks/pre-commit.legacy`
Migration mode: prek will also run legacy hook `.git/hooks/pre-commit.legacy`.
Use `--overwrite` to remove legacy hooks.
prek installed at `.git/hooks/pre-commit`
prek installed at `.git/hooks/commit-msg`
```

Both hooks then run on every commit, and the old shim's hardcoded uv cache path fails
once that cache is gone. `prek install -f` prints `Overwriting existing hook` and leaves
no legacy file — verified end to end against a rendered project, not just from `--help`.

## Why this shape of fix

`just install` is what people already run. Making it self-healing means a contributor
with a stale checkout is fixed by a command they'd run anyway, instead of needing to
receive and remember a one-off instruction. That instruction was carried as an open task
(`prek-hook-runner` §7.7) for four days precisely because "tell every contributor…" has
no completion condition.

`template/.claude/skills/update-from-template/SKILL.md` **already used `-f`**. The correct
form was known in this codebase and applied in one of eight places.

## Sites changed

| file | |
|---|---|
| `justfile` | this repo's own `install` |
| `template/justfile.jinja` | generated projects' `install` |
| `template/CONTRIBUTING.md` | |
| `template/docs/pages/how-to/contribute.md.jinja` | step 4 |
| `docs/pages/how-to/contribute.md` | ×2, command and prose |
| `docs/pages/tutorials/quickstart.md` | |

Left alone: the comment in `.pre-commit-config.yaml.jinja` explaining why
`default_install_hook_types` exists — that's prose about the command, not an instruction.

## Worth recording

The archived task described this failure three ways, and measurement contradicted all
three: it said prek "keeps running pre-commit **instead of**" (both run), that "the
commit-msg type was never installed" (both types install — the config names them), and
that it was "silent" (prek prints the notice and names the flag).

That description survived being archived, written to memory, and reported to the user
twice before anyone ran the command. The memory note now leads with the correction.

## Verification

`351 passed, 4 skipped`; `prek run --all-files` clean; rendered project confirmed to carry
`-f` in all three shipped files, and the resulting command confirmed to clear a planted
legacy shim.
