### PR TITLE
fix(docs): correct three v0.29.0 rendering bugs the fan-out surfaced

### DIFF
--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -26,11 +26,18 @@ build:
       # Generate the API pages and export the notebooks before mkdocs builds --
       # the explicit step that replaced the deleted on_pre_build hook, which the
       # mkdocs integration no longer triggers.
-      - "${READTHEDOCS_VIRTUALENV_PATH}/bin/python" docs_build/build.py prebuild
+      #
+      # The value is an UNQUOTED (plain) scalar on purpose: a YAML list item that
+      # STARTS with a quote is a quoted scalar and may carry no trailing content,
+      # so `- "${VENV}/bin/python" docs_build/build.py prebuild` is a parse error
+      # (check-yaml and Read the Docs both reject it). The variable needs no
+      # quoting -- RTD's paths contain no spaces -- exactly like the `install:`
+      # line above.
+      - ${READTHEDOCS_VIRTUALENV_PATH}/bin/python docs_build/build.py prebuild
     post_build:
       # Export the cleaned markdown into the built site for LLM consumption --
       # the explicit step that replaced the deleted on_post_build hook.
-      - "${READTHEDOCS_VIRTUALENV_PATH}/bin/python" docs_build/build.py postbuild "${READTHEDOCS_OUTPUT}html"
+      - ${READTHEDOCS_VIRTUALENV_PATH}/bin/python docs_build/build.py postbuild "${READTHEDOCS_OUTPUT}html"
       # Check for broken links
       - uvx linkchecker "${READTHEDOCS_OUTPUT}html/index.html" --no-status --no-warnings --ignore-url material/overrides
 

--- a/template/docs_build/_glossary.py.jinja
+++ b/template/docs_build/_glossary.py.jinja
@@ -171,9 +171,16 @@ def _linkify(lines, page):
             fence = fence_match.group(1)
             out.append(line)
             continue
-        # Indented code (4 spaces or a tab) and ATX headings are not prose: a
-        # link mid-heading looks broken, and code is code.
-        if line.startswith(("    ", "\t")) or line.lstrip().startswith("#"):
+        # Indented code (4 spaces or a tab), ATX headings and mkdocstrings autodoc
+        # directives are not prose. A link mid-heading looks broken and code is
+        # code -- and linkifying a term inside a `::: pkg.module.Symbol` directive
+        # corrupts the identifier so mkdocstrings cannot collect it, failing the
+        # strict build. A project with a module named after an .autolink term (a
+        # `stationarity` module and a `Stationarity` term) would otherwise turn a
+        # generated API page's `::: pkg.stationarity.X` into
+        # `::: pkg.[stationarity](...).X`. Options under a `:::` are indented, so
+        # the `"    "` guard already covers them; this adds the directive itself.
+        if line.startswith(("    ", "\t")) or line.lstrip().startswith(("#", ":::")):
             out.append(line)
             continue
         out.append(_link_line(line, pattern, terms, rel_glossary, linked))

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -265,7 +265,9 @@ watch:
   # exit 0, even under `--strict`. Re-adding it would publish an empty site
   # from a green build, in every repo at once.
   - docs
-{#- No examples/src entries: the examples/notebooks are exported at build time
-    (and once at serve startup), not live-watched, because executing a notebook
-    on every edit is too slow; and src/ is owned by the docs_build/serve.py
-    watcher, not the engine. -#}
+{# No examples/src entries: the examples/notebooks are exported at build time
+   (and once at serve startup), not live-watched, because executing a notebook
+   on every edit is too slow; and src/ is owned by the docs_build/serve.py
+   watcher, not the engine. The comment opens with `{#`, NOT `{#-`: the leading
+   dash would strip the newline after `- docs` above and render a file with no
+   trailing newline, failing end-of-file-fixer in every generated project. -#}

--- a/tests/test_repo_docs.py
+++ b/tests/test_repo_docs.py
@@ -94,6 +94,8 @@ def test_repo_docs_build_ships_content_not_an_empty_site(tmp_path):
     assert build.returncode == 0, build.stderr[-2000:]
 
     index = site / "index.html"
-    assert index.is_file() and index.stat().st_size > 500, "the home page is missing or empty -- the build shipped nothing"
+    assert index.is_file() and index.stat().st_size > 500, (
+        "the home page is missing or empty -- the build shipped nothing"
+    )
     assert not list(site.glob("material/overrides/*.html")), "the Material theme override leaked into the built site"
     assert len(list(site.rglob("index.html"))) > 5, "the site has too few pages; content collapsed"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1966,6 +1966,45 @@ def test_glossary_never_links_inside_code_or_headings(copie_session_minimal):
     assert "[memory buffer](glossary.md#memory-buffer)" in out, "prose occurrence was not linked"
 
 
+def test_glossary_never_links_inside_an_autodoc_directive(copie_session_minimal):
+    """A `:::` mkdocstrings directive is a machine identifier, never prose.
+
+    The glossary linker runs as a Preprocessor, *before* mkdocstrings collects the
+    `:::` autodoc blocks on the generated API pages. A project whose module name
+    matches an .autolink term -- e.g. a `stationarity` module and a `Stationarity`
+    term -- would see `::: pkg.stationarity.ASinhTransformer` rewritten into
+    `::: pkg.[stationarity](...).ASinhTransformer`, which mkdocstrings cannot
+    collect, failing the strict build. yohou (the only repo with both a matching
+    module and term) hit exactly this; the directive line must pass through
+    untouched, and because it is skipped rather than linked, the first-occurrence
+    link correctly falls on the following prose instead.
+    """
+    project_dir = copie_session_minimal.project_dir
+    # A term whose slug collides with a module path segment in the `:::` below.
+    _write_glossary(
+        project_dir,
+        extra="Stationarity { #stationarity .autolink }\n:   A stable statistical regime.\n",
+    )
+    glossary = _load_glossary(project_dir, "glossary_autodoc")
+
+    md = (
+        "::: pkg.stationarity.ASinhTransformer\n"
+        "    options:\n"
+        "      show_root_heading: true\n"
+        "\n"
+        "Stationarity is a real concept mentioned in this prose.\n"
+    )
+    lines = glossary._linkify(md.split("\n"), _glossary_page())
+    out = "\n".join(lines)
+
+    assert lines[0] == "::: pkg.stationarity.ASinhTransformer", (
+        f"the autodoc directive was corrupted -- mkdocstrings cannot collect it: {lines[0]!r}"
+    )
+    # The fix is scoped to the directive: prose still links, and the skipped
+    # directive means first-occurrence lands here rather than being consumed above.
+    assert "[Stationarity](glossary.md#stationarity)" in out, "prose occurrence was not linked"
+
+
 def test_glossary_page_does_not_link_itself(copie_session_minimal):
     """The glossary must not turn its own definitions into links to themselves."""
     project_dir = copie_session_minimal.project_dir
@@ -2870,19 +2909,22 @@ def test_mkdocstrings_template_overrides_ship(request, fixture_name):
 
 @pytest.mark.parametrize("fixture_name", ["copie_session_default", "copie_session_minimal"])
 def test_no_rendered_file_ends_in_a_blank_line(request, fixture_name):
-    """No generated text file ends in a blank line.
+    """Every generated text file ends in exactly one newline.
 
     This is a lint rule the template imposes on generated projects and then
-    broke itself. v0.28.0 shipped four `.jinja.jinja` overrides whose bodies are
-    wrapped in `{% raw %}...{% endraw %}`; with copier's `keep_trailing_newline`
-    the newline after `{% endraw %}` was emitted on top of the body's own, so
-    every rendered override ended in a blank line and the generated project's
-    `end-of-file-fixer` failed. Seven repos went CI-red on the same commit.
+    broke itself, in both directions. v0.28.0 shipped four `.jinja.jinja`
+    overrides whose bodies are wrapped in `{% raw %}...{% endraw %}`; with
+    copier's `keep_trailing_newline` the newline after `{% endraw %}` was emitted
+    on top of the body's own, so every rendered override ended in a blank line.
+    v0.29.0 then shipped the opposite: `mkdocs.yml` ended with a `{#- ... -#}`
+    comment whose leading dash stripped the final newline, so the rendered file
+    had NO trailing newline. Both fail the generated project's
+    `end-of-file-fixer`; seven repos go CI-red on the same commit either way.
 
     It shipped through a green suite because every check looked at the SOURCE
     file, which is correctly one newline -- the defect exists only after
     rendering. So this test asserts on the rendered tree, and asserts it for
-    every text file rather than the four that happened to be wrong: the next
+    every text file rather than the few that happened to be wrong: the next
     instance will not be in the same place.
     """
     project_dir = request.getfixturevalue(fixture_name).project_dir
@@ -2893,23 +2935,75 @@ def test_no_rendered_file_ends_in_a_blank_line(request, fixture_name):
     # that matter. Scoping this keeps a failure readable and about our own files.
     ignored = {".git", ".venv", "site", "__pycache__", ".nox", "node_modules"}
     offenders = []
+    missing_newline = []
     for path in project_dir.rglob("*"):
         if not path.is_file() or path.suffix not in suffixes:
             continue
         rel = path.relative_to(project_dir)
         if ignored & set(rel.parts):
             continue
-        # `docs/pages/api/` is generated at build time from `"\n\n".join(sections)`,
-        # so those pages legitimately end in a blank line -- and the generated project
-        # gitignores them, so its own `end-of-file-fixer` never sees them. Excluding
-        # them keeps this test about files the template ships, and stops it depending
-        # on whether some earlier test happened to run a docs build in this fixture.
-        if rel.as_posix().startswith("docs/pages/api/"):
+        # Skip build-time output under docs/: the generated API pages
+        # (`"\n\n".join(sections)`, legitimately blank-line-terminated) and marimo's
+        # exported example apps (`docs/examples/<name>/index.html`, an HTML file with
+        # no trailing newline). Both are gitignored in the generated project
+        # (`docs/pages/api/`, `docs/examples/*/`), so its own `end-of-file-fixer`
+        # never sees them; including them would make this test depend on whether an
+        # earlier test happened to run a docs build or notebook export in the shared
+        # session fixture.
+        posix = rel.as_posix()
+        if posix.startswith("docs/pages/api/") or posix.startswith("docs/examples/"):
             continue
-        if path.read_bytes().endswith(b"\n\n"):
+        data = path.read_bytes()
+        if data.endswith(b"\n\n"):
             offenders.append(rel.as_posix())
+        elif data and not data.endswith(b"\n"):
+            missing_newline.append(rel.as_posix())
     offenders.sort()
+    missing_newline.sort()
     assert not offenders, f"rendered files ending in a blank line: {offenders}"
+    assert not missing_newline, f"rendered files with no trailing newline: {missing_newline}"
+
+
+@pytest.mark.parametrize("fixture_name", ["copie_session_default", "copie_session_minimal"])
+def test_every_rendered_yaml_file_parses(request, fixture_name):
+    """Every generated .yml/.yaml file is syntactically valid YAML.
+
+    v0.29.0 shipped a `.readthedocs.yml` whose `build.jobs` list items began with
+    a quoted scalar carrying trailing content (`- "${VENV}/bin/python" build.py
+    prebuild`), which is invalid YAML. It passed the whole suite because every
+    check read the `.jinja` SOURCE; nothing parsed the RENDERED file. The
+    generated project's `check-yaml` hook and Read the Docs both rejected it, so
+    the fan-out went CI-red and RTD-red across the fleet at once. This parses the
+    rendered tree so the next malformed YAML is caught here, not downstream.
+    """
+    import yaml
+
+    # mkdocs.yml legitimately uses `!!python/name:` and `!ENV`; register both so a
+    # valid file is not misread as a parse failure -- the same handlers every real
+    # reader of that file installs. A syntax error still raises.
+    loader = type("L", (yaml.SafeLoader,), {})
+    loader.add_multi_constructor("tag:yaml.org,2002:python/name:", lambda _l, suffix, _n: suffix)
+    loader.add_constructor("!ENV", lambda _l, _n: None)
+
+    project_dir = request.getfixturevalue(fixture_name).project_dir
+    ignored = {".git", ".venv", "site", "__pycache__", ".nox", "node_modules"}
+    errors = {}
+    checked = 0
+    for path in project_dir.rglob("*"):
+        if not path.is_file() or path.suffix not in {".yml", ".yaml"}:
+            continue
+        rel = path.relative_to(project_dir)
+        if ignored & set(rel.parts):
+            continue
+        checked += 1
+        try:
+            yaml.load(path.read_text(encoding="utf-8"), Loader=loader)
+        except yaml.YAMLError as exc:
+            errors[rel.as_posix()] = str(exc).splitlines()[0]
+    # A selector that matches nothing is a silent pass; this fleet's dominant bug
+    # shape. `.readthedocs.yml` and `mkdocs.yml` alone guarantee a non-zero count.
+    assert checked >= 2, f"expected to parse several rendered YAML files, checked {checked}"
+    assert not errors, f"rendered YAML files that do not parse: {errors}"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## What

Three defects the v0.29.0 fan-out surfaced across the fleet. Each appears only in the **rendered** output, so the template's own suite (which reads the `.jinja` source) stayed green while every generated project went CI-red on the v0.29.0 update.

### Bug 1 — `.readthedocs.yml` renders as invalid YAML (fleet-wide, blocking)
The `build.jobs` `pre_build`/`post_build` items began with a double-quoted scalar carrying trailing content (`- "${VENV}/bin/python" docs_build/build.py prebuild`), which YAML forbids. This failed `check-yaml` in every generated project **and** made Read the Docs reject the config outright, so the `build.jobs` wiring never even parsed. Rendered as a plain scalar now, matching the `install:` line above.

Confirmed live on the fan-out PRs: e.g. kedro-azureml #44 and kedro-dagster #134 show **check-yaml FAIL + RTD build FAIL** (`success=False`) while Docs-build-strict passed — the "CI green, RTD red" hazard.

### Bug 2 — `mkdocs.yml` renders with no trailing newline (fleet-wide)
The final `watch:`-section jinja comment's leading `-` (`{#-`) stripped the file's trailing newline, failing `end-of-file-fixer` in every generated project. Changed to `{#`.

### Bug 3 — `docs_build/_glossary.py` corrupts `:::` autodoc identifiers (Tier 1, build-red)
As a markdown *preprocessor* (it runs before mkdocstrings), the glossary linker linkified `.autolink` terms inside generated API pages' `::: pkg.module.Symbol` directive lines, corrupting the identifier so mkdocstrings could not collect it and the strict build aborted. A repo with a module named after a glossary term hit this (yohou: a `stationarity` module and a `Stationarity` `.autolink` term → `::: yohou.[stationarity](…).ASinhTransformer`). Skip `:::` directive lines, exactly as ATX headings and indented code already were. A regression from v0.28.4, where the glossary ran as an `on_page_content` hook *after* render.

## Why they shipped, and the guard added
The recurring fleet trap: **every check read the `.jinja` source; nothing parsed the rendered output.** Added three regression tests over the rendered tree (both `include_examples` variants):
- `test_every_rendered_yaml_file_parses` — parses every rendered `.yml`/`.yaml`, with a non-zero-count floor so a selector matching nothing cannot pass silently.
- extended `test_no_rendered_file_ends_in_a_blank_line` to also catch a *missing* trailing newline.
- `test_glossary_never_links_inside_an_autodoc_directive` — a term whose slug collides with a module path segment must leave the `:::` line untouched.

Each fix verified against fresh renders of both variants; the glossary fix has a negative control (unguarded prose path still corrupts; guarded `_linkify` preserves the directive). Fast suite: 160 passed.

## After merge
Tag **v0.29.1**, then the fleet second pass folds v0.29.1 into the seven open `template-update` PRs (a small delta on top of their v0.29.0 work), clearing the red check-yaml/RTD/strict-build checks.

## Not in this PR (repo-side, correctly surfaced by the new machinery, for repo owners)
- Broken `See Also` targets in **sklearn-wrap** (1) and **kedro-dagster** (5) docstrings — the new `_see_also.py` correctly failing `--strict` on cross-refs that the old hook emitted as silent plain text.
- **kedro-dagster** `datasets.md`: a latent generated-vs-curated duplicate primary anchor now surfaced by the first autoref lookup; fix is `options: { skip_local_inventory: true }` on its two `:::` blocks (any repo curating a `:::` page over an auto-generated object will hit this).