### PR TITLE
fix(docs): render a hand-written bullet See Also as a flat list

### DIFF
--- a/template/docs_build/_see_also.py.jinja
+++ b/template/docs_build/_see_also.py.jinja
@@ -32,6 +32,12 @@ _HEADING = re.compile(r"(?m)^(?P<indent>[ \t]*)See Also[ \t]*\n(?P=indent)-{3,}[
 # name-only targets onto one line.
 _ENTRY = re.compile(r"^\s*`?(?P<name>[A-Za-z_][\w.]*)`?\s*(?::\s*(?P<desc>.*))?$")
 
+# A leading markdown list marker on an entry line. Some docstrings hand-write See
+# Also as a bullet list already (``- `X` : ...``); stripping the marker before we
+# re-wrap the entry stops ``- `X``` becoming ``- - `X```` -- a nested,
+# double-bulleted list once rendered.
+_LIST_MARKER = re.compile(r"^[-*+]\s+")
+
 
 class SeeAlsoExtension(Extension):
     """Rewrite See Also blocks into markdown cross-references at collection time."""
@@ -112,6 +118,10 @@ class SeeAlsoExtension(Extension):
         left it unlinked. Indentation is the real signal -- a line at (or below)
         the first entry's indent starts a new entry; a more-indented line
         continues the one above.
+
+        A leading markdown list marker on an entry is stripped: some docstrings
+        hand-write See Also as a bullet list, and re-wrapping ``- `X``` into
+        ``- - `X``` renders a nested, double-bulleted list.
         """
         entries: list[list[str]] = []
         base_indent: int | None = None
@@ -122,7 +132,7 @@ class SeeAlsoExtension(Extension):
             if base_indent is None:
                 base_indent = indent
             if not entries or indent <= base_indent:
-                entries.append([line.strip()])
+                entries.append([_LIST_MARKER.sub("", line.strip())])
             else:
                 entries[-1].append(line.strip())
         return [" ".join(parts) for parts in entries]

--- a/tests/test_see_also.py
+++ b/tests/test_see_also.py
@@ -69,6 +69,16 @@ class NameOnly:
     Beta
     Gamma
     """
+
+
+class Bulleted:
+    """Bulleted.
+
+    See Also
+    --------
+    - [`Beta`][test_project.models.Beta] : Hand-written bullet with a link.
+    - [`Gamma`][test_project.models.Gamma] : Another.
+    """
 '''
 
 
@@ -163,6 +173,22 @@ def test_name_only_entries_each_become_a_linked_list_item(rewritten):
     assert "- [`Beta`][test_project.models.Beta]" in out
     assert "- [`Gamma`][test_project.models.Gamma]" in out
     assert "Beta Gamma" not in out  # not collapsed onto one flowed line
+
+
+def test_pre_bulleted_entries_render_as_a_flat_list(rewritten):
+    """Hand-written bullet-list See Also entries render as a flat list, not nested.
+
+    Some docstrings already write See Also as markdown bullets with author links
+    (``- [`X`][ref] : desc``). Re-wrapping ``- [X]`` into ``- - [X]`` renders a
+    nested, double-bulleted list once markdown converts it -- yohou (the fleet's
+    largest curated docs) does this in 169 blocks. The leading list marker is
+    stripped so each entry becomes a single clean list item, the author's link
+    preserved.
+    """
+    out = rewritten("models.Bulleted")
+    assert "- [`Beta`][test_project.models.Beta] : Hand-written bullet with a link." in out
+    assert "- [`Gamma`][test_project.models.Gamma] : Another." in out
+    assert "- -" not in out, "entries were double-bulleted -- markdown renders that as a nested list"
 
 
 def test_single_entry_stays_a_paragraph(rewritten):


### PR DESCRIPTION
## What

A residual See Also rendering bug I found while verifying v0.29.2 against yohou's *actual* rendered output. The v0.29.2 name-only fix stopped multi-target See Also blocks collapsing onto one line, but for docstrings that **hand-write See Also as a markdown bullet list** it introduced a subtler artifact.

yohou (the fleet's largest curated docs) writes See Also like this in **169 blocks**:

```
See Also
--------
- [`BaseForecaster`][yohou.base.forecaster.BaseForecaster] : Base class for forecasters.
- [`LagTransformer`][yohou.preprocessing.window.LagTransformer] : Creates lagged features.
```

The rewrite prepended its own `- ` to every entry, turning `- [X]` into `- - [X]`, which markdown converts to a **nested, double-bulleted list** — one indented single-item sublist per entry (`<ul><li><ul><li>…`). The author's links still resolve (via autorefs), so it *looks* like a list of linked bullets, but the structure is wrong: extra nesting and indentation on every entry.

This is invisible to `check_docs` — a malformed-but-valid list is not a `--strict` warning — so only an eyeball on rendered HTML catches it.

## Fix

Strip a leading list marker (`-`/`*`/`+`) from each entry before re-wrapping, so a pre-bulleted entry becomes **one clean flat list item** with the author's link preserved. Verified flat (no nesting, no double-dash) across every See Also form:

| form | result |
|---|---|
| `- [`X`][ref] : desc` (yohou) | flat, author link kept |
| `- X : desc` (pre-bulleted, plain) | flat, linked |
| `X` (name-only) | flat, linked |
| `X : desc` | flat, linked |
| single entry | paragraph |
| wrapped description | joined, flat |

## Test
`test_pre_bulleted_entries_render_as_a_flat_list` (a `Bulleted` model in `tests/test_see_also.py`) asserts no `- -` double-bullet and the author link intact. Whole `tests/` fast suite: 352 passed.

## After merge
Tag **v0.29.3**; fold into yohou PR #112 (its 169 See Also blocks render as clean flat lists) — materially yohou; inert-but-correct for the rest.
