### PR TITLE
feat(docs): add an exclamation point to the home welcome title

### DIFF
--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -1,7 +1,7 @@
 ![](assets/logo_dark.png#only-dark){width=800}
 ![](assets/logo_light.png#only-light){width=800}
 
-# Welcome to {{ project_name }}'s documentation
+# Welcome to {{ project_name }}'s documentation!
 
 {{ description }}
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -292,7 +292,7 @@ exclude = ["CHANGELOG.md", "site", "htmlcov", ".nox", ".venv", "openspec"]
 # first.children when the first heading is level 1, an empty ToC on the one
 # page that most needs one.
 "docs/pages/reference/changelog.md" = ["MD041"]
-"docs/index.md" = ["MD041"]  # Landing page starts with logo, not heading
+"docs/index.md" = ["MD041", "MD026"]  # + welcome H1 intentionally ends with "!"
 "CONTRIBUTING.md" = ["MD057"]  # Relative link to docs/ is valid at project level
 {% if include_actions %}
 

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -51,7 +51,7 @@ class TestDocsIndexContent:
 
         # Should include project name in welcome heading and throughout
         assert "My Awesome Tool" in content
-        assert "Welcome to My Awesome Tool's documentation" in content
+        assert "Welcome to My Awesome Tool's documentation!" in content
 
         # Should include CTA cards with proper structure
         assert "Get Started in 5 Minutes" in content


### PR DESCRIPTION
Makes the generated home page's welcome H1 read **`# Welcome to <Project>'s documentation!`** (with an exclamation point). The browser tab is unaffected — the v0.30.2 theme override keeps it the bare site name.

This is the **template default**, so it applies to newly generated projects. Because `docs/index.md` is `_skip_if_exists`, it does not propagate to existing repos via a copier update — the 7 existing fleet repos are being updated directly on their open template-update PR branches (yohou, which had dropped the H1 entirely, gets it added back).

- `template/docs/index.md.jinja` — welcome H1 gains `!`
- `tests/test_docs_content.py` — asserts the `!` is present