### PR TITLE
fix(docs): join flush-left References citation continuation lines

### DIFF
--- a/template/docs_build/_references.py.jinja
+++ b/template/docs_build/_references.py.jinja
@@ -109,27 +109,30 @@ class ReferencesExtension(Extension):
     def _split_entries(self, body: str) -> list[str]:
         """Group the block's lines into entries and strip each entry's marker.
 
-        numpydoc puts each reference at the section's base indent and indents any
-        wrapped continuation beneath it; entries may be separated by blank lines.
-        A line at (or below) the first entry's indent starts a new entry; a
-        more-indented line continues the one above. Each entry's leading list
-        marker and citation label are stripped, so the caller can re-number from 1
-        without doubling markers.
+        A new reference begins at a citation marker (`[1]`, `.. [1]`) or a list
+        marker (`1.`, `-`); every other line continues the entry above it. This is
+        keyed on the marker, NOT on indentation: numpydoc *recommends* indenting a
+        wrapped continuation, but many docstrings write the continuation flush with
+        the marker line, and splitting those by indent turned one citation into one
+        list item per physical line. Marker-keyed splitting folds a flush-left
+        multi-line citation into a single entry and still separates blank-line- or
+        indent-separated entries correctly. Each entry's leading marker is stripped
+        so the caller can re-number from 1 without doubling markers.
         """
         entries: list[list[str]] = []
-        base_indent: int | None = None
         for line in body.splitlines():
             if not line.strip():
                 continue
-            indent = len(line) - len(line.lstrip())
-            if base_indent is None:
-                base_indent = indent
             stripped = line.strip()
-            if not entries or indent <= base_indent:
+            if not entries or self._starts_entry(stripped):
                 entries.append([self._strip_marker(stripped)])
             else:
                 entries[-1].append(stripped)
         return [" ".join(parts).strip() for parts in entries]
+
+    def _starts_entry(self, line: str) -> bool:
+        """Whether a (stripped) line begins a new reference: it leads with a marker."""
+        return bool(_LIST_MARKER.match(line) or _CITATION.match(line))
 
     def _strip_marker(self, line: str) -> str:
         """Remove a leading list marker and citation label from an entry's first line."""

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -93,6 +93,17 @@ class ResidualRst:
     ----------
     [1] An entry embedding a stray .. [note] directive mid-text.
     """
+
+
+class FlushLeft:
+    """Flush left.
+
+    References
+    ----------
+    [1] Akiba, T. (2019). Optuna: A Next-generation Framework.
+    In Proceedings of the 25th ACM SIGKDD International Conference.
+    https://doi.org/10.1145/3292500.3330701
+    """
 '''
 
 
@@ -171,6 +182,23 @@ def test_body_citation_reference_loses_its_underscore(rewritten):
     out = rewritten("models.BodyCite")
     assert "the method [1] described below." in out
     assert "[1]_" not in out
+
+
+def test_flush_left_multiline_citation_is_one_item(rewritten):
+    """A bare-bracket citation whose continuations are NOT indented stays one item.
+
+    numpydoc recommends indenting a wrapped continuation, but many docstrings write
+    it flush with the `[1]` marker. Splitting entries by indentation turned such a
+    citation into one list item per physical line; splitting on the citation marker
+    folds it back into a single entry.
+    """
+    out = rewritten("models.FlushLeft")
+    assert (
+        "1. Akiba, T. (2019). Optuna: A Next-generation Framework. "
+        "In Proceedings of the 25th ACM SIGKDD International Conference. "
+        "https://doi.org/10.1145/3292500.3330701" in out
+    )
+    assert "2." not in out  # not split into multiple numbered items
 
 
 def test_section_boundary_stops_at_the_next_section(rewritten):


### PR DESCRIPTION
## Why

The v0.29.4 fleet roll-out surfaced this on **yohou-optuna**: its `OptunaSearchCV` References citation wraps across five source lines written *flush* with the `[1]` marker (not indented under it). The `_references` extension split entries by indentation, so each physical line became its own `<li>` — the citation rendered as five numbered items instead of one.

Every other repo indents its continuations, so this was a single instance — but it's a real limitation: flush-left continuation is a common, valid docstring style.

## What

`_split_entries` now keys on the **citation marker**, not indentation: a line starting with `[1]` / `.. [1]` / `1.` begins a new reference; every other line continues the entry above it. This folds a flush-left multi-line citation into one item and still separates blank-line- or indent-separated entries correctly.

- Handles indented, flush-left, RST, and markdown-list forms uniformly.
- New regression test `test_flush_left_multiline_citation_is_one_item`; all existing tests still pass (8 total).

## Rollout note

Low urgency — the acute instance (yohou-optuna) was already fixed at source in its v0.29.4 PR by indenting the continuation. This is the durable template fix; it can ride the next routine release and fan-out rather than forcing a re-fan of the open v0.29.4 PRs.