### PR TITLE
fix(ci): gate test-compat in the ci-passed roll-up

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -345,11 +345,16 @@ jobs:
   # only when they all succeeded or were legitimately skipped, giving the ruleset one stable
   # name that survives matrix and conditional changes. Validate PR Title and Validate Commit
   # Message live in their own workflows and are required alongside this check.
+  #
+  # `test-compat` is listed even though it ships disabled (`if: false`): a skipped dependency
+  # does not fail an `if: always()` roll-up, so this is a harmless no-op until a project
+  # enables compat pins, at which point that job is gated automatically without touching this.
   ci-passed:
     name: CI passed
     if: always()
     needs:
       - test-fast
+      - test-compat
       - test-full
       - lint
       - test_docstrings

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -453,8 +453,10 @@ def test_generated_ci_declares_rollup_gate(copie_session_default):
     assert gate["name"] == "CI passed"
     # if: always() so the gate reports even when a dependency failed or was skipped.
     assert str(gate.get("if")).strip() == "always()", "ci-passed must run with if: always()"
-    # It must depend on the blocking jobs so their failure fails the gate.
-    for job in ("test-fast", "test-full", "lint", "test_docstrings", "check_docs"):
+    # It must depend on the blocking jobs so their failure fails the gate. test-compat ships
+    # disabled (if: false); it is still a dependency so a project that enables compat pins is
+    # gated automatically, and a skipped dependency does not fail the if: always() roll-up.
+    for job in ("test-fast", "test-compat", "test-full", "lint", "test_docstrings", "check_docs"):
         assert job in gate["needs"], f"ci-passed must depend on {job}"
 
 


### PR DESCRIPTION
## What

Add `test-compat` to the generated `ci-passed` roll-up's `needs` (template output only; the root repo has no `test-compat` job and is untouched).

## Why

The v0.32.0 fan-out surfaced that **yohou has `test-compat` enabled** (a real blocking job), but `ci-passed` did not depend on it — so a required-check ruleset of just `CI passed` would ignore Compat-test failures there.

`test-compat` ships disabled (`if: false`) in the template, and a *skipped* dependency does not fail an `if: always()` roll-up. So this is a harmless no-op everywhere it's disabled, and it automatically gates any repo that enables compat pins — no per-repo ruleset change needed.

Does **not** fix the separate-workflow gap (kedro `tests-versions.yml`); GitHub `needs:` can't span workflows, so those stay direct ruleset requirements.

## Verification

- `test_generated_ci_declares_rollup_gate` updated to assert `test-compat` in `needs`; passes.
- Rendered both `include_examples` values: `needs` now `[test-fast, test-compat, test-full, lint, test_docstrings, check_docs(, examples)]`, all resolving to real jobs.