### PR TITLE
fix(ci): pin exact uv version in all setup-uv steps

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -139,6 +139,17 @@ include_actions:
   help: "Include GitHub Actions CI/CD workflows?"
   default: true
 
+uv_version:
+  type: str
+  # Pinned exact uv version for the CI setup-uv steps. Pinning an exact X.Y.Z
+  # skips setup-uv's resolve-"latest" network call (the transient "fetch failed"
+  # point); a range would still resolve over the network, so keep it exact.
+  # Bumped by hand: Dependabot's github-actions ecosystem updates `uses:` refs,
+  # not the setup-uv `version:` input, and nothing reads copier.yml.
+  help: "uv version to pin in CI setup-uv steps (exact X.Y.Z)"
+  default: "0.10.0"
+  when: "{{ include_actions }}"
+
 include_examples:
   type: bool
   help: "Include examples/ directory with marimo notebooks?"

--- a/template/.claude/skills/update-from-template/SKILL.md
+++ b/template/.claude/skills/update-from-template/SKILL.md
@@ -179,6 +179,26 @@ without it. Anyone who skips this keeps invoking a runner that can no longer par
 they get a confusing failure rather than a clean one. Tell every contributor, not just
 whoever ran the update.
 
+### Pin uv in workflows the template does not own
+
+`copier update` only touches files the template generates. The templated workflows
+(`tests.yml`, `changelog.yml`, `nightly.yml`, `commit-message.yml`) pin an exact uv
+version on every `astral-sh/setup-uv` step:
+
+```yaml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"   # exact X.Y.Z, not "latest" or a range
+          # ...existing enable-cache / cache-dependency-glob stay as they are
+```
+
+An unpinned step resolves "latest" over the network on every run, and a transient
+blip there fails the job in a fraction of a second with `##[error]fetch failed`,
+before any real work. **Any workflow you added yourself** (anything not in the list
+above) keeps its own `astral-sh/setup-uv` steps, and the update leaves them untouched.
+After syncing, add the same exact `version:` pin to those steps by hand, matching the
+value the templated workflows now use, so the flake cannot reach your bespoke CI either.
+
 ```bash
 git add -A
 git commit -m "chore: update from template <version>"

--- a/template/.copier-answers.yml.jinja
+++ b/template/.copier-answers.yml.jinja
@@ -15,3 +15,4 @@ min_python_version: '{{ min_python_version }}'
 package_name: {{ package_name }}
 project_name: {{ project_name }}
 project_slug: {{ project_slug }}
+uv_version: '{{ uv_version }}'

--- a/template/.github/skills/update-from-template/SKILL.md
+++ b/template/.github/skills/update-from-template/SKILL.md
@@ -179,6 +179,26 @@ without it. Anyone who skips this keeps invoking a runner that can no longer par
 they get a confusing failure rather than a clean one. Tell every contributor, not just
 whoever ran the update.
 
+### Pin uv in workflows the template does not own
+
+`copier update` only touches files the template generates. The templated workflows
+(`tests.yml`, `changelog.yml`, `nightly.yml`, `commit-message.yml`) pin an exact uv
+version on every `astral-sh/setup-uv` step:
+
+```yaml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"   # exact X.Y.Z, not "latest" or a range
+          # ...existing enable-cache / cache-dependency-glob stay as they are
+```
+
+An unpinned step resolves "latest" over the network on every run, and a transient
+blip there fails the job in a fraction of a second with `##[error]fetch failed`,
+before any real work. **Any workflow you added yourself** (anything not in the list
+above) keeps its own `astral-sh/setup-uv` steps, and the update leaves them untouched.
+After syncing, add the same exact `version:` pin to those steps by hand, matching the
+value the templated workflows now use, so the flake cannot reach your bespoke CI either.
+
 ```bash
 git add -A
 git commit -m "chore: update from template <version>"

--- a/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "{{ uv_version }}"
 
       - name: Run hooks on generated CHANGELOG
         run: |
@@ -100,6 +102,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}

--- a/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "{{ uv_version }}"
 
       - name: Set up Python
         run: uv python install

--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -23,6 +23,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -34,6 +34,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -71,6 +72,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -109,6 +111,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -154,6 +157,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -181,6 +185,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -207,6 +212,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -260,6 +266,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ class CopierTestFixture:
             "license": "MIT",
             "include_actions": True,
             "include_examples": True,
+            "uv_version": "0.10.0",
         }
 
         # Override with extra answers
@@ -118,6 +119,7 @@ def copie_session_default(session_projects_dir):
         "license": "MIT",
         "include_actions": True,
         "include_examples": True,
+        "uv_version": "0.10.0",
     }
 
     # Generate project once
@@ -163,6 +165,7 @@ def copie_session_minimal(session_projects_dir):
         "license": "MIT",
         "include_actions": False,
         "include_examples": False,
+        "uv_version": "0.10.0",
     }
 
     # Generate project once
@@ -209,6 +212,7 @@ def copie_session_custom(session_projects_dir):
         "license": "Apache-2.0",
         "include_actions": True,
         "include_examples": True,
+        "uv_version": "0.10.0",
     }
 
     # Generate project once

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -402,6 +402,74 @@ class TestWorkflowConsistency:
         # They should all be consistent
         assert len(set(uses_action_values)) <= 2, f"Inconsistent uv setup: {uv_setup_patterns}"
 
+    def test_all_setup_uv_steps_pin_exact_version(self, copie):
+        """Every astral-sh/setup-uv step pins the same exact uv version.
+
+        Resolving "latest" is an un-retried GitHub API call and the point at which a
+        transient network blip fails CI before any real work (the "fetch failed"
+        flake). An exact X.Y.Z pin skips that resolve; a range like "0.10" would still
+        resolve over the network, so asserting the version is merely non-empty is not
+        enough. This also guards that the pin is uniform (no step left on "latest"),
+        that the previously-untested commit-message workflow is covered, and that the
+        cache configuration of each step is preserved rather than disturbed.
+        """
+        import re
+
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflows_dir = result.project_dir / ".github" / "workflows"
+        exact_semver = re.compile(r"^\d+\.\d+\.\d+$")
+
+        # Collect every setup-uv step across all generated workflows, wherever it
+        # appears, so a step added to any workflow is covered without editing the test.
+        setup_uv_steps = []  # (workflow_file, with_block)
+        for workflow_path in sorted(workflows_dir.glob("*.yml")):
+            workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+            for job in (workflow.get("jobs") or {}).values():
+                for step in job.get("steps") or []:
+                    if str(step.get("uses", "")).startswith("astral-sh/setup-uv"):
+                        setup_uv_steps.append((workflow_path.name, step.get("with") or {}))
+
+        assert setup_uv_steps, "no astral-sh/setup-uv steps found in generated workflows"
+
+        # R1: every step pins an *exact* X.Y.Z version, never a range or "latest".
+        pinned_versions = set()
+        for workflow_file, with_block in setup_uv_steps:
+            version = with_block.get("version")
+            assert version, f"{workflow_file}: setup-uv step does not pin a uv version"
+            assert exact_semver.match(str(version)), (
+                f"{workflow_file}: uv version {version!r} is not an exact X.Y.Z pin; "
+                "a range still resolves over the network and reintroduces the flake"
+            )
+            pinned_versions.add(str(version))
+
+        # R2: the pin is uniform. The expected value is read from the rendered project,
+        # not hardcoded, so bumping the copier default does not break this test.
+        assert len(pinned_versions) == 1, f"setup-uv steps pin differing uv versions: {sorted(pinned_versions)}"
+        covered_files = {f for f, _ in setup_uv_steps}
+        assert "commit-message.yml" in covered_files, "commit-message.yml setup-uv step is not covered by the pin"
+
+        # R3: cache configuration preserved. A step that enables the cache must also set
+        # the dependency glob (never half-configured); the dependency-installing test
+        # steps keep their cache; the commit-message step (which installs nothing) gets
+        # no cache fabricated onto it.
+        for workflow_file, with_block in setup_uv_steps:
+            if with_block.get("enable-cache"):
+                assert with_block.get("cache-dependency-glob") == "pyproject.toml", (
+                    f"{workflow_file}: setup-uv enables the cache without the glob"
+                )
+        tests_steps = [w for f, w in setup_uv_steps if f == "tests.yml"]
+        assert tests_steps and all(w.get("enable-cache") for w in tests_steps), (
+            "tests.yml setup-uv steps should retain enable-cache (they install deps)"
+        )
+        commit_steps = [w for f, w in setup_uv_steps if f == "commit-message.yml"]
+        assert commit_steps and all("enable-cache" not in w for w in commit_steps), (
+            "commit-message.yml setup-uv step should pin version only, with no cache"
+        )
+
     def test_all_workflows_install_nox_consistently(self, copie):
         """Test that all workflows that need nox install it the same way."""
         result = copie.copy(extra_answers={"include_actions": True})

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1202,6 +1202,9 @@ def test_copier_answers_stores_all_user_inputs(copie):
     assert "package_name: my_test_pkg" in content
     assert "project_name: My Test Package" in content
     assert "project_slug: my-test-package" in content
+    # uv_version must persist so a project's pinned uv survives `copier update`
+    # (the workflow files regenerate from it); it is recorded unconditionally.
+    assert "uv_version: '0.10.0'" in content or "uv_version: 0.10.0" in content
 
 
 def test_max_python_version_in_classifiers(copie):


### PR DESCRIPTION
## Description

Pins an exact uv version on every generated `astral-sh/setup-uv` step, sourced from a single new `copier.yml` variable (`uv_version`, default `0.10.0`). This removes setup-uv's resolve-"latest" network call, which is the point at which a transient blip fails CI with `##[error]fetch failed` before any real work runs.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

A generated project (`kedro-dagster`) hit a CI failure where the `astral-sh/setup-uv@v7` step "Install the latest version of uv" died in ~0.2s with `fetch failed`, before Python install or any test. It was transient (a re-run passed), but every setup-uv step in this template shared the same un-hardened `latest`-resolving config, so the flake can recur in any of the 7 generated repos. Failing run: https://github.com/stateful-y/kedro-dagster/actions/runs/30019050800

An **exact** pin (not a range) lets setup-uv skip the resolve API call and construct the download URL directly; with the existing `enable-cache`, most runs make zero `github.com` fetches for uv.

## What changed

- **New `copier.yml` variable `uv_version`** (default `0.10.0`), gated `when: include_actions`, and recorded in `.copier-answers.yml.jinja` so a project's pinned uv **survives `copier update`** (the answers file is hand-written; a variable absent from it is silently never persisted).
- **All 11 setup-uv steps** across `tests.yml` (7), `changelog.yml` (2), `nightly.yml` (1), `commit-message.yml` (1) now pin `version: "{{ uv_version }}"`. The 9 cache steps keep `enable-cache`/`cache-dependency-glob`; the 2 bare steps get `version:` only (no fabricated cache).
- **Strengthened guard test** (`test_all_setup_uv_steps_pin_exact_version`) asserts every step pins the same **exact** `X.Y.Z` version and that cache config is intact, reading the value from the rendered project. Plus a persistence assertion in `test_copier_answers_stores_all_user_inputs`.
- **`update-from-template` skill** (both mirrors) gains a note telling downstream maintainers to pin bespoke workflows too.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` (`just test-fast`: 361 passed)
- [x] Tested template generation with `copier copy` (rendered a sample: 11 pins, valid YAML, `uv_version` recorded in `.copier-answers.yml`)
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

**Downstream follow-up the template cannot do.** `copier update` only touches the 4 templated workflows. Generated repos with **non-templated** workflows must pin setup-uv `version:` locally after syncing, notably `kedro-dagster`'s `.github/workflows/tests-versions.yml` (the file that actually flaked). Tracked as the OpenSpec change `fanout-harden-setup-uv-version-pin`, to run after this merges and a release is cut.

**Convention note (exact vs minor).** Pinned to an **exact** version deliberately: a minor/range pin (`"0.10"`) would still resolve the newest patch over the network, defeating the purpose. Bump path is manual and one line (edit `uv_version` in `copier.yml`, release, fan out); Dependabot's `github-actions` ecosystem bumps `uses:` refs, not the setup-uv `version:` input. A Renovate custom manager to auto-bump it is a possible future follow-up (separate tooling decision).
