### PR TITLE
feat(docs): make this repository's own docs engine-independent

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,15 @@ site_url: https://python-package-copier.readthedocs.io/
 repo_url: https://github.com/stateful-y/python-package-copier
 edit_uri: edit/main/docs/
 
+# The Material theme override in docs/material/overrides/ lives inside docs_dir,
+# so mkdocs would copy it into the built site as a static asset (main.html served
+# 200). It is a theme template, not a page. `exclude_docs` keeps it out. Under the
+# successor engine (Zensical) `exclude_docs` is ignored, but main.html is a
+# Material `base.html` override with no meaning there -- it rides with the theme
+# migration, which is out of scope for this change.
+exclude_docs: |
+  material/overrides/*.html
+
 theme:
   name: material
   custom_dir: docs/material/overrides
@@ -69,19 +78,27 @@ nav:
     - Update from Template: pages/how-to/update-template.md
     - Add Dependencies: pages/how-to/add-dependencies.md
     - Contribute to the Template: pages/how-to/contribute.md
+  - Explanation:
+    - Architecture Overview: pages/explanation/architecture.md
+    - Release Process: pages/explanation/release-process.md
+  # Reference is last on purpose: it is the section you arrive at knowing what
+  # you want, so it earns its place by being findable, not by being passed
+  # through -- learn, do, understand, then look things up. Same order the
+  # generated template's own nav uses.
   - Reference:
     - Template Variables: pages/reference/template-variables.md
     - Project Structure: pages/reference/project-structure.md
     - Commands: pages/reference/commands.md
     - GitHub Workflows: pages/reference/github-workflows.md
     - Configuration Files: pages/reference/configuration.md
-  - Explanation:
-    - Architecture Overview: pages/explanation/architecture.md
-    - Release Process: pages/explanation/release-process.md
 
 extra_javascript:
   - javascripts/readthedocs.js
 
 watch:
-  - mkdocs.yml
+  # Deliberately NOT mkdocs.yml: MkDocs already watches its own config file during
+  # `serve`, independent of this key, so listing it buys nothing -- and under the
+  # successor engine (Zensical) a config file that names itself in `watch:` makes
+  # the build emit ZERO html, silently, at exit 0, even under `--strict`. Re-adding
+  # it would publish an empty site from a green build.
   - docs

--- a/tests/test_repo_docs.py
+++ b/tests/test_repo_docs.py
@@ -1,0 +1,99 @@
+"""Engine-independence invariants for THIS repository's own documentation.
+
+The `docs-engine-portability` change made the docs this template *generates* for
+downstream projects survive a migration off Material for MkDocs (EOL 2026-11-05)
+to Zensical. This pins the same guarantee for the docs this repo publishes about
+*itself* -- the root `mkdocs.yml` and `docs/`.
+
+These docs are pure prose plus the Material theme: no `hooks:`, no markers, no
+mkdocstrings rendering, no build-step modules. So the guarantee is mostly
+"already true", and most of these assertions pin an invariant rather than test a
+fix -- they fail loudly if a future edit reintroduces the engine-locked patterns
+the fleet change had to remove.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO = Path(__file__).resolve().parent.parent
+
+
+def _repo_mkdocs_config():
+    """Load the repository's own mkdocs.yml, tolerating custom YAML tags."""
+
+    class _Loader(yaml.SafeLoader):
+        pass
+
+    _Loader.add_multi_constructor("tag:yaml.org,2002:python/name:", lambda _loader, suffix, _node: suffix)
+    _Loader.add_constructor("!ENV", lambda _loader, _node: None)
+    return yaml.load((_REPO / "mkdocs.yml").read_text(encoding="utf-8"), Loader=_Loader)
+
+
+def test_repo_docs_config_does_not_watch_itself():
+    """A config that names itself in `watch:` makes the successor engine build an empty site.
+
+    Zensical treats a self-referencing `watch:` as a signal to watch nothing and
+    emits ZERO html at exit 0, `--strict` included. MkDocs watches its own config
+    during `serve` regardless, so the entry is pure downside.
+    """
+    config = _repo_mkdocs_config()
+    watch = config.get("watch") or []
+    assert "mkdocs.yml" not in watch, "mkdocs.yml watches itself; the successor engine builds an empty site from that"
+    assert "docs" in watch, "the docs directory must still be watched during serve"
+
+
+def test_repo_docs_have_no_engine_hooks_or_in_source_build_tooling():
+    """The repo's own docs depend on no mkdocs event hooks and ship no in-docs build tooling.
+
+    Both are already true and pinned here: unlike the generated projects, these
+    docs never had a `hooks.py` or a `docs_build/`. A `hooks:` key would not run
+    under the successor engine, and any build-tooling `.py` under `docs_dir` would
+    be published as a static asset.
+    """
+    config = _repo_mkdocs_config()
+    assert "hooks" not in config, "the repo's own docs declare a hooks: key; the successor engine never runs it"
+    stray = sorted(p.relative_to(_REPO).as_posix() for p in (_REPO / "docs").rglob("*.py"))
+    assert not stray, f"build-tooling .py under docs/ would be published as a static asset: {stray}"
+
+
+def test_repo_docs_theme_override_is_excluded_from_publishing():
+    """The Material theme override must not be published as a site asset.
+
+    `docs/material/overrides/main.html` sits inside `docs_dir`, so without an
+    `exclude_docs` entry mkdocs copies it to `site/material/overrides/main.html`.
+    """
+    config = _repo_mkdocs_config()
+    excluded = config.get("exclude_docs") or ""
+    assert "material/overrides/*.html" in excluded, (
+        "the theme override is not excluded; it would publish as site/material/overrides/main.html"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_repo_docs_build_ships_content_not_an_empty_site(tmp_path):
+    """A real build produces non-empty pages and leaks no theme override.
+
+    A green `--strict` build is not evidence: the empty-site bug and a leaked
+    asset both pass at exit 0. This asserts on content instead.
+    """
+    if shutil.which("uv") is None:
+        pytest.skip("uv is required to build the docs")
+    site = tmp_path / "site"
+    build = subprocess.run(
+        ["uv", "run", "--group", "docs", "mkdocs", "build", "--clean", "--strict", "--site-dir", str(site)],
+        cwd=_REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert build.returncode == 0, build.stderr[-2000:]
+
+    index = site / "index.html"
+    assert index.is_file() and index.stat().st_size > 500, "the home page is missing or empty -- the build shipped nothing"
+    assert not list(site.glob("material/overrides/*.html")), "the Material theme override leaked into the built site"
+    assert len(list(site.rglob("index.html"))) > 5, "the site has too few pages; content collapsed"


### PR DESCRIPTION
Applies the `docs-engine-portability` treatment to the docs this repo publishes about **itself** (root `mkdocs.yml` + `docs/`) — a separate build from the docs the template generates for downstream projects (#205).

The honest finding: these docs are pure prose + the Material theme (no `hooks:`, no markers, no mkdocstrings), so they were already engine-independent in almost every way the fleet change had to fix. The real surface is two config lines and a test:

- **Remove the `watch: mkdocs.yml` self-reference** — a config that watches itself makes the successor engine (Zensical) build an empty site at exit 0, `--strict` included. MkDocs watches its own config during `serve` regardless.
- **`exclude_docs: material/overrides/*.html`** — stops the Material `main.html` override publishing as a static asset (the leak class the fleet change closed).
- **`tests/test_repo_docs.py`** — pins the invariants: structural (no self-watch, no `hooks:` key, override excluded, no build tooling under `docs/`) plus a real `mkdocs build --strict` that asserts on content (non-empty pages, no leaked override). A green build is not proof.
- **Nav reorder**: Explanation before Reference (reference last, the Diátaxis order the generated template's own nav uses).

**Verification:** fast suite 340 passed, ruff + rumdl clean, and the docs build under `--strict` (15 pages, 0.23s) with the override confirmed absent from `site/`.

Theme portability (Material → Zensical, including `main.html`) is deferred, exactly as #205 deferred it. Independent of #205; this is a separate small PR against `main`.