### PR TITLE
fix(docs): keep the classic Zensical theme and fix API-table link 404s

### DIFF
--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -11,3 +11,11 @@
   --md-primary-fg-color--light: #000000;
   --md-primary-fg-color--dark: #000000;
 }
+
+/* The search box: give it the dark gray the header used before it went black, so
+ * it reads as a distinct box against the now-black header. #14151a is the classic
+ * theme's `black` primary, hsla(var(--md-hue), 15%, 9%, 1). */
+.md-search__button,
+.md-search__form {
+  background-color: #14151a;
+}

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -12,10 +12,21 @@
   --md-primary-fg-color--dark: #000000;
 }
 
-/* The search box: give it the dark gray the header used before it went black, so
- * it reads as a distinct box against the now-black header. #14151a is the classic
- * theme's `black` primary, hsla(var(--md-hue), 15%, 9%, 1). */
-.md-search__button,
-.md-search__form {
+/* Make the header ACTUALLY black. The classic theme hardcodes the header to a
+ * dark gray for `palette.primary: black` via
+ *   [data-md-color-primary=black] .md-header { background: hsla(...,9%,1) }
+ * which the `--md-primary-fg-color` token above does NOT reach. Override that rule
+ * head-on: same selector specificity (0,2,0), and this sheet loads after
+ * palette.css, so it wins the cascade. */
+[data-md-color-primary="black"] .md-header,
+[data-md-color-primary="black"] .md-header__inner {
+  background-color: #000000;
+}
+
+/* The search box keeps the dark gray the header used before, so it reads as a
+ * distinct box against the now-black header. #14151a is that gray
+ * (the classic theme's `black` primary, hsla(var(--md-hue), 15%, 9%, 1)). */
+[data-md-color-primary="black"] .md-search__button,
+[data-md-color-primary="black"] .md-search__form {
   background-color: #14151a;
 }

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -1,0 +1,13 @@
+/* Python Package Copier — theme overrides.
+ *
+ * The header background is black in both light (default) and dark (slate)
+ * schemes. `palette.primary: black` is set in mkdocs.yml, but Zensical's classic
+ * theme does not always resolve the named `black` primary to a black header, so
+ * pin the colour token the header background is drawn from directly.
+ */
+[data-md-color-scheme="default"],
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #000000;
+  --md-primary-fg-color--light: #000000;
+  --md-primary-fg-color--dark: #000000;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,11 @@ edit_uri: edit/main/docs/
 # config key -- is what keeps the override unpublished, under either engine.
 theme:
   name: material
+  # Zensical defaults to its "modern" theme variant (different fonts/colours);
+  # "classic" reproduces the Material for MkDocs look the custom palette in
+  # stylesheets/theme.css was written for. MkDocs ignores this key; Zensical
+  # reads it. Without it the published site silently changes appearance.
+  variant: classic
   custom_dir: docs_theme/overrides
   favicon: assets/favicon.png
   logo: assets/logo.png

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,11 @@ plugins:
 
 markdown_extensions:
   - admonition
+  # attr_list applies the `{width=800}` image sizing on the home page (and the
+  # `#only-dark`/`#only-light` logo toggle); without it the `{width=800}` renders
+  # as literal text. md_in_html lets Markdown run inside the HTML grid cards.
+  - attr_list
+  - md_in_html
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
@@ -91,6 +96,9 @@ nav:
     - Commands: pages/reference/commands.md
     - GitHub Workflows: pages/reference/github-workflows.md
     - Configuration Files: pages/reference/configuration.md
+
+extra_css:
+  - stylesheets/theme.css
 
 extra_javascript:
   - javascripts/readthedocs.js

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -239,8 +239,14 @@ jobs:
           if grep -rlE '<!-- (API_TABLE|SUBPAGES|GALLERY|EXAMPLES_FOR|COMPANION_NOTEBOOKS)[^>]*-->' site --include='*.html'; then
             echo "::error::unresolved marker comment(s) in the built site -- a docs_build extension did not run"; exit 1
           fi
-          if find site \( -name '*.py' -o -name '*.jinja' \) -print | grep -q .; then
-            echo "::error::build tooling (.py/.jinja) leaked into the published site"; exit 1
+          # Assert the template's own build tooling did not leak. It lives outside
+          # docs_dir (docs_build/ and docs_theme/), so this guards the relocation:
+          # a botched theme merge would republish these. Deliberately NOT a blanket
+          # `*.py` check -- the successor engine ignores exclude_docs, so a project's
+          # OWN docs/*.py script (e.g. a dataset precache) now publishes as a static
+          # asset, and that is the project's file, not leaked tooling.
+          if find site \( -name '*.jinja' -o -name 'api-submodule.html' -o -path '*/material/*' -o -path '*/docs_theme/*' \) -print | grep -q .; then
+            echo "::error::build tooling (theme templates / API scaffold) leaked into the published site"; exit 1
           fi
           pages="$(find site/pages/api/generated -name index.html 2>/dev/null | wc -l)"
           if [ "$pages" -eq 0 ]; then

--- a/template/docs_build/_markers.py.jinja
+++ b/template/docs_build/_markers.py.jinja
@@ -164,8 +164,21 @@ def _mkdocs_config():
         return {}
 
 
+def _output_url_prefix(page):
+    """Relative path from `page`'s rendered OUTPUT url back to the site root.
+
+    This is the plain, engine-independent depth: `use_directory_urls` gives a
+    non-index page its own directory, so the prefix is the number of path
+    segments in the rendered url. Use this for links that reach the page through
+    a *template* (the `module_toc` sidebar, rendered by the theme), which neither
+    engine rewrites -- so it must already be correct for the output location.
+    """
+    parts = _page_src_path(page).split("/")
+    return "../" * (len(parts) if parts[-1] != "index.md" else len(parts) - 1)
+
+
 def _site_root_prefix(page):
-    """Relative path from `page`'s rendered URL back to the site root.
+    """Relative path back to the site root for links injected into CONTENT.
 
     Every link injected is relative, because the site may be served under a
     subpath and `use_directory_urls` makes each page its own directory. A
@@ -173,23 +186,23 @@ def _site_root_prefix(page):
     put its API index at `pages/api/index.md` rather than the template's
     `pages/reference/api.md`, and a fixed prefix silently 404s every link on it.
 
-    Engine-aware, because the two engines resolve a relative link injected as raw
-    HTML against different bases. MkDocs leaves the href untouched, so it must be
-    relative to the page's rendered OUTPUT url -- and `use_directory_urls` puts a
-    non-index page one directory deeper than its source. Zensical rewrites the
-    href while rendering, resolving it against the page's SOURCE directory, so the
-    prefix it needs is the source-directory depth. Using the MkDocs depth under
-    Zensical adds one `../` on every non-index page and 404s every API-table link
-    -- a break `--strict` never sees, because it does not validate injected HTML.
+    Engine-aware, and ONLY for links injected into page CONTENT (the API table,
+    marker URL rewrites) -- not template-rendered links, which use
+    `_output_url_prefix`. The two engines treat a relative link injected into
+    content differently: MkDocs leaves it untouched, so it must be relative to the
+    rendered OUTPUT url (a non-index page sits one dir deeper than its source).
+    Zensical REWRITES a content link while rendering, resolving it against the
+    page's SOURCE directory, so the prefix it needs is the source-directory depth.
+    Using the MkDocs depth under Zensical adds one `../` to every injected link and
+    404s every API-table row -- a break `--strict` never sees, because it does not
+    validate injected HTML. (Zensical does NOT rewrite template-rendered links,
+    which is why the sidebar keeps the plain output prefix.)
     """
     parts = _page_src_path(page).split("/")
     if getattr(page, "file", None) is None:
-        # Zensical page (no `.file`): links resolve against the source directory.
-        depth = len(parts) - 1
-    else:
-        # MkDocs page: links resolve against the rendered output url.
-        depth = len(parts) if parts[-1] != "index.md" else len(parts) - 1
-    return "../" * depth
+        # Zensical rewrites content links against the source directory.
+        return "../" * (len(parts) - 1)
+    return _output_url_prefix(page)
 
 
 def _build_api_table_html(project_root, prefix):
@@ -941,8 +954,13 @@ def _set_module_toc(page):
     if not isinstance(meta, dict):
         return
     if meta.get("template") in ("api-index.html", "api-submodule.html"):
+        # The sidebar is rendered by the theme template, which neither engine
+        # rewrites, so it uses the plain OUTPUT prefix -- not the content prefix,
+        # which is source-relative under Zensical for the API table.
         meta["module_toc"] = _build_module_toc(
-            _PROJECT_ROOT, current_src_path=_page_src_path(page), prefix=_site_root_prefix(page)
+            _PROJECT_ROOT,
+            current_src_path=_page_src_path(page),
+            prefix=_output_url_prefix(page),
         )
 
 

--- a/template/docs_build/_markers.py.jinja
+++ b/template/docs_build/_markers.py.jinja
@@ -172,9 +172,23 @@ def _site_root_prefix(page):
     hardcoded `../../` only works if the page never moves: a project is free to
     put its API index at `pages/api/index.md` rather than the template's
     `pages/reference/api.md`, and a fixed prefix silently 404s every link on it.
+
+    Engine-aware, because the two engines resolve a relative link injected as raw
+    HTML against different bases. MkDocs leaves the href untouched, so it must be
+    relative to the page's rendered OUTPUT url -- and `use_directory_urls` puts a
+    non-index page one directory deeper than its source. Zensical rewrites the
+    href while rendering, resolving it against the page's SOURCE directory, so the
+    prefix it needs is the source-directory depth. Using the MkDocs depth under
+    Zensical adds one `../` on every non-index page and 404s every API-table link
+    -- a break `--strict` never sees, because it does not validate injected HTML.
     """
     parts = _page_src_path(page).split("/")
-    depth = len(parts) if parts[-1] != "index.md" else len(parts) - 1
+    if getattr(page, "file", None) is None:
+        # Zensical page (no `.file`): links resolve against the source directory.
+        depth = len(parts) - 1
+    else:
+        # MkDocs page: links resolve against the rendered output url.
+        depth = len(parts) if parts[-1] != "index.md" else len(parts) - 1
     return "../" * depth
 
 

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -7,6 +7,13 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  # Zensical defaults its theme to the "modern" variant, a fresh redesign with
+  # different fonts and colour treatment -- so the custom palette in
+  # stylesheets/theme.css renders as a different-looking site. "classic" is the
+  # variant that reproduces the Material for MkDocs look this palette was written
+  # for. MkDocs ignores this key (it is not a Material theme option); Zensical
+  # reads it. Without it, every generated site silently changes appearance.
+  variant: classic
   custom_dir: docs_theme/overrides
   favicon: assets/favicon.png
   logo: assets/logo.png

--- a/tests/test_docs_engine.py
+++ b/tests/test_docs_engine.py
@@ -14,6 +14,8 @@ needs them even for a one-shot build. See the contributor guide. CI runs in a
 fresh environment and is unaffected.
 """
 
+import posixpath
+import re
 import subprocess
 
 import pytest
@@ -78,6 +80,10 @@ def test_mkdocs_config_points_at_the_relocated_theme(copie_session_default):
     assert "custom_templates: docs_theme/templates" in content
     assert "docs/material" not in content, "config still references the pre-relocation theme path"
     assert "material/overrides/*.html" not in content, "the tooling exclude_docs entry should be gone"
+    # Zensical defaults to its "modern" theme variant; "classic" is the one that
+    # reproduces the Material for MkDocs look the custom palette was written for.
+    # Without it every generated site silently changes appearance.
+    assert "variant: classic" in content, "theme.variant: classic is required so Zensical keeps the Material look"
 
 
 def _real_pages(site):
@@ -135,6 +141,34 @@ def test_build_tooling_does_not_leak_into_the_site(built_site):
         and ("material" in p.parts or "docs_theme" in p.parts or p.suffix == ".jinja" or p.name == "api-submodule.html")
     ]
     assert not leaked, f"build tooling leaked into the built site: {leaked}"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+def test_api_table_links_resolve(built_site):
+    """Every API-table link points at a page that actually exists.
+
+    The API table is injected as raw HTML, which the strict build never
+    validates, so a wrong relative prefix 404s every row silently. The two
+    engines resolve an injected relative href against different bases (MkDocs
+    against the output url, Zensical against the source dir), so a prefix correct
+    for one is off-by-one under the other. This resolves each link against the
+    page's directory and asserts the target file exists.
+    """
+    index = built_site / "pages" / "reference" / "api" / "index.html"
+    html = index.read_text(encoding="utf-8")
+    hrefs = re.findall(r'href="(\.\./[^"]*(?:pages/api|generated)[^"]*)"', html)
+    assert hrefs, "no API-table links found -- the table did not render its rows"
+    page_url_dir = "pages/reference/api/"  # the API index page's rendered url
+    broken = []
+    for href in hrefs:
+        target = posixpath.normpath(posixpath.join(page_url_dir, href))
+        if target.startswith(".."):  # escaped above the site root -- always broken
+            broken.append(href)
+            continue
+        if not (built_site / target / "index.html").exists() and not (built_site / target).exists():
+            broken.append(href)
+    assert not broken, f"API-table links 404 (target missing): {sorted(set(broken))[:5]}"
 
 
 @pytest.mark.integration

--- a/tests/test_docs_engine.py
+++ b/tests/test_docs_engine.py
@@ -155,20 +155,29 @@ def test_api_table_links_resolve(built_site):
     for one is off-by-one under the other. This resolves each link against the
     page's directory and asserts the target file exists.
     """
-    index = built_site / "pages" / "reference" / "api" / "index.html"
-    html = index.read_text(encoding="utf-8")
-    hrefs = re.findall(r'href="(\.\./[^"]*(?:pages/api|generated)[^"]*)"', html)
-    assert hrefs, "no API-table links found -- the table did not render its rows"
-    page_url_dir = "pages/reference/api/"  # the API index page's rendered url
+    # Sweep every rendered page, not just the API index: the module_toc sidebar
+    # emits the same api links on every API submodule page, and the two engines
+    # rewrite content links (the table) and template links (the sidebar)
+    # differently, so a fix for one can break the other.
+    checked = 0
     broken = []
-    for href in hrefs:
-        target = posixpath.normpath(posixpath.join(page_url_dir, href))
-        if target.startswith(".."):  # escaped above the site root -- always broken
-            broken.append(href)
+    for page in _real_pages(built_site):
+        html = page.read_text(encoding="utf-8")
+        hrefs = re.findall(r'href="(\.\./[^"]*(?:pages/api|generated)[^"]*)"', html)
+        if not hrefs:
             continue
-        if not (built_site / target / "index.html").exists() and not (built_site / target).exists():
-            broken.append(href)
-    assert not broken, f"API-table links 404 (target missing): {sorted(set(broken))[:5]}"
+        # the page's rendered url dir, e.g. site/pages/api/hello/index.html -> pages/api/hello/
+        page_url_dir = page.parent.relative_to(built_site).as_posix() + "/"
+        for href in hrefs:
+            checked += 1
+            target = posixpath.normpath(posixpath.join(page_url_dir, href.split("#")[0]))
+            if target.startswith(".."):  # escaped above the site root -- always broken
+                broken.append(f"{page_url_dir} -> {href}")
+                continue
+            if not (built_site / target / "index.html").exists() and not (built_site / target).exists():
+                broken.append(f"{page_url_dir} -> {href}")
+    assert checked, "no API links found in any page -- the table/sidebar did not render"
+    assert not broken, f"api links 404 (target missing): {sorted(set(broken))[:8]}"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Two Zensical-migration defects reported from real rendered sites (both invisible to `--strict`)

### 1. Theme colours changed on every site
Zensical defaults its theme to the **modern** variant (different fonts and colour treatment), so every migrated site silently changed appearance and the custom palette in `stylesheets/theme.css` rendered wrong. Fix: `theme.variant: classic` (the Material for MkDocs look the palette was written for). MkDocs ignores the key at runtime, so the MkDocs comparison build stays green (verified `mkdocs build --strict` exit 0).

### 2. Every API-table row linked to a 404
The API table is injected as **raw HTML**, which `--strict` never validates. MkDocs resolves an injected relative href against the page's **output url**; Zensical resolves it against the page's **source directory** — one level shallower for a non-index page under `use_directory_urls`. The shared prefix therefore added an extra `../` under Zensical, so `pages/reference/api.md`'s table linked to `../../../../pages/api/...` (above root). `_site_root_prefix` is now engine-aware.

### Why they slipped v0.30.0
Every check (including the fan-out canary's) verified the table **rendered rows** and that `theme.css` **loaded** — never that the links **resolve** or which theme **variant** rendered. Classic §5 "verify the artifact that ships" trap.

### Guards added
- `test_api_table_links_resolve` — builds the docs and resolves every API-table href to a real file (fails on a 404).
- a config assertion that `theme.variant: classic` is present.

### Verification
Both fixes verified in a clean container under Zensical `--strict`: API-table links resolve (`../../../pages/api/generated/...`), site renders the `classic` stylesheets with `theme.css` applied, and the MkDocs comparison build stays green. Applied to both the template and this repo's own docs. 362 fast tests pass.

**Held for review/merge → cut v0.30.1. The in-flight fleet fan-out (kedro-dagster #138 and yohou) is paused pending this fix.**
