### PR TITLE
fix(lint): broaden generated tests/** ruff S-ignore for common test patterns

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -188,7 +188,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["ARG", "S101", "S110", "S301", "S311", "S603", "S607", "T201", "PLR2004"]  # Allow asserts, try/except/pass, pickle, non-crypto random, subprocess, prints, and magic values in tests
+"tests/**/*" = ["ARG", "S101", "S104", "S105", "S106", "S107", "S108", "S110", "S112", "S301", "S311", "S603", "S607", "T201", "PLR2004"]  # Insecure-looking patterns that are legitimate in tests: asserts; bind-all-interfaces; hardcoded passwords/temp paths; try/except pass/continue; pickle; non-crypto random; subprocess; prints; magic values
 # The template's documentation build tooling lives in docs_build/. Every script
 # there prints build progress and may hold per-build caches.
 #


### PR DESCRIPTION
## What

Broadens the generated `tests/**` ruff `S`-ignore with `S104, S105, S106, S107, S108, S112`.

## Why (evidence from the v0.34.0 fan-out)

Enabling ruff `S` fleet-wide (v0.33.0) surfaced `S` findings in real **test** code that the template's `tests/**` ignore did not cover, forcing per-repo triage during the fan-out:
- **sklearn-wrap**: `S105/S106/S107` — password-named test fixtures
- **kedro-dagster**: `S104/S108/S112` — bind-all-interfaces, hardcoded temp paths, try/except/continue
- **kedro-azureml-pipeline**: `S112` — best-effort plugin-load loop in conftest

All are legitimate in test code (the same "tests may do insecure-looking things" philosophy behind the existing `S101/S110/S301/S311/S603/S607` ignores). Adding them upstream means future repos and fan-outs skip this triage. **`src/` still enforces every `S` rule.**

## Scope
One line in `template/pyproject.toml.jinja`. Config-only; fast suite green (383). This is the v0.35.0 follow-up to the security hardening work.
