### PR TITLE
docs(skill): require fan-out PRs be opened ready-for-review

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -223,6 +223,11 @@ Group a section index under `##` headings only when it is big enough to need it 
 - **`gh pr edit` silently fails here** (GraphQL Projects-classic deprecation). Use
   `gh api -X PATCH repos/OWNER/REPO/pulls/N -f title=... -F body=@file` and **read it back**.
 - **A CONFLICTING PR runs no Actions.** "0 failures" out of ~1 check is meaningless.
+- **A DRAFT PR skips draft-gated jobs.** Many jobs in this fleet carry
+  `if: ... pull_request.draft == false` (the full test matrix, compat, and the
+  `tests-versions` matrix). On a draft PR they show `skipping`, so `gh pr checks` reports
+  green over a thin subset — the heaviest jobs, and any job a CI-touching change most needs
+  to exercise, never ran. Open PRs ready-for-review, not draft (see §7).
 - **`gh pr checks` does not accept `--json` on this machine** — it exits with
   `unknown flag: --json`. An earlier version of this file called it a *silent* empty return;
   re-measured, it is a hard error, and the "empty result" agents watched for ~10 minutes was
@@ -485,3 +490,10 @@ it when the repo would otherwise block on something unrelated.
   to a scratch branch, or copy files aside.
 - **Push to the existing branch; do not open a second PR.** These are long-lived
   `template-update/*` PRs that advance across releases.
+- **Open the PR ready-for-review, never draft.** "Held for review" means *do-not-merge*,
+  stated in the body and left to the user — it does NOT mean draft. Draft PRs skip every
+  `pull_request.draft == false` job (the full matrix, compat, `tests-versions`), which are
+  the jobs a fan-out most needs to see green; a CI-touching change (e.g. pinning
+  `tests-versions.yml`) is then verified by nothing but the YAML walker while the PR sits
+  draft. Create with `gh pr create` WITHOUT `--draft`; if a PR already exists as a draft,
+  `gh pr ready <N>` before reporting it done. Leave the actual merge to the user.

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -223,6 +223,11 @@ Group a section index under `##` headings only when it is big enough to need it 
 - **`gh pr edit` silently fails here** (GraphQL Projects-classic deprecation). Use
   `gh api -X PATCH repos/OWNER/REPO/pulls/N -f title=... -F body=@file` and **read it back**.
 - **A CONFLICTING PR runs no Actions.** "0 failures" out of ~1 check is meaningless.
+- **A DRAFT PR skips draft-gated jobs.** Many jobs in this fleet carry
+  `if: ... pull_request.draft == false` (the full test matrix, compat, and the
+  `tests-versions` matrix). On a draft PR they show `skipping`, so `gh pr checks` reports
+  green over a thin subset — the heaviest jobs, and any job a CI-touching change most needs
+  to exercise, never ran. Open PRs ready-for-review, not draft (see §7).
 - **`gh pr checks` does not accept `--json` on this machine** — it exits with
   `unknown flag: --json`. An earlier version of this file called it a *silent* empty return;
   re-measured, it is a hard error, and the "empty result" agents watched for ~10 minutes was
@@ -485,3 +490,10 @@ it when the repo would otherwise block on something unrelated.
   to a scratch branch, or copy files aside.
 - **Push to the existing branch; do not open a second PR.** These are long-lived
   `template-update/*` PRs that advance across releases.
+- **Open the PR ready-for-review, never draft.** "Held for review" means *do-not-merge*,
+  stated in the body and left to the user — it does NOT mean draft. Draft PRs skip every
+  `pull_request.draft == false` job (the full matrix, compat, `tests-versions`), which are
+  the jobs a fan-out most needs to see green; a CI-touching change (e.g. pinning
+  `tests-versions.yml`) is then verified by nothing but the YAML walker while the PR sits
+  draft. Create with `gh pr create` WITHOUT `--draft`; if a PR already exists as a draft,
+  `gh pr ready <N>` before reporting it done. Leave the actual merge to the user.


### PR DESCRIPTION
## Description

Makes the `fan-out-to-packages` skill mandate that fan-out PRs are opened **ready-for-review, not draft**.

## Type of Change

- [x] Documentation update

## Motivation and Context

The v0.29.6 uv-version-pin fan-out opened all 7 fleet PRs as drafts. Draft PRs skip every `if: ... pull_request.draft == false` job — in this fleet the full test matrix, the compat job, and the `tests-versions.yml` matrix. Those are exactly the jobs the fan-out most needs to see run: the change hand-pinned setup-uv in `tests-versions.yml`, and that step was then **skipped** on the draft PR, so its pin was verified only structurally (the YAML walker), never exercised by a runner. A draft fan-out PR reports a green CI that never ran its heaviest jobs.

## What changed

`.claude/skills/fan-out-to-packages/SKILL.md` and its byte-identical `.github/skills/` mirror:
- **§5 (Tooling lies):** a gotcha bullet — a DRAFT PR skips draft-gated jobs, so `gh pr checks` reports green over a thin subset.
- **§7 (Git hygiene):** a mandate — open the PR ready-for-review, never draft; "held for review" means do-not-merge (stated in the body, left to the user), not draft. Create without `--draft`; if one already exists as a draft, `gh pr ready <N>`.

## How Has This Been Tested?

- [x] Both skill mirrors verified byte-identical (`diff -q`)
- [x] `prek` (rumdl) passes on both files

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly

## Additional Notes

Docs-only; no template output changes. Follows #222 (which recorded the bespoke setup-uv workflows the same fan-out surfaced). Both stem from the v0.29.6 rollout of #220.
