### PR TITLE
fix(ci): persist renovate_preset and annotate every setup-uv pin

### DIFF
--- a/template/.copier-answers.yml.jinja
+++ b/template/.copier-answers.yml.jinja
@@ -15,4 +15,5 @@ min_python_version: '{{ min_python_version }}'
 package_name: {{ package_name }}
 project_name: {{ project_name }}
 project_slug: {{ project_slug }}
+renovate_preset: '{{ renovate_preset }}'
 uv_version: '{{ uv_version }}'

--- a/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
@@ -34,6 +34,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
           version: "{{ uv_version }}"
 
       - name: Set up Python

--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -23,6 +23,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          # renovate: datasource=github-releases depName=astral-sh/uv
           version: "{{ uv_version }}"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -817,6 +817,36 @@ def test_workflows_pin_uv_nox_and_git_cliff(copie_session_default):
     for dep in ("astral-sh/uv", "nox", "orhun/git-cliff"):
         assert f"depName={dep}" in joined, f"missing renovate annotation for {dep}, so it cannot be bumped"
 
+    # EVERY setup-uv version pin must carry the annotation, not just one. A single
+    # un-annotated step (e.g. commit-message.yml was missed once) is a pin Renovate
+    # silently never bumps.
+    for wf in workflows:
+        lines = wf.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if line.strip().startswith("version:") and "astral-sh/setup-uv" in "\n".join(lines[max(0, i - 4) : i]):
+                prev = lines[i - 1].strip() if i > 0 else ""
+                assert prev.startswith("# renovate:"), (
+                    f"{wf.name} line {i + 1}: a setup-uv version pin has no `# renovate:` annotation, "
+                    "so Renovate cannot bump it"
+                )
+
+
+def test_renovate_preset_persisted_in_copier_answers(copie):
+    """A chosen renovate_preset must round-trip through .copier-answers.yml.
+
+    That file is an explicit allowlist of variables. A variable missing from it is not
+    persisted, so the next `copier update` falls back to the question default and
+    silently reverts the rendered renovate.json (stub -> self-contained). This guards
+    the preset choice against being lost on the very next update.
+    """
+    result = copie.copy(extra_answers={"renovate_preset": "stateful-y/renovate-config"})
+
+    answers = (result.project_dir / ".copier-answers.yml").read_text(encoding="utf-8")
+    assert "renovate_preset:" in answers and "stateful-y/renovate-config" in answers, (
+        "renovate_preset is not persisted in .copier-answers.yml; a future copier update "
+        "would revert renovate.json to the self-contained config"
+    )
+
 
 def test_github_actions_when_disabled(copie):
     """Test that GitHub Actions workflows are NOT created when include_actions=False."""


### PR DESCRIPTION
## Why

The canary fan-out of v0.31.0 (sklearn-optuna) caught two bugs introduced by #231 before they reached the fleet:

1. **`renovate_preset` was never persisted.** `.copier-answers.yml.jinja` is an explicit allowlist of variables; `renovate_preset` was missing from it. So a fleet repo's chosen preset is not written to its answers file, and the **next** `copier update` (without `--data`) falls back to the default `""` and silently regenerates `renovate.json` as the full self-contained config, clobbering the preset stub. This is exactly the silent-revert failure class the Renovate change set out to eliminate.
2. **Two setup-uv pins were un-annotated** (`commit-message.yml`, `nightly.yml`), so Renovate's custom manager would never bump them.

## What changes

- Add `renovate_preset` to `template/.copier-answers.yml.jinja`.
- Add the `# renovate:` annotation to the setup-uv pins in `commit-message.yml.jinja` and `nightly.yml.jinja`.
- **Regression guards:** a test asserting *every* setup-uv version pin carries a `# renovate:` annotation (this caught the `nightly.yml` miss during development), and a test that `renovate_preset` round-trips through `.copier-answers.yml`.

## Impact on the fan-out

The fleet fan-out is **paused** until this ships. Fanning out v0.31.0 as-is would plant a latent self-revert in all seven repos. Once this is merged and released, the fan-out will target the new tag and pass `--data renovate_preset=stateful-y/renovate-config`, which both renders the stub and persists the answer, making all future updates self-healing.

**Held for review — do not merge** until you're ready to cut the release.

Full fast suite: 366 passed.