### PR TITLE
feat(docs): render numpydoc References sections as a markdown list

### DIFF
--- a/template/.claude/skills/diataxis-reference-writer/SKILL.md
+++ b/template/.claude/skills/diataxis-reference-writer/SKILL.md
@@ -124,6 +124,25 @@ def process(data: list[float], *, normalize: bool = False) -> Result:
     """
 ```
 
+### References and Citations
+
+Write a `References` section as a **markdown ordered list with markdown links**, and cite it in prose with a plain `[1]`. Do **not** use reStructuredText/Sphinx citation syntax — `.. [1]` definitions or `[1]_` references. griffe hands the References section to mkdocstrings as raw text, so RST renders literally on the page (`.. [1]` appears verbatim) instead of as a citation. See `src/<package>/hello.py` for a worked example.
+
+```python
+def estimate(...):
+    """Estimate the thing.
+
+    The method follows the standard approach [1] with the correction from [2].
+
+    References
+    ----------
+    1. [Author, A. (2019). Title of the work.](https://doi.org/10.1000/xyz):
+        the method this implements.
+    2. [Author, B. (2023). A follow-up.](https://doi.org/10.1000/abc):
+        the correction applied here.
+    """
+```
+
 ### MkDocs Page Using mkdocstrings
 
 ```markdown

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs_build/_markdown_export.py       # build step imported by build.py; same tie
 docs_build/_notebooks.py             # build step imported by build.py; examples-only
 docs_build/serve.py                  # live-preview supervisor; watches src/ and regenerates API pages
 docs_build/_see_also.py              # griffe extension; rewrites numpydoc See Also into cross-references
+docs_build/_references.py            # griffe extension; normalizes numpydoc References into a markdown ordered list
 docs_build/_source_links.py           # griffe extension; attaches View-on-GitHub URLs for the Source Code heading
 docs_build/_markers.py               # python-markdown extension; resolves the docs markers (API_TABLE, SUBPAGES, gallery, companion)
 docs_build/_glossary.py              # python-markdown extension; links glossary terms to their definitions at markdown level

--- a/template/.github/skills/diataxis-reference-writer/SKILL.md
+++ b/template/.github/skills/diataxis-reference-writer/SKILL.md
@@ -124,6 +124,25 @@ def process(data: list[float], *, normalize: bool = False) -> Result:
     """
 ```
 
+### References and Citations
+
+Write a `References` section as a **markdown ordered list with markdown links**, and cite it in prose with a plain `[1]`. Do **not** use reStructuredText/Sphinx citation syntax — `.. [1]` definitions or `[1]_` references. griffe hands the References section to mkdocstrings as raw text, so RST renders literally on the page (`.. [1]` appears verbatim) instead of as a citation. See `src/<package>/hello.py` for a worked example.
+
+```python
+def estimate(...):
+    """Estimate the thing.
+
+    The method follows the standard approach [1] with the correction from [2].
+
+    References
+    ----------
+    1. [Author, A. (2019). Title of the work.](https://doi.org/10.1000/xyz):
+        the method this implements.
+    2. [Author, B. (2023). A follow-up.](https://doi.org/10.1000/abc):
+        the correction applied here.
+    """
+```
+
 ### MkDocs Page Using mkdocstrings
 
 ```markdown

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -48,6 +48,7 @@ docs_build/_markdown_export.py       # build step imported by build.py; same tie
 docs_build/_notebooks.py             # build step imported by build.py; examples-only
 docs_build/serve.py                  # live-preview supervisor; watches src/ and regenerates API pages
 docs_build/_see_also.py              # griffe extension; rewrites numpydoc See Also into cross-references
+docs_build/_references.py            # griffe extension; normalizes numpydoc References into a markdown ordered list
 docs_build/_source_links.py           # griffe extension; attaches View-on-GitHub URLs for the Source Code heading
 docs_build/_markers.py               # python-markdown extension; resolves the docs markers (API_TABLE, SUBPAGES, gallery, companion)
 docs_build/_glossary.py              # python-markdown extension; links glossary terms to their definitions at markdown level

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -53,6 +53,21 @@ default_install_hook_types: [pre-commit, commit-msg]
         exclude: .*_version\.py$
         require_serial: true
 
+      # Ban reStructuredText citation syntax in docstrings. numpydoc "References"
+      # sections must use a markdown ordered list with plain `[1]` prose citations,
+      # never RST (`.. [1]` definitions or `[1]_` references) -- griffe hands the
+      # section to mkdocstrings as raw text, so RST renders literally on the API
+      # page. The docs build normalizes it anyway, but catching it at author time
+      # keeps the source clean. `pygrep` is built into prek, so this adds no
+      # dependency; it fails when either form matches.
+      - id: no-rst-citations
+        name: no reStructuredText citation syntax in docstrings
+        description: Use a markdown ordered list and plain `[1]` citations, not RST `.. [1]` / `[1]_`.
+        language: pygrep
+        entry: '(^\s*\.\. \[|\[[^]]+\]_)'
+        types: [python]
+        files: ^src/
+
       # Ruff linter (autofix)
       - id: ruff
         name: ruff

--- a/template/docs_build/_references.py.jinja
+++ b/template/docs_build/_references.py.jinja
@@ -1,0 +1,137 @@
+"""Griffe extension: normalize numpydoc "References" into a markdown list.
+
+This runs during Griffe collection, before mkdocstrings parses the docstring, so a
+References section written in any of the three styles seen across the fleet --
+reStructuredText citation definitions (`.. [1] ...`), bare-bracket entries
+(`[1] ...`), or an already-markdown ordered list (`1. ...`) -- renders as one
+clean markdown ordered list. It is the twin of `_see_also.py`: Griffe's numpy
+parser hands a References section to mkdocstrings as an unstructured *admonition*
+whose raw text is passed straight to `convert_markdown`, so RST citation syntax
+renders literally (`.. [1]` appears verbatim on the page) and a bare-bracket block
+collapses into one run-on paragraph. Rewriting the raw docstring here fixes both,
+independent of when and how the docstring is later parsed, and under any engine.
+
+Registered via `handlers.python.options.extensions` in mkdocs.yml, next to
+`_see_also`. Unlike See Also, References entries are freeform citations that name
+no project symbols, so this extension needs no name lookup -- it only reshapes
+text.
+
+The render target is a markdown ordered list, NOT markdown footnotes (`[^1]`):
+mkdocstrings pools footnotes at the *page* bottom and their numbers collide across
+the many objects rendered on one API page, so a list -- which stays inside each
+object's own section -- is the portable form. `hello.py` in the template models it.
+"""
+
+import logging
+import re
+
+from griffe import Extension
+
+# Warnings logged under the "mkdocs" logger tree are counted by mkdocs and turn a
+# --strict build red -- the same idiom `_markers` and `_api_pages` use. A References
+# section that still holds RST citation syntax after this pass would otherwise ship
+# as literal text on the page; warning here makes that a build failure instead.
+log = logging.getLogger("mkdocs.hooks")
+
+# The "References" section heading: a line, then an underline of dashes at the same
+# indent (numpydoc requires the underline to be at least as long as the title).
+_HEADING = re.compile(r"(?m)^(?P<indent>[ \t]*)References[ \t]*\n(?P=indent)-{3,}[ \t]*\n")
+
+# The start of the NEXT numpydoc section: a non-blank title line followed by a
+# dashes-only underline. This -- not the first blank line, which is where See Also
+# stops -- is where a References block ends, because references are routinely
+# separated by blank lines; stopping at the first one would drop every entry after
+# it. A reference entry's continuation lines are never a dashes-only line, so this
+# cannot mistake an entry for a section header.
+_NEXT_SECTION = re.compile(r"(?m)^[ \t]*\S.*\n[ \t]*-{3,}[ \t]*$")
+
+# A leading markdown list marker (`- `, `* `, `+ `, `1. `) on an entry line. Some
+# docstrings already write References as a list; stripping the marker before we
+# re-number stops `1. X` becoming `1. 1. X` (or `- X` a nested `1. - X`).
+_LIST_MARKER = re.compile(r"^(?:\d+\.|[-*+])\s+")
+
+# A leading citation label: the RST definition form (`.. [1] `, `.. [CIT2002] `) or
+# the bare-bracket form (`[1] `). The bare form requires whitespace after the `]` so
+# a markdown link at the start of an entry (`[Title](url)`) is left untouched -- its
+# `]` is followed by `(`, not a space.
+_CITATION = re.compile(r"^\.\. \[[^\]]+\]\s*|^\[[^\]]+\]\s+")
+
+# An inline citation *reference* in RST style: `[1]_`, `[CIT2002]_`. Rewritten to
+# plain `[1]` so no trailing-underscore reference survives into rendered prose.
+_BODY_CITE = re.compile(r"\[([^\]]+)\]_")
+
+# Whatever the RST citation-definition marker looks like after normalization has run.
+# If it survives, an entry could not be reshaped and the page would show it literally.
+_RESIDUAL_RST = ".. ["
+
+
+class ReferencesExtension(Extension):
+    """Rewrite numpydoc References blocks into a markdown ordered list at collection."""
+
+    def on_object(self, *, obj, **_kwargs) -> None:
+        """Rewrite the References block of any object whose docstring has one."""
+        docstring = obj.docstring
+        if docstring is None or "References" not in docstring.value:
+            return
+        rewritten = self._rewrite(docstring.value, obj.path)
+        # Inline `[1]_` references point at a References entry, so only rewrite them
+        # where a References section exists -- conservative, and there are none in
+        # the fleet today anyway.
+        rewritten = _BODY_CITE.sub(r"[\1]", rewritten)
+        if rewritten != docstring.value:
+            docstring.value = rewritten
+
+    def _rewrite(self, text: str, path: str) -> str:
+        """Replace a References block's entries with a markdown ordered list."""
+        heading = _HEADING.search(text)
+        if heading is None:
+            return text
+
+        body_start = heading.end()
+        rest = text[body_start:]
+        # The block runs to the next section header, or to the end of the docstring.
+        next_section = _NEXT_SECTION.search(rest)
+        body_end = body_start + (next_section.start() if next_section else len(rest))
+
+        entries = self._split_entries(text[body_start:body_end])
+        if not entries:
+            return text
+
+        block = "".join(f"{i}. {entry}\n" for i, entry in enumerate(entries, start=1))
+        if _RESIDUAL_RST in block:
+            # An entry held RST citation syntax the marker strip did not reach (a
+            # second directive, a directive on a continuation line). Left alone it
+            # renders verbatim; under --strict this warning fails the build.
+            log.warning("references: RST citation syntax survived normalization in %s", path)
+
+        return text[:body_start] + block + text[body_end:]
+
+    def _split_entries(self, body: str) -> list[str]:
+        """Group the block's lines into entries and strip each entry's marker.
+
+        numpydoc puts each reference at the section's base indent and indents any
+        wrapped continuation beneath it; entries may be separated by blank lines.
+        A line at (or below) the first entry's indent starts a new entry; a
+        more-indented line continues the one above. Each entry's leading list
+        marker and citation label are stripped, so the caller can re-number from 1
+        without doubling markers.
+        """
+        entries: list[list[str]] = []
+        base_indent: int | None = None
+        for line in body.splitlines():
+            if not line.strip():
+                continue
+            indent = len(line) - len(line.lstrip())
+            if base_indent is None:
+                base_indent = indent
+            stripped = line.strip()
+            if not entries or indent <= base_indent:
+                entries.append([self._strip_marker(stripped)])
+            else:
+                entries[-1].append(stripped)
+        return [" ".join(parts).strip() for parts in entries]
+
+    def _strip_marker(self, line: str) -> str:
+        """Remove a leading list marker and citation label from an entry's first line."""
+        line = _LIST_MARKER.sub("", line, count=1)
+        return _CITATION.sub("", line, count=1)

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -206,9 +206,13 @@ plugins:
             # Griffe extensions run during collection. `_see_also` rewrites
             # numpydoc "See Also" blocks into markdown cross-references before the
             # docstring is rendered, so autorefs links them -- replacing the HTML
-            # post-processing the docs hooks used to do.
+            # post-processing the docs hooks used to do. `_references` is its twin
+            # for the "References" section: it normalizes RST citation syntax
+            # (`.. [1]`) and bare-bracket entries into a markdown ordered list, so
+            # neither renders as literal text or a run-on paragraph.
             extensions:
               - docs_build/_see_also.py
+              - docs_build/_references.py
               - docs_build/_source_links.py
             docstring_style: numpy
             show_source: true

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,227 @@
+"""Tests for the References Griffe extension (`docs_build/_references.py`).
+
+The extension normalizes a numpydoc "References" section into a markdown ordered
+list at Griffe collection time, before mkdocstrings renders the docstring. Griffe
+hands the section to mkdocstrings as raw text, so without this pass RST citation
+syntax (`.. [1]`) renders literally and a bare-bracket block collapses into one
+run-on paragraph. These tests drive the extension through a real Griffe load and
+assert on the rewritten docstring; one test builds the docs and checks that a
+References section reaches the page as a list with no RST artifacts.
+"""
+
+import importlib.util
+import logging
+import sys
+
+import pytest
+from _build_layout import BUILD_DIR
+
+_MODELS = '''\
+"""Models."""
+
+
+class RstStyle:
+    """RST style.
+
+    References
+    ----------
+    .. [1] Akiba, T. (2019). Optuna. <https://doi.org/10.1145/3292500.3330701>
+    """
+
+
+class BareBracket:
+    """Bare bracket.
+
+    References
+    ----------
+    [1] Hyndman, R.J. (2021). "Forecasting: principles and
+        practice," 3rd edition.
+    """
+
+
+class MultiEntry:
+    """Multi entry.
+
+    References
+    ----------
+    [1] First reference.
+
+    [2] Second reference.
+    """
+
+
+class MarkdownList:
+    """Markdown list.
+
+    References
+    ----------
+    1. [NumPy guide](https://numpydoc.readthedocs.io/):
+        the convention used here.
+    2. [PEP 498](https://peps.python.org/pep-0498/):
+        f-strings.
+    """
+
+
+class BodyCite:
+    """Body cite.
+
+    Uses the method [1]_ described below.
+
+    References
+    ----------
+    [1] Some Author (2020).
+    """
+
+
+class FollowedBySection:
+    """Followed by section.
+
+    References
+    ----------
+    [1] Only reference.
+
+    Examples
+    --------
+    >>> FollowedBySection()
+    """
+
+
+class ResidualRst:
+    """Residual RST.
+
+    References
+    ----------
+    [1] An entry embedding a stray .. [note] directive mid-text.
+    """
+'''
+
+
+def _load_extension(project_dir, suffix):
+    """Load the generated `_references` extension under a unique module name."""
+    sys.modules.pop("_references", None)
+    spec = importlib.util.spec_from_file_location(
+        f"generated_references_{suffix}", project_dir / BUILD_DIR / "_references.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rewritten(project_dir, extension_module, package_name, obj_path):
+    """Load the package through Griffe with the extension; return obj's docstring."""
+    import griffe
+
+    extensions = griffe.load_extensions(extension_module.ReferencesExtension())
+    loader = griffe.GriffeLoader(search_paths=[str(project_dir / "src")], extensions=extensions)
+    package = loader.load(package_name)
+    return package[obj_path].docstring.value
+
+
+@pytest.fixture
+def rewritten(copie):
+    """Render a project, drop in a models module, return a per-object rewriter."""
+    result = copie.copy(extra_answers={"include_examples": False})
+    assert result.exit_code == 0
+    project_dir = result.project_dir
+    (project_dir / "src" / "test_project" / "models.py").write_text(_MODELS, encoding="utf-8")
+    ext = _load_extension(project_dir, "references")
+
+    def _get(obj_path):
+        return _rewritten(project_dir, ext, "test_project", obj_path)
+
+    return _get
+
+
+def test_rst_citation_definition_becomes_a_list_item(rewritten):
+    """`.. [1] ...` is normalized to `1. ...` with no RST marker left behind."""
+    out = rewritten("models.RstStyle")
+    assert "1. Akiba, T. (2019). Optuna." in out
+    assert ".. [" not in out
+    assert "[1]" not in out
+
+
+def test_bare_bracket_entry_joins_its_continuation(rewritten):
+    """`[1] ...` with an indented continuation becomes one list item, not a code block."""
+    out = rewritten("models.BareBracket")
+    assert '1. Hyndman, R.J. (2021). "Forecasting: principles and practice," 3rd edition.' in out
+    assert "[1] Hyndman" not in out
+
+
+def test_multiple_entries_become_distinct_list_items(rewritten):
+    """Blank-line-separated entries each get their own number, not one paragraph."""
+    out = rewritten("models.MultiEntry")
+    assert "1. First reference." in out
+    assert "2. Second reference." in out
+    # The bracket markers are gone and the two references are not run together.
+    assert "[1]" not in out
+    assert "[2]" not in out
+
+
+def test_existing_markdown_list_is_preserved(rewritten):
+    """An already-markdown list keeps its links and is not double-numbered."""
+    out = rewritten("models.MarkdownList")
+    assert "1. [NumPy guide](https://numpydoc.readthedocs.io/):" in out
+    assert "2. [PEP 498](https://peps.python.org/pep-0498/):" in out
+    assert "1. 1." not in out
+    assert "](https://numpydoc.readthedocs.io/)" in out  # link intact
+
+
+def test_body_citation_reference_loses_its_underscore(rewritten):
+    """An inline `[1]_` reference in prose becomes plain `[1]`."""
+    out = rewritten("models.BodyCite")
+    assert "the method [1] described below." in out
+    assert "[1]_" not in out
+
+
+def test_section_boundary_stops_at_the_next_section(rewritten):
+    """A section after References is preserved, not swallowed into the block."""
+    out = rewritten("models.FollowedBySection")
+    assert "1. Only reference." in out
+    assert "Examples" in out
+    assert ">>> FollowedBySection()" in out
+
+
+def test_unnormalizable_rst_warns(rewritten, caplog):
+    """RST citation syntax that survives normalization warns (fatal under --strict).
+
+    A stray `.. [` inside an entry's text is not a leading marker the strip
+    reaches, so it would render literally. The extension logs under the ``mkdocs``
+    logger tree, which mkdocs counts and a ``--strict`` build treats as an error.
+    """
+    with caplog.at_level(logging.WARNING, logger="mkdocs.hooks"):
+        out = rewritten("models.ResidualRst")
+    assert "1. An entry embedding a stray" in out
+    assert any("references:" in r.message and "ResidualRst" in r.message for r in caplog.records)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_references_render_as_a_list_end_to_end(copie):
+    """A full build renders a References section as a list with no RST leak.
+
+    The unit tests prove the rewrite; this proves it reaches the rendered page.
+    The sample package's ``Greeter`` ships a References section, so its generated
+    page is the one to inspect.
+    """
+    import subprocess
+
+    result = copie.copy(extra_answers={"include_examples": False})
+    assert result.exit_code == 0
+    project_dir = result.project_dir
+
+    build = subprocess.run(
+        ["uvx", "nox", "-s", "build_docs"],
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert build.returncode == 0, f"build failed:\n{build.stdout}\n{build.stderr}"
+
+    page = project_dir / "site" / "pages" / "api" / "generated" / "test_project.hello.Greeter" / "index.html"
+    assert page.is_file(), "generated page for Greeter not found"
+    html = page.read_text(encoding="utf-8")
+    # The References section reached the page as a list, and no RST marker leaked.
+    assert "numpydoc.readthedocs.io" in html, "References content missing from the page"
+    assert ".. [" not in html, "RST citation syntax leaked into the rendered page"


### PR DESCRIPTION
## Why

numpydoc **References** sections render incorrectly on every generated docs site. Griffe's numpy parser treats References — like See Also — as an unstructured *admonition* and passes the raw section text to `convert_markdown`. So RST/Sphinx citation syntax leaks as literal text, and the common bare-bracket style collapses into one run-on paragraph. Confirmed live: `sklearn-optuna`'s `OptunaSearchCV` page renders the literal string `.. [1] Akiba, T., …`.

Across the 7 generated repos, three styles exist today: RST `.. [n]` (1 object, sklearn-optuna), bare-bracket `[n]` (8 of 9 References sections), and markdown ordered list (only the template's own `hello.py`, the intended style).

## What

- **New griffe extension `docs_build/_references.py`** (twin of `_see_also.py`): rewrites the References block at collection time, normalizing all three styles into one markdown ordered list, joining numpydoc continuation lines, and rewriting body `[n]_` → `[n]`. Residual `.. [` warns under the `mkdocs` logger tree → fatal under `--strict` (fail loud, not silent).
- **Registered** in `mkdocs.yml` next to `_see_also.py`.
- **`no-rst-citations` pygrep pre-commit hook** (zero-dependency) banning `.. [` / `[…]_` in `src/` — defense-in-depth so authored docstrings stay clean.
- **Convention documented** in the `diataxis-reference-writer` skill (both `.claude` and `.github` mirrors).

Render target is an ordered list, **not** footnotes: mkdocstrings pools footnotes at page bottom with colliding numbers across the many objects on one API page.

## Verification

- 7 new unit tests (all three styles → `<ol>`, section-boundary, `[n]_`→`[n]`, idempotent markdown list, strict-warn guard) + 1 integration test.
- 102 docs-related fast tests pass, no regressions; `just fix` clean.
- Built a generated project's docs and confirmed the `Greeter` References renders as an `<ol>` with linked items and **no `.. [` / `[1]_` on the page**.
- Verified the pre-commit hook fails on injected RST and passes clean, end-to-end in a generated project via prek.

## Fleet rollout (follow-up, not in this PR)

The transform fixes rendering for every repo on its **next docs build after `copier update`** — with zero docstring edits. The only manual touch is `sklearn-optuna`'s one `.. [1]` source line, which the new lint flags on adoption (the transform renders it correctly regardless). Repos without References sections (`kedro-dagster`, `kedro-azureml-pipeline`) are unaffected; the extension is not gated on `include_examples`.