### PR TITLE
feat(ci): run whole-project gates at pre-push and add a roll-up merge gate

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -10,7 +10,13 @@ jobs:
     name: Validate Commit Message
     runs-on: ubuntu-latest
 
-    # Only single-commit PRs. GitHub's `squash_merge_commit_title` defaults to
+    # This job always runs so it can be a *required* status check. A job gated off at the
+    # job level is skipped and reports no conclusion, which leaves a required check stuck
+    # "waiting" and blocks the PR. Instead the single-commit gate lives on each step: on a
+    # multi-commit PR the steps skip and the job still reports success, so the ruleset can
+    # require it unconditionally.
+    #
+    # Why single-commit only: GitHub's `squash_merge_commit_title` defaults to
     # COMMIT_OR_PR_TITLE, which takes the squash title from the commit when a PR has
     # exactly one commit and from the PR title otherwise. So this is precisely the case
     # where the commit message -- not the PR title -- is what git-cliff reads into the
@@ -18,12 +24,11 @@ jobs:
     # ship their title, so their intermediate commits stay free-form on purpose:
     # requiring conventional WIP messages that get squashed away is pure friction.
     #
-    # `commits` is the PR's commit count, which is the same input GitHub uses to make
-    # that choice. Counting changed files or diff hunks instead would gate the wrong PRs.
-    if: ${{ github.event.pull_request.commits == 1 }}
+    # `commits` is the PR's commit count, the same input GitHub uses to make that choice.
 
     steps:
       - name: Checkout the commit that will ship
+        if: ${{ github.event.pull_request.commits == 1 }}
         uses: actions/checkout@v7
         with:
           # The PR head itself, not the merge commit checkout/@v7 defaults to -- the
@@ -32,12 +37,15 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
+        if: ${{ github.event.pull_request.commits == 1 }}
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
+        if: ${{ github.event.pull_request.commits == 1 }}
         run: uv python install
 
       - name: Validate the commit message that becomes the squash title
+        if: ${{ github.event.pull_request.commits == 1 }}
         run: |
           git log -1 --format=%B HEAD > "$RUNNER_TEMP/commit-msg"
           echo "Validating the message that will become the squash commit title:"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,3 +91,27 @@ jobs:
         run: |
           # renovate: datasource=pypi depName=nox
           uvx nox@2026.7.11 -s fix
+
+  # Single required status check. The branch ruleset requires this one job, not the
+  # individual jobs above: test-fast is a matrix (its check-run names vary by OS/Python and
+  # differ between draft and ready PRs) and test-full is skipped on draft PRs, so neither
+  # can be named directly in a ruleset. This job depends on every blocking job and passes
+  # only when they all succeeded or were legitimately skipped, giving the ruleset one stable
+  # name that survives matrix and conditional changes. Validate PR Title and Validate Commit
+  # Message live in their own workflows and are required alongside this check.
+  ci-passed:
+    name: CI passed
+    if: always()
+    needs:
+      - test-fast
+      - test-full
+      - lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job did not pass
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::a required CI job failed or was cancelled"
+          exit 1
+      - name: All required jobs passed
+        run: echo "All required CI jobs passed or were legitimately skipped."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
-# `install` creates only the pre-commit hook unless told otherwise, so commitizen's
-# `stages: [commit-msg]` hook was declared but never installed -- the gate existed on
-# paper and never once ran. Naming both types here is what makes `prek install` wire up
-# the commit-msg hook that validates the message a single-commit PR ships.
-default_install_hook_types: [pre-commit, commit-msg]
+# `install` creates only the pre-commit hook unless told otherwise, so any hook pinned to
+# another stage would be declared but never installed -- the gate would exist on paper and
+# never run (as commitizen's `commit-msg` hook once did). Naming every stage here is what
+# makes `prek install` wire up the commit-msg hook that validates a single-commit PR's
+# message and the pre-push hook (interrogate) that gates before a push.
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 repos:
   # prek's built-in Rust implementations, declared explicitly. Pointing these at
@@ -50,6 +51,9 @@ repos:
       # second (byte-identical) copy of it under .claude/skills dropped the pool
       # below the gate. A threshold that moves when you copy a file is measuring the
       # pool, not the code; excluding both copies leaves the gate on what it is for.
+      # Runs at pre-push, not pre-commit: interrogate scores a pooled average across
+      # the whole package, so it gives no per-commit signal and only refuses commits /
+      # trips on old code during a rebase. pre-push runs it once before sharing.
       - id: interrogate
         name: interrogate
         entry: uv run --locked interrogate
@@ -57,6 +61,7 @@ repos:
         types: [python]
         exclude: ^(tests/|\.claude/skills/|\.github/skills/|.*_version\.py$|.*\{%.*%\}.*)
         require_serial: true
+        stages: [pre-push]
 
       # Ruff linter (autofix)
       - id: ruff

--- a/justfile
+++ b/justfile
@@ -7,10 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
-    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
-    # every commit. `-f` overwrites instead. Measured; the migration notice
-    # prek prints names this flag, and this is the command people actually run.
+    # -f matters twice over. It overwrites an existing shim instead of chaining it:
+    # without it prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy`
+    # and CHAINS it -- both run on every commit. And it re-wires the hook set on an
+    # existing clone, which is how a clone that installed before `pre-push` was added
+    # picks up the pre-push gate instead of leaving it declared-but-never-run.
     uv run prek install -f
 
 # Run tests with parallel execution

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,8 +93,13 @@ def test_slow(session: nox.Session) -> None:
 @nox.session(venv_backend="none")
 def fix(session: nox.Session) -> None:
     """Format the code base to adhere to our styles, and complain about what we cannot do automatically."""
-    # --locked pins the exact uv.lock versions, so a stale lock fails loudly here and
-    # local matches CI. It is also what keeps prek itself pinned -- never use `uvx prek`.
+    # Run at the pre-push stage. A hook with no `stages:` key runs at every stage, so this
+    # one pass covers the full suite: the autofixing formatters AND the pre-push gate
+    # (interrogate), while excluding commitizen (pinned to commit-msg). A plain `prek run`
+    # uses the pre-commit stage, which since interrogate moved to pre-push would silently
+    # skip it -- here and in the CI lint job that runs this session. --locked pins the exact
+    # uv.lock versions, so a stale lock fails loudly and local matches CI, and it keeps prek
+    # pinned -- never use `uvx prek`.
     session.run(
         "uv",
         "run",
@@ -103,6 +108,8 @@ def fix(session: nox.Session) -> None:
         "run",
         "--all-files",
         "--show-diff-on-failure",
+        "--stage",
+        "pre-push",
         *session.posargs,
         external=True,
     )

--- a/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
@@ -10,7 +10,13 @@ jobs:
     name: Validate Commit Message
     runs-on: ubuntu-latest
 
-    # Only single-commit PRs. GitHub's `squash_merge_commit_title` defaults to
+    # This job always runs so it can be a *required* status check. A job gated off at the
+    # job level is skipped and reports no conclusion, which leaves a required check stuck
+    # "waiting" and blocks the PR. Instead the single-commit gate lives on each step: on a
+    # multi-commit PR the steps skip and the job still reports success, so the ruleset can
+    # require it unconditionally.
+    #
+    # Why single-commit only: GitHub's `squash_merge_commit_title` defaults to
     # COMMIT_OR_PR_TITLE, which takes the squash title from the commit when a PR has
     # exactly one commit and from the PR title otherwise. So this is precisely the case
     # where the commit message -- not the PR title -- is what git-cliff reads into the
@@ -18,12 +24,11 @@ jobs:
     # ship their title, so their intermediate commits stay free-form on purpose:
     # requiring conventional WIP messages that get squashed away is pure friction.
     #
-    # `commits` is the PR's commit count, which is the same input GitHub uses to make
-    # that choice. Counting changed files or diff hunks instead would gate the wrong PRs.
-    if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}
+    # `commits` is the PR's commit count, the same input GitHub uses to make that choice.
 
     steps:
       - name: Checkout the commit that will ship
+        if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}
         uses: actions/checkout@v7
         with:
           # The PR head itself, not the merge commit checkout/@v7 defaults to -- the
@@ -32,15 +37,18 @@ jobs:
           fetch-depth: 1
 
       - name: Install uv
+        if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
           version: "{{ uv_version }}"
 
       - name: Set up Python
+        if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}
         run: uv python install
 
       - name: Validate the commit message that becomes the squash title
+        if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}
         run: |
           git log -1 --format=%B HEAD > "$RUNNER_TEMP/commit-msg"
           echo "Validating the message that will become the squash commit title:"

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -336,4 +336,31 @@ jobs:
 
       - name: Run example notebooks
         run: nox -s test_examples
-{% endif -%}
+{% endif %}
+
+  # Single required status check. The branch ruleset requires this one job, not the
+  # individual jobs above: test-fast is a matrix (its check-run names vary by OS/Python and
+  # differ between draft and ready PRs) and test-full is skipped on draft PRs, so neither
+  # can be named directly in a ruleset. This job depends on every blocking job and passes
+  # only when they all succeeded or were legitimately skipped, giving the ruleset one stable
+  # name that survives matrix and conditional changes. Validate PR Title and Validate Commit
+  # Message live in their own workflows and are required alongside this check.
+  ci-passed:
+    name: CI passed
+    if: always()
+    needs:
+      - test-fast
+      - test-full
+      - lint
+      - test_docstrings
+      - check_docs
+{% if include_examples %}      - examples
+{% endif %}    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job did not pass
+        if: {% raw %}${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}{% endraw %}
+        run: |
+          echo "::error::a required CI job failed or was cancelled"
+          exit 1
+      - name: All required jobs passed
+        run: echo "All required CI jobs passed or were legitimately skipped."

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -1,8 +1,9 @@
-{% if include_actions %}# `install` creates only the pre-commit hook unless told otherwise, so commitizen's
-# `stages: [commit-msg]` hook was declared but never installed -- the gate existed on
-# paper and never once ran. Naming both types here is what makes `prek install` wire up
-# the commit-msg hook that validates the message a single-commit PR ships.
-default_install_hook_types: [pre-commit, commit-msg]
+{% if include_actions %}# `install` creates only the pre-commit hook unless told otherwise, so any hook pinned to
+# another stage would be declared but never installed -- the gate would exist on paper and
+# never run (as commitizen's `commit-msg` hook once did). Naming every stage here is what
+# makes `prek install` wire up the commit-msg hook that validates a single-commit PR's
+# message and the pre-push hooks (ty, interrogate, no-rst-citations) that gate before a push.
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
 
 {% endif %}repos:
   # prek's built-in Rust implementations, declared explicitly. Pointing these at
@@ -43,7 +44,10 @@ default_install_hook_types: [pre-commit, commit-msg]
   # than every contributor paying 16 packages for it.
   - repo: local
     hooks:
-      # Docstring coverage
+      # Docstring coverage. Runs at pre-push, not pre-commit: it scores a pooled
+      # average across the whole package rather than the staged files, so it gives
+      # no per-commit signal, and running it on every commit only refuses commits
+      # and fires on old code during a rebase. pre-push runs it once before sharing.
       - id: interrogate
         name: interrogate
         entry: uv run --locked interrogate
@@ -52,6 +56,7 @@ default_install_hook_types: [pre-commit, commit-msg]
         files: ^src/
         exclude: .*_version\.py$
         require_serial: true
+        stages: [pre-push]
 
       # Ban reStructuredText citation syntax in docstrings. numpydoc "References"
       # sections must use a markdown ordered list with plain `[1]` prose citations,
@@ -60,6 +65,7 @@ default_install_hook_types: [pre-commit, commit-msg]
       # page. The docs build normalizes it anyway, but catching it at author time
       # keeps the source clean. `pygrep` is built into prek, so this adds no
       # dependency; it fails when either form matches.
+      # A whole-source docstring gate like interrogate/ty, so it runs at pre-push too.
       - id: no-rst-citations
         name: no reStructuredText citation syntax in docstrings
         description: Use a markdown ordered list and plain `[1]` citations, not RST `.. [1]` / `[1]_`.
@@ -67,6 +73,7 @@ default_install_hook_types: [pre-commit, commit-msg]
         entry: '(^\s*\.\. \[|\[[^]]+\]_)'
         types: [python]
         files: ^src/
+        stages: [pre-push]
 
       # Ruff linter (autofix)
       - id: ruff
@@ -104,6 +111,7 @@ default_install_hook_types: [pre-commit, commit-msg]
 
       # Type checking with ty. Projects with optional-dependency code paths can
       # add `--extra <name>` here so ty resolves them instead of warning.
+      # A whole-project, non-autofixing gate, so it runs at pre-push, not on every commit.
       - id: ty
         name: ty
         entry: uv run --locked ty check src
@@ -112,3 +120,4 @@ default_install_hook_types: [pre-commit, commit-msg]
         files: ^src/
         pass_filenames: false
         require_serial: true
+        stages: [pre-push]

--- a/template/justfile.jinja
+++ b/template/justfile.jinja
@@ -7,10 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
-    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
-    # every commit. `-f` overwrites instead. Measured; the migration notice
-    # prek prints names this flag, and this is the command people actually run.
+    # -f matters twice over. It overwrites an existing shim instead of chaining it:
+    # without it prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy`
+    # and CHAINS it -- both run on every commit. And it re-wires the hook set on an
+    # existing clone, which is how a clone that installed before `pre-push` was added
+    # picks up the pre-push gate instead of leaving it declared-but-never-run.
     uv run prek install -f
 
 # Run tests and doctests with parallel execution

--- a/template/noxfile.py.jinja
+++ b/template/noxfile.py.jinja
@@ -262,8 +262,13 @@ def lint(session: nox.Session) -> None:
 @nox.session(venv_backend="none")
 def fix(session: nox.Session) -> None:
     """Format the code base to adhere to our styles, and complain about what we cannot do automatically."""
-    # --locked pins the exact uv.lock versions, so a stale lock fails loudly here and
-    # local matches CI. It is also what keeps prek itself pinned -- never use `uvx prek`.
+    # Run at the pre-push stage. A hook with no `stages:` key runs at every stage, so this
+    # one pass covers the full suite: the autofixing formatters AND the pre-push gates (ty,
+    # interrogate, no-rst-citations), while excluding commitizen (pinned to commit-msg). A
+    # plain `prek run` uses the pre-commit stage, which since those gates moved to pre-push
+    # would silently skip them -- here and in the CI lint job that runs this session, a
+    # green check measuring nothing. --locked pins the exact uv.lock versions, so a stale
+    # lock fails loudly and local matches CI, and it keeps prek pinned -- never `uvx prek`.
     session.run(
         "uv",
         "run",
@@ -272,6 +277,8 @@ def fix(session: nox.Session) -> None:
         "run",
         "--all-files",
         "--show-diff-on-failure",
+        "--stage",
+        "pre-push",
         *session.posargs,
         external=True,
     )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -388,6 +388,76 @@ def test_precommit_ty_uses_uv_run(copie_session_default):
     assert "pass_filenames: false" in content
 
 
+def test_precommit_whole_project_gates_run_at_pre_push(copie_session_default):
+    """The refusing whole-project gates run at pre-push, not on every commit.
+
+    ty, interrogate, and no-rst-citations do not autofix and score the whole project, so
+    running them at pre-commit only refuses commits and fires on old code during a rebase.
+    They move to the pre-push stage, and `default_install_hook_types` must name pre-push or
+    the hook is declared but never wired into .git/hooks -- a gate that exists only on paper.
+    """
+    content = (copie_session_default.project_dir / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    # Parse per-hook so a stray stages line elsewhere cannot satisfy the check for the
+    # wrong hook: slice from each id to the next hook declaration (or end of file).
+    for hook_id in ("interrogate", "no-rst-citations", "ty"):
+        block = content.split(f"id: {hook_id}", 1)[1].split("- id:", 1)[0]
+        assert "stages: [pre-push]" in block, f"{hook_id} should run at pre-push, not pre-commit"
+
+    # The stage is actually installed, not merely declared.
+    hook_types = content.split("default_install_hook_types:")[1].split("\n")[0]
+    assert "pre-push" in hook_types, f"pre-push missing from install hook types: {hook_types}"
+
+
+def test_noxfile_fix_runs_pre_push_stage(copie_session_default):
+    """The fix session (run by the CI lint job) also runs the pre-push-stage gates.
+
+    The gates moved off pre-commit, and a plain `prek run` only runs the pre-commit stage,
+    so without running the pre-push stage here the CI lint job would silently stop type- and
+    docstring-checking (a green check measuring nothing). This is the CI-side enforcement
+    that holds even when a contributor never installed local hooks.
+    """
+    content = (copie_session_default.project_dir / "noxfile.py").read_text(encoding="utf-8")
+    fix_body = content.split("def fix(", 1)[1].split("\ndef ", 1)[0]
+    assert '"--stage"' in fix_body and '"pre-push"' in fix_body, (
+        "the fix session must run the pre-push stage so CI covers the moved gates"
+    )
+
+
+def test_install_command_forces_hook_reinstall(copie_session_default):
+    """The documented install command reinstalls hooks forcibly with `prek install -f`.
+
+    `default_install_hook_types` only wires hooks at install time, so a clone that installed
+    before pre-push was added needs a forced reinstall to pick up the new stage. Without -f,
+    prek chains an old shim instead of overwriting it and the pre-push gate stays unwired.
+    """
+    justfile = (copie_session_default.project_dir / "justfile").read_text(encoding="utf-8")
+    assert "prek install -f" in justfile, "install recipe must force-reinstall hooks (prek install -f)"
+
+
+def test_generated_ci_declares_rollup_gate(copie_session_default):
+    """The generated CI declares the always-running roll-up gate the ruleset requires.
+
+    test-fast is a matrix and test-full is skipped on draft PRs, so neither has a stable
+    check-run name a ruleset can require. `ci-passed` depends on every blocking job and runs
+    with `if: always()`, giving the ruleset one stable required check that survives matrix
+    and conditional changes. (safe_load also fails if the templated YAML is malformed.)
+    """
+    import yaml
+
+    wf = copie_session_default.project_dir / ".github" / "workflows" / "tests.yml"
+    data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+
+    assert "ci-passed" in data["jobs"], "roll-up gate job 'ci-passed' missing from CI"
+    gate = data["jobs"]["ci-passed"]
+    assert gate["name"] == "CI passed"
+    # if: always() so the gate reports even when a dependency failed or was skipped.
+    assert str(gate.get("if")).strip() == "always()", "ci-passed must run with if: always()"
+    # It must depend on the blocking jobs so their failure fails the gate.
+    for job in ("test-fast", "test-full", "lint", "test_docstrings", "check_docs"):
+        assert job in gate["needs"], f"ci-passed must depend on {job}"
+
+
 def test_precommit_linters_are_pinned_by_uv_lock(copie_session_default):
     """Test that version-sensitive linters resolve from uv.lock, not a pre-commit rev.
 


### PR DESCRIPTION
## What

Client-side half of the `harden-hook-stages-and-merge-gates` change (template + tests + CI). The server-side ruleset changes and the 7-repo fan-out follow after this merges and releases.

### Hooks
- Move `ty`, `interrogate`, and `no-rst-citations` from `pre-commit` to `pre-push` (template + root). They refuse rather than autofix and score the whole project, so on every commit they only blocked commits and fired on old code during rebases.
- Add `pre-push` to `default_install_hook_types`; `just install` keeps `prek install -f` so existing clones actually wire the new stage.

### CI coverage stays intact
- The `fix` nox session now runs `prek run --all-files --stage pre-push`. A hook with no `stages:` runs at every stage, so this single pass covers the autofixers **and** the moved gates. The CI lint job runs `nox -s fix`, so the gates run in CI regardless of local hook install (ships atomically with the move).

### Merge gate (template output for the ruleset)
- Add a `ci-passed` roll-up job (`if: always()`) that aggregates `tests.yml`'s matrix/conditional jobs into one stable required-check name (the matrix-named `Fast tests (…)` and draft-skipped `test-full` can't be required directly).
- Make `commit-message.yml` always-run (per-step gating instead of a job-level `if`) so it always reports a check-run and can be required without deadlocking multi-commit PRs.

### Tests
Six fast tests added/updated (pre-push placement, install types, `fix` runs the stage, `-f` retained, roll-up job present). 10/10 hook/CI tests pass.

## Follow-ups (not in this PR)
- Require `CI passed` + `Validate PR Title` + `Validate Commit Message` on each repo's `main` ruleset, with the up-to-date flag (live GitHub ops).
- Fan out to the 7 fleet repos via `copier update`.
- Ruleset check-name guard.