### PR TITLE
docs(release): document signing release tags with gitsign

### DIFF
--- a/docs/pages/explanation/release-process.md
+++ b/docs/pages/explanation/release-process.md
@@ -62,7 +62,7 @@ The version is determined by the Git tag - there is no version file to manually 
 
 ## The Complete Flow in Practice
 
-1. Developer pushes a version tag: `git tag v0.2.0 -m "Release v0.2.0" && git push origin v0.2.0`
+1. Developer pushes a **signed** version tag: `git tag -s v0.2.0 -m "Release v0.2.0" && git push origin v0.2.0` (tags are signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing, so the tag is verifiable with no long-lived GPG key; this complements the artifact-level PEP 740 attestations)
 2. `changelog.yml` generates the changelog, builds the package, creates a PR
 3. Maintainer reviews and merges the PR
 4. `publish-release.yml` creates a GitHub Release with artifacts

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -694,12 +694,22 @@ graph LR
 
 ### How It Works
 
-1. **Tag a release:**
+1. **Tag a release** (signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing):
 
     ```bash
-   git tag v0.2.0 -m "Release v0.2.0"
+   git tag -s v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
     ```
+
+    One-time gitsign setup so `git tag -s` signs via Sigstore, with no long-lived GPG key to manage:
+
+    ```bash
+   git config --local gpg.x509.program gitsign
+   git config --local gpg.format x509
+   git config --local tag.gpgSign true
+    ```
+
+    The first signing authenticates via your identity provider in a browser; verify a tag with `gitsign verify-tag`. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
 
 2. **Automated changelog workflow** (`changelog.yml`):
     - Generates changelog from conventional commits using git-cliff


### PR DESCRIPTION
Resolves the deferred **signed-tags item (7.1)** via the option you chose: document keyless Sigstore signing with [gitsign](https://github.com/sigstore/gitsign), so maintainers sign release tags when they create them (`git tag -s`), keeping the current push-a-tag release flow.

- Generated projects: adds signing + one-time gitsign setup to the Release Process how-to.
- Template repo: same in its own release-process explanation doc.

Advisory (opt-in) by design; the published artifacts already carry PEP 740 attestations, so this makes the git tag itself verifiable too. Docs-only; fast suite 383 green. A v0.37.0 candidate — release + fan out whenever convenient.