### PR TITLE
fix(ci): repair the release path and the checks that missed it

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,8 +6,12 @@ on:
       - 'v*.*.*'
 
 # Least-privilege default: read-only token; the changelog job widens as needed.
+# `pull-requests: read` is for git-cliff, which reads merged PRs to attribute entries;
+# it stays on GITHUB_TOKEN rather than borrowing the App token, whose write scope this
+# job needs only for opening the PR.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changelog:
@@ -37,6 +41,15 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          # `.git-cliff.toml` sets `[remote.github]`, so git-cliff calls the GitHub API
+          # to attach PR links and @usernames to each entry. Without a token those calls
+          # are anonymous, and anonymous means 60 requests/hour shared across every job
+          # on the runner's IP -- so this step used to succeed or 403 depending on who
+          # else was building at the time. git-cliff panics on that 403 (exit 101) rather
+          # than falling back to plain entries, which turned a rate limit into a failed
+          # release. Authenticated, the ceiling is 5000/hour and the flake goes away.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get the tag name
           TAG_NAME="${GITHUB_REF#refs/tags/}"

--- a/copier.yml
+++ b/copier.yml
@@ -178,17 +178,6 @@ include_codecov:
   default: "{{ repo_visibility == 'public' }}"
   when: "{{ include_actions }}"
 
-uv_version:
-  type: str
-  # Pinned exact uv version for the CI setup-uv steps. Pinning an exact X.Y.Z
-  # skips setup-uv's resolve-"latest" network call (the transient "fetch failed"
-  # point); a range would still resolve over the network, so keep it exact.
-  # Bumped by hand: Dependabot's github-actions ecosystem updates `uses:` refs,
-  # not the setup-uv `version:` input, and nothing reads copier.yml.
-  help: "uv version to pin in CI setup-uv steps (exact X.Y.Z)"
-  default: "0.10.0"
-  when: "{{ include_actions }}"
-
 renovate_preset:
   type: str
   # Renovate replaces Dependabot for version updates. When this is set, the generated

--- a/template/.copier-answers.yml.jinja
+++ b/template/.copier-answers.yml.jinja
@@ -19,4 +19,3 @@ project_name: {{ project_name }}
 project_slug: {{ project_slug }}
 renovate_preset: '{{ renovate_preset }}'
 repo_visibility: {{ repo_visibility }}
-uv_version: '{{ uv_version }}'

--- a/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
@@ -7,8 +7,12 @@ on:
 
 # Least-privilege default: read-only token unless a job widens it explicitly. The PR
 # is opened with a GitHub App token (below), not GITHUB_TOKEN, so no job needs write.
+# `pull-requests: read` is for git-cliff, which reads merged PRs to attribute entries;
+# it stays on GITHUB_TOKEN rather than borrowing the App token, whose write scope this
+# job needs only for opening the PR.
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changelog:
@@ -38,6 +42,15 @@ jobs:
 
       - name: Generate changelog
         id: changelog
+        env:
+          # `.git-cliff.toml` sets `[remote.github]`, so git-cliff calls the GitHub API
+          # to attach PR links and @usernames to each entry. Without a token those calls
+          # are anonymous, and anonymous means 60 requests/hour shared across every job
+          # on the runner's IP -- so this step used to succeed or 403 depending on who
+          # else was building at the time. git-cliff panics on that 403 (exit 101) rather
+          # than falling back to plain entries, which turned a rate limit into a failed
+          # release. Authenticated, the ceiling is 5000/hour and the flake goes away.
+          GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         run: |
           # Get the tag name
           TAG_NAME="${GITHUB_REF#refs/tags/}"
@@ -59,7 +72,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
 
       - name: Run hooks on generated CHANGELOG
         run: |

--- a/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/commit-message.yml.jinja
@@ -45,7 +45,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
 
       - name: Set up Python
         if: {% raw %}${{ github.event.pull_request.commits == 1 }}{% endraw %}

--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -32,7 +32,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -51,7 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -59,15 +59,17 @@ jobs:
         run: uv build --python {{ min_python_version }} --python-preference only-managed --sdist --wheel . --out-dir dist
 
       - name: Check distributions
-        run: uvx twine check dist/*
+        # renovate: datasource=pypi depName=twine
+        run: uvx twine==7.0.0 check dist/*
 
       # Software bill of materials (CycloneDX) for the release, generated from the
       # locked dependency set so it enumerates exactly what this release resolves.
       - name: Generate SBOM (CycloneDX)
+        # renovate: datasource=pypi depName=cyclonedx-bom
         run: |
           uv export --frozen --no-emit-project --format requirements-txt -o sbom-requirements.txt
-          uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
-            --output-format JSON --outfile sbom.cdx.json
+          uvx --from cyclonedx-bom==7.3.1 cyclonedx-py requirements sbom-requirements.txt \
+            --output-format JSON --output-file sbom.cdx.json
 
       - name: Store the distribution packages
         uses: actions/upload-artifact@v7
@@ -138,12 +140,17 @@ jobs:
           name: {% raw %}${{ env.sbom-artifact-name }}{% endraw %}
           path: sbom/
 
-      - name: Create GitHub Release
+      # Created as a draft: a draft release is visible to maintainers only, so nothing
+      # is public until the `pypi` environment gate has been approved and the upload
+      # has succeeded. `finalize-release` undrafts it. If the gate is rejected or the
+      # upload fails, the draft is all that exists and can simply be deleted.
+      - name: Create draft GitHub Release
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         run: |
           VERSION="{% raw %}${{ needs.build.outputs.version }}{% endraw %}"
           gh release create "$VERSION" \
+            --draft \
             --title "$VERSION" \
             --notes "{% raw %}${{ steps.release_notes.outputs.notes }}{% endraw %}" \
             dist/* sbom/sbom.cdx.json
@@ -172,3 +179,20 @@ jobs:
         with:
           attestations: true
           verify-metadata: false
+
+  # Last step in the chain: make the release public only once the artifacts are
+  # actually on PyPI, so the GitHub Release and the PyPI record cannot disagree.
+  finalize-release:
+    name: Publish the GitHub Release
+    needs:
+      - build
+      - pypi-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Undraft the GitHub Release
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
+        run: gh release edit "{% raw %}${{ needs.build.outputs.version }}{% endraw %}" --draft=false

--- a/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/tests.yml.jinja
@@ -39,7 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -79,7 +79,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -124,7 +124,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -174,7 +174,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -204,7 +204,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -233,7 +233,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -304,7 +304,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -333,7 +333,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           # renovate: datasource=github-releases depName=astral-sh/uv
-          version: "{{ uv_version }}"
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/tests/_tool_invocations.py
+++ b/tests/_tool_invocations.py
@@ -1,0 +1,117 @@
+"""Find every tool a workflow shells out to, pinned or not.
+
+The `setup-uv` assertions in `test_repo_workflows.py` and `test_github_workflows.py`
+quantify over steps that already carry a `version:` input. That shape cannot see a tool
+that was never pinned at all, which is precisely how `uvx --from cyclonedx-bom` reached
+seven repos: it resolved to the newest release on every run, and broke every generated
+project's release on the day cyclonedx-bom 7.0 removed a flag the step was passing. The
+check passed throughout, because an unpinned invocation was not in the set it measured.
+
+So this enumerates *invocations* and reports each one's pin status, rather than
+enumerating pins. An unpinned tool is a failure, not an absence.
+
+Text-based rather than YAML-based, for two reasons. The `# renovate:` marker is a
+comment, so a parser drops it and a structural check cannot see it missing. And these
+invocations live inside `run:` script bodies, which are opaque strings to a YAML parser.
+"""
+
+import re
+from dataclasses import dataclass
+
+# `uvx --from <spec> <cmd>`, `uvx <spec>`, and `uv tool install <spec>`. The spec is
+# everything up to the first whitespace, so `nox@2026.7.11` and `twine==7.0.0` both
+# arrive intact and a bare `nox` arrives unpinned.
+_FROM = re.compile(r"\buvx\s+(?:--\S+\s+)*--from\s+(?P<spec>\S+)")
+_UVX = re.compile(r"\buvx\s+(?!--from\b)(?:--\S+\s+)*(?P<spec>\S+)")
+_INSTALL = re.compile(r"\buv\s+tool\s+install\s+(?:--\S+\s+)*(?P<spec>\S+)")
+
+# A pinned spec carries an exact version, either `pkg==1.2.3` (PyPI) or `pkg@1.2.3`
+# (uv's tool syntax). A range or a bare name is not a pin.
+_PINNED = re.compile(r"^[A-Za-z0-9._-]+(==|@)\d[\w.+-]*$")
+
+
+@dataclass(frozen=True)
+class Invocation:
+    """One tool invocation found in a workflow's shell body."""
+
+    path: str
+    line: int
+    spec: str
+    text: str
+    annotated: bool
+
+    @property
+    def name(self):
+        """The tool name, with any version stripped."""
+        return re.split(r"==|@", self.spec, maxsplit=1)[0]
+
+    @property
+    def pinned(self):
+        """True when the spec carries an exact version."""
+        return bool(_PINNED.match(self.spec))
+
+
+def _job_start_lines(lines):
+    """Line indices where a new job begins, so `uv tool install` scope can be bounded.
+
+    A tool installed in one job is not on PATH in another, so a pin in job A must not
+    excuse a bare invocation in job B.
+    """
+    return [i for i, line in enumerate(lines) if re.match(r"^  [A-Za-z0-9_-]+:\s*$", line)]
+
+
+def find_invocations(path):
+    """Every tool invocation in one workflow file, with its pin and annotation status.
+
+    Lines that are themselves comments are skipped: the changelog workflow explains in
+    prose why `uvx prek` would float, and a scan that matched prose would fail on the
+    documentation of the very rule it enforces.
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    found = []
+    for i, line in enumerate(lines):
+        if line.strip().startswith("#"):
+            continue
+        for pattern in (_FROM, _UVX, _INSTALL):
+            match = pattern.search(line)
+            if not match:
+                continue
+            # The annotation sits above the step's `run:` key, which may be several
+            # lines up when the body is a block scalar.
+            window = lines[max(0, i - 6) : i]
+            found.append(
+                Invocation(
+                    path=path.name,
+                    line=i + 1,
+                    spec=match.group("spec"),
+                    text=line.strip(),
+                    annotated=any(w.strip().startswith("# renovate:") for w in window),
+                )
+            )
+            break
+    return found
+
+
+def unpinned(invocations, lines_by_path):
+    """Invocations with no exact version, excusing those pinned by a preceding install.
+
+    `uv tool run` (`uvx`) reuses an already-installed tool unless `--isolated` is
+    passed, so `uvx nox -s fix` after `uv tool install nox==2026.7.11` in the same job
+    runs the pinned nox. Flagging it would be a false positive that teaches people to
+    silence the check.
+    """
+    offenders = []
+    for inv in invocations:
+        if inv.pinned:
+            continue
+        starts = _job_start_lines(lines_by_path[inv.path])
+        job_start = max((s for s in starts if s < inv.line), default=0)
+        installed = {
+            other.name
+            for other in invocations
+            if other.path == inv.path and other.pinned and job_start < other.line < inv.line
+        }
+        if inv.name not in installed:
+            offenders.append(inv)
+    return offenders

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ class CopierTestFixture:
             "include_actions": True,
             "include_examples": True,
             "include_codecov": True,
-            "uv_version": "0.10.0",
             "renovate_preset": "",
         }
 
@@ -65,6 +64,18 @@ class CopierResult:
         self.result = result
         self.exit_code = 0 if project_dir.exists() else 1
         self.exception = None
+        # What the template actually rendered into the project root, captured now.
+        #
+        # Session-scoped projects are shared, and the tests that run tooling inside one
+        # (`uv sync`, the nox smoke session) leave `uv.lock`, `.coverage`, `coverage.xml`
+        # and `junit.*.xml` behind. A consumer that re-lists the directory later cannot
+        # tell those apart from files the template shipped, so it reads run artifacts as
+        # template output -- which made the parity gate demand manifest entries for them
+        # whenever it happened to run after the polluting test. Snapshotting at
+        # generation time makes the measured set the rendered set, whatever runs after.
+        self.rendered_root_files = (
+            sorted(path.name for path in project_dir.iterdir() if path.is_file()) if project_dir.exists() else []
+        )
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -125,7 +136,6 @@ def copie_session_default(session_projects_dir):
         "include_actions": True,
         "include_examples": True,
         "include_codecov": True,
-        "uv_version": "0.10.0",
         "renovate_preset": "",
     }
 
@@ -173,7 +183,6 @@ def copie_session_minimal(session_projects_dir):
         "repo_visibility": "public",
         "include_actions": False,
         "include_examples": False,
-        "uv_version": "0.10.0",
         "renovate_preset": "",
     }
 
@@ -223,7 +232,6 @@ def copie_session_custom(session_projects_dir):
         "include_actions": True,
         "include_examples": True,
         "include_codecov": True,
-        "uv_version": "0.10.0",
         "renovate_preset": "",
     }
 

--- a/tests/parity_manifest.yml
+++ b/tests/parity_manifest.yml
@@ -94,6 +94,13 @@ file_gates:
     reason: >-
       Publishes to PyPI via OIDC trusted publishing. Nothing to publish, per the
       build exclusion above.
+  publish-release.yml:finalize-release:
+    status: excluded
+    reason: >-
+      Undrafts the GitHub Release once the PyPI upload has succeeded, so that the
+      approval gate precedes every outward-facing effect. This repo has no PyPI
+      upload to gate, per the pypi-publish exclusion above, so its release is
+      created public in one step and there is nothing to undraft.
   commit-message.yml:validate-commit-message:
     equivalent: commit-message.yml:validate-commit-message
     status: matched

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -140,6 +140,90 @@ class TestTestsWorkflow:
 class TestPublishWorkflow:
     """Test the publish-release.yml workflow."""
 
+    def test_approval_gate_precedes_every_outward_facing_effect(self, copie):
+        """Nothing is public until the PyPI upload has succeeded.
+
+        The `pypi` environment gate exists so a human can stop a release. It used to sit
+        only on the last job, so `create-release` published a public GitHub Release,
+        with the wheels, sdist and SBOM attached, before the approval was ever
+        requested. By the time anyone was asked, rejecting cost more than approving:
+        deleting a release does not un-download it or retract its notifications, and the
+        repo is left advertising a version that never reached PyPI.
+
+        The fix is ordering, so this asserts ordering: the release is created as a
+        draft (maintainer-visible, so artifacts can still be inspected while the gate is
+        pending) and undrafted by a job that runs only after the upload succeeds.
+        """
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflow_path = result.project_dir / ".github" / "workflows" / "publish-release.yml"
+        content = workflow_path.read_text(encoding="utf-8")
+        jobs = yaml.safe_load(content)["jobs"]
+
+        gated = [name for name, body in jobs.items() if (body.get("environment") or {})]
+        assert gated == ["pypi-publish"], f"expected the pypi upload to be the gated job, found {gated}"
+
+        assert "--draft \\" in content or "--draft\n" in content, (
+            "the GitHub Release is not created as a draft, so it goes public before the approval gate"
+        )
+
+        assert "finalize-release" in jobs, "no finalize-release job, so a drafted release would never be published"
+        needs = jobs["finalize-release"].get("needs") or []
+        assert "pypi-publish" in needs, (
+            f"finalize-release does not wait on pypi-publish (needs: {needs}), so the release could be "
+            "made public before or without the upload succeeding"
+        )
+        assert "--draft=false" in content, "finalize-release never undrafts the release"
+
+        # The undraft must not itself be gated on anything the approval could bypass.
+        assert jobs["finalize-release"].get("environment") in (None, {}), (
+            "finalize-release carries its own environment gate, which would strand approved releases as drafts"
+        )
+
+    def test_changelog_generation_is_authenticated(self, copie):
+        """git-cliff's GitHub API calls carry a token.
+
+        `.git-cliff.toml` enables the GitHub integration, so every run calls the API to
+        attach PR links and @usernames. Anonymous, that is 60 requests/hour shared
+        across every job on the runner's IP, and git-cliff panics on the resulting 403
+        instead of degrading to plain entries: exit 101, no changelog PR, and a pushed
+        tag with no release behind it. It failed roughly one run in ten, and the tenth
+        was a release.
+        """
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflow_path = result.project_dir / ".github" / "workflows" / "changelog.yml"
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+        assert (workflow.get("permissions") or {}).get("pull-requests") == "read", (
+            "changelog.yml does not grant `pull-requests: read`; git-cliff queries the pulls "
+            "endpoint as well as commits, so `contents: read` alone still 403s"
+        )
+
+        generate = [
+            step
+            for job in (workflow.get("jobs") or {}).values()
+            for step in (job.get("steps") or [])
+            if "git-cliff --config" in str(step.get("run", ""))
+        ]
+        assert generate, "no git-cliff generate step found; this check would pass over nothing"
+        for step in generate:
+            env = step.get("env") or {}
+            assert "GITHUB_TOKEN" in env, (
+                "the git-cliff step has no GITHUB_TOKEN in its env, so its API calls go out anonymous "
+                "and the release fails whenever the shared runner IP has exhausted its quota"
+            )
+            assert "app-token" not in str(env["GITHUB_TOKEN"]), (
+                "the git-cliff step borrows the App token; it only reads here, so it should use the "
+                "scoped GITHUB_TOKEN rather than widening what the release path can write"
+            )
+
     def test_publish_workflow_exists(self, copie):
         """Test that publish workflow exists when actions enabled."""
         result = copie.copy(extra_answers={"include_actions": True})
@@ -493,6 +577,48 @@ class TestWorkflowConsistency:
                 assert "uv tool install nox" in content or "uvx nox" in content, (
                     f"{workflow_file} doesn't install nox consistently"
                 )
+
+    def test_every_invoked_tool_is_pinned_and_annotated(self, copie):
+        """Every tool the generated workflows shell out to is pinned, not just the pinned ones.
+
+        `test_all_setup_uv_steps_pin_exact_version` quantifies over steps that already
+        carry a `version:` input. A tool invoked with no constraint at all is not in
+        that set, so it was never unpinned as far as the suite could tell. That is how
+        `uvx --from cyclonedx-bom` shipped to seven repos and broke every one of their
+        releases the day cyclonedx-bom 7.0 removed a flag the step passed, with this
+        file green throughout. `uvx twine check` was the same defect, in the same job,
+        four lines away, and equally invisible.
+
+        So this enumerates invocations and requires each to carry an exact version and
+        a `# renovate:` annotation. Without the version it floats; without the
+        annotation nothing can bump it and it rots wherever it was last set.
+        """
+        from _tool_invocations import find_invocations, unpinned
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflows_dir = result.project_dir / ".github" / "workflows"
+        invocations, lines_by_path = [], {}
+        for workflow_path in sorted(workflows_dir.glob("*.yml")):
+            invocations += find_invocations(workflow_path)
+            lines_by_path[workflow_path.name] = workflow_path.read_text(encoding="utf-8").splitlines()
+
+        # Guard the input set: if the scan ever finds nothing, every assertion below
+        # passes over an empty set and the gap silently reopens.
+        assert invocations, "no tool invocations found in generated workflows; the scan is reading the wrong tree"
+
+        floating = unpinned(invocations, lines_by_path)
+        assert not floating, (
+            "tools invoked with no exact version (they resolve to whatever is newest on the day): "
+            + ", ".join(f"{i.path}:{i.line} `{i.text}`" for i in floating)
+        )
+
+        unannotated = [i for i in invocations if i.pinned and not i.annotated]
+        assert not unannotated, (
+            "pinned tools with no `# renovate:` annotation, so nothing can ever bump them: "
+            + ", ".join(f"{i.path}:{i.line} `{i.spec}`" for i in unannotated)
+        )
 
 
 class TestWorkflowPermissions:

--- a/tests/test_parity_manifest.py
+++ b/tests/test_parity_manifest.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from conftest import CopierResult
 
 _REPO = Path(__file__).resolve().parent.parent
 _MANIFEST_PATH = Path(__file__).resolve().parent / "parity_manifest.yml"
@@ -33,13 +34,21 @@ def _manifest():
     return yaml.safe_load(_MANIFEST_PATH.read_text(encoding="utf-8"))
 
 
-def _derive_shipped_gates(project_dir):
+def _derive_shipped_gates(generated):
     """Every gate a generated project receives, read from the rendered project.
 
     Derived, not listed. Workflow *job* identifiers and pre-commit *hook* ids are the
     two places a gate is declared, and both are structural, so a gate added to the
     template appears here without anyone editing this file.
+
+    Takes the generation result, not a directory, because the root-file half must read
+    what was *rendered* rather than what is in the directory now. The session project is
+    shared, and the nox smoke test runs a full tool pass inside it, so by the time this
+    runs the directory may also hold `uv.lock`, `.coverage`, `coverage.xml` and
+    `junit.*.xml`. Re-listing counted those as gates the template ships and demanded
+    manifest entries for them, which made this gate pass or fail on test order alone.
     """
+    project_dir = generated.project_dir
     gates = set()
     for workflow_path in sorted((project_dir / ".github" / "workflows").glob("*.yml")):
         workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
@@ -57,9 +66,8 @@ def _derive_shipped_gates(project_dir):
     # both -- which is exactly how they reached seven generated projects and never
     # this one. The project root is a bounded, structural set, so this stays derived
     # rather than becoming a second hand-maintained list.
-    for path in sorted(project_dir.iterdir()):
-        if path.is_file():
-            gates.add(f"file:{path.name}")
+    for name in generated.rendered_root_files:
+        gates.add(f"file:{name}")
     return gates
 
 
@@ -70,7 +78,7 @@ def test_derivation_finds_gates_at_all(copie_session_default):
     vacuously and the parity gap silently reopens. That is the failure this whole
     capability exists to catch, so check it here first rather than trusting it.
     """
-    gates = _derive_shipped_gates(copie_session_default.project_dir)
+    gates = _derive_shipped_gates(copie_session_default)
     assert len(gates) > 20, f"derivation found only {len(gates)} gates; it is probably reading the wrong tree"
     assert any(g.startswith("hook:") for g in gates), "no pre-commit hooks derived"
     assert any(":" in g and not g.startswith("hook:") for g in gates), "no workflow jobs derived"
@@ -83,7 +91,7 @@ def test_every_shipped_gate_is_answered(copie_session_default):
     quantified over the template and silently meant nothing about this repo; an
     unanswered entry is what makes that visible instead of invisible.
     """
-    shipped = _derive_shipped_gates(copie_session_default.project_dir)
+    shipped = _derive_shipped_gates(copie_session_default)
     answered = set(_manifest()["file_gates"])
     unanswered = sorted(shipped - answered)
     assert not unanswered, (
@@ -99,7 +107,7 @@ def test_no_stale_manifest_entries(copie_session_default):
     for deleted gates slowly stops describing anything, and its passing tells you less
     every release.
     """
-    shipped = _derive_shipped_gates(copie_session_default.project_dir)
+    shipped = _derive_shipped_gates(copie_session_default)
     stale = sorted(set(_manifest()["file_gates"]) - shipped)
     assert not stale, (
         f"manifest answers {len(stale)} gate(s) the template no longer ships: {stale}. Remove the stale entries."
@@ -368,3 +376,38 @@ def test_the_roll_up_detector_accepts_a_correctly_configured_ruleset():
     """And it must not cry wolf on the real configuration, or it will be switched off."""
     assert "CI passed" in required_checks_from_rulesets([_ruleset()])
     assert "CI passed" in required_checks_from_rulesets([_ruleset(enforcement="evaluate", contexts=("x",)), _ruleset()])
+
+
+def test_derivation_ignores_files_written_after_generation(tmp_path):
+    """The gate set is what the template rendered, not what the directory holds later.
+
+    The session project is shared, and the nox smoke test runs a full tool pass inside
+    it, leaving `uv.lock`, `.coverage`, `coverage.xml` and `junit.*.xml` behind. When
+    the derivation re-listed the directory it read those as gates the template ships and
+    demanded manifest entries for them, so this gate passed or failed purely on whether
+    it ran before or after that test. `test_fast` deselects the polluting test, which is
+    why merges stayed green while the full and slow runs carried a live flake, worsened
+    by `-n auto` distributing the two tests across workers unpredictably.
+
+    A denylist of known artifact names would have reopened the moment a tool wrote a
+    new one, which is the same "measures the wrong set" defect this file exists to
+    catch. Snapshotting at generation time fixes the input instead.
+    """
+    project_dir = tmp_path / "rendered"
+    (project_dir / ".github" / "workflows").mkdir(parents=True)
+    (project_dir / "SECURITY.md").write_text("shipped by the template", encoding="utf-8")
+    (project_dir / ".pre-commit-config.yaml").write_text("repos: []", encoding="utf-8")
+
+    generated = CopierResult(project_dir=project_dir, result=None)
+
+    # Everything a tool run drops into a project root afterwards.
+    for artifact in ("uv.lock", ".coverage", "coverage.xml", "junit.3.11.xml"):
+        (project_dir / artifact).write_text("", encoding="utf-8")
+
+    gates = _derive_shipped_gates(generated)
+
+    assert "file:SECURITY.md" in gates, "a file the template rendered is missing from the derived gates"
+    for artifact in ("uv.lock", ".coverage", "coverage.xml", "junit.3.11.xml"):
+        assert f"file:{artifact}" not in gates, (
+            f"{artifact} was written after generation but is counted as a gate the template ships"
+        )

--- a/tests/test_repo_workflows.py
+++ b/tests/test_repo_workflows.py
@@ -16,9 +16,12 @@ import subprocess
 from pathlib import Path
 
 import yaml
+from _tool_invocations import find_invocations
+from _tool_invocations import unpinned as unpinned_invocations
 
 _REPO = Path(__file__).resolve().parent.parent
 _WORKFLOWS = _REPO / ".github" / "workflows"
+_TEMPLATE_WORKFLOWS = _REPO / "template" / ".github" / "{% if include_actions %}workflows{% endif %}"
 _EXACT_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
 
@@ -44,14 +47,28 @@ def _setup_uv_steps():
     return steps
 
 
-def _copier_default_uv_version():
-    """The uv version copier.yml pins for generated projects.
+def _template_uv_version():
+    """The uv version the template pins for generated projects.
 
     Read rather than hardcoded so this repo's pin is checked against the same source of
     truth the fleet gets, and a bump in one place fails here instead of drifting.
+
+    The source moved: uv used to be a copier answer read from `copier.yml`, which meant
+    every generated repo also stored the value in `.copier-answers.yml` where Renovate
+    could not see it and it went stale. It is now a literal in the template's own
+    workflows, maintained like `nox` and `git-cliff`, so that is what this reads.
     """
-    config = yaml.safe_load((_REPO / "copier.yml").read_text(encoding="utf-8"))
-    return str(config["uv_version"]["default"])
+    versions = set()
+    for path in sorted(_TEMPLATE_WORKFLOWS.glob("*.jinja")):
+        for i, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
+            if not line.strip().startswith("version:"):
+                continue
+            preceding = "\n".join(path.read_text(encoding="utf-8").splitlines()[max(0, i - 4) : i])
+            if "astral-sh/setup-uv" in preceding:
+                versions.add(line.split(":", 1)[1].strip().strip('"').strip("'"))
+    assert versions, "no templated setup-uv version pin found; this check would compare against nothing"
+    assert len(versions) == 1, f"the template pins differing uv versions: {sorted(versions)}"
+    return versions.pop()
 
 
 def test_the_assertion_reads_this_repository_not_generated_output():
@@ -88,8 +105,8 @@ def test_repo_uv_pin_is_uniform_and_matches_the_version_shipped_to_projects():
     """
     versions = {str(w["version"]) for _, w in _setup_uv_steps() if w.get("version")}
     assert len(versions) == 1, f"setup-uv steps pin differing uv versions: {sorted(versions)}"
-    assert versions == {_copier_default_uv_version()}, (
-        f"this repo pins uv {sorted(versions)} but copier.yml ships {_copier_default_uv_version()} to projects"
+    assert versions == {_template_uv_version()}, (
+        f"this repo pins uv {sorted(versions)} but the template ships {_template_uv_version()} to projects"
     )
 
 
@@ -252,3 +269,68 @@ def test_instruction_body_difference_reports_each_side():
     assert only_first == ["extra-a"]
     assert only_second == ["extra-b"]
     assert instruction_body_difference(["same", ""], ["same"]) == ([], [])
+
+
+def test_every_invoked_tool_in_this_repo_is_pinned_and_annotated():
+    """Every tool this repo's workflows shell out to is pinned, not just the pinned ones.
+
+    The generated-output half of this pair is in `test_github_workflows.py`, and the
+    reason both exist is the reason this file exists at all: a property enforced
+    downstream was silently absent upstream. `uvx --from cyclonedx-bom` floated in the
+    template for months because the pin assertions quantified over steps that already
+    carried a version, so an unpinned tool was not in the set being measured.
+
+    This repo's own release path is smaller (no SBOM, no PyPI upload), but its nox
+    invocations are the same class of dependency, and nothing asserted they stay
+    pinned once someone adds a new one.
+    """
+    invocations, lines_by_path = [], {}
+    for path in _repo_workflow_paths():
+        invocations += find_invocations(path)
+        lines_by_path[path.name] = path.read_text(encoding="utf-8").splitlines()
+
+    assert invocations, "no tool invocations found in this repository's workflows; the scan is reading the wrong tree"
+
+    floating = unpinned_invocations(invocations, lines_by_path)
+    assert not floating, (
+        "tools invoked with no exact version (they resolve to whatever is newest on the day): "
+        + ", ".join(f"{i.path}:{i.line} `{i.text}`" for i in floating)
+    )
+
+    unannotated = [i for i in invocations if i.pinned and not i.annotated]
+    assert not unannotated, (
+        "pinned tools with no `# renovate:` annotation, so nothing can ever bump them: "
+        + ", ".join(f"{i.path}:{i.line} `{i.spec}`" for i in unannotated)
+    )
+
+
+def test_this_repo_authenticates_git_cliff():
+    """git-cliff's GitHub API calls are authenticated here too, not only downstream.
+
+    `.git-cliff.toml` enables the GitHub integration, so every changelog run calls the
+    API. Anonymous calls share a 60/hour budget with everything else on the runner's
+    IP, and git-cliff panics on the resulting 403 rather than degrading to plain
+    entries, so the job exits 101, no changelog PR opens, and the pushed tag is left
+    with no release behind it. This repo shipped the fix to seven projects while
+    carrying the identical defect in its own workflow.
+    """
+    changelog = _WORKFLOWS / "changelog.yml"
+    content = changelog.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(content)
+
+    assert (workflow.get("permissions") or {}).get("pull-requests") == "read", (
+        "changelog.yml does not grant `pull-requests: read`; git-cliff queries the pulls "
+        "endpoint as well as commits, so `contents: read` alone still 403s"
+    )
+    generate = [
+        step
+        for job in (workflow.get("jobs") or {}).values()
+        for step in (job.get("steps") or [])
+        if "git-cliff --config" in str(step.get("run", ""))
+    ]
+    assert generate, "no git-cliff generate step found in changelog.yml; this check would pass over nothing"
+    for step in generate:
+        assert "GITHUB_TOKEN" in (step.get("env") or {}), (
+            "the git-cliff step has no GITHUB_TOKEN in its env, so its GitHub API calls go out "
+            "anonymous and the release fails whenever the shared IP quota is exhausted"
+        )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -887,7 +887,18 @@ def test_workflows_pin_uv_nox_and_git_cliff(copie_session_default):
     assert "uv tool install nox\n" not in joined, "a floating `uv tool install nox` remains"
     assert re.search(r"tool: git-cliff@\d[\w.]*", joined), "git-cliff is not pinned to an exact version"
 
-    for dep in ("astral-sh/uv", "nox", "orhun/git-cliff"):
+    # The release path's own tools. `cyclonedx-bom` floated until it broke every
+    # generated project's release; `twine` is the same invocation shape in the same job.
+    assert re.search(r"uvx --from cyclonedx-bom==\d[\w.]*", joined), "cyclonedx-bom is not pinned to an exact version"
+    assert re.search(r"uvx twine==\d[\w.]*", joined), "twine is not pinned to an exact version"
+
+    # `--outfile` was a deprecated alias that cyclonedx-bom 7.0 removed, so the step
+    # began exiting 2 with no change in any consuming repo. `--output-file` is accepted
+    # by 6.x and 7.x alike, which makes it correct independently of the pin above.
+    assert "--output-file " in joined, "the SBOM step does not use the supported --output-file flag"
+    assert "--outfile" not in joined, "the SBOM step still passes --outfile, removed in cyclonedx-bom 7.x"
+
+    for dep in ("astral-sh/uv", "nox", "orhun/git-cliff", "cyclonedx-bom", "twine"):
         assert f"depName={dep}" in joined, f"missing renovate annotation for {dep}, so it cannot be bumped"
 
     # EVERY setup-uv version pin must carry the annotation, not just one. A single
@@ -1366,9 +1377,13 @@ def test_copier_answers_stores_all_user_inputs(copie):
     assert "package_name: my_test_pkg" in content
     assert "project_name: My Test Package" in content
     assert "project_slug: my-test-package" in content
-    # uv_version must persist so a project's pinned uv survives `copier update`
-    # (the workflow files regenerate from it); it is recorded unconditionally.
-    assert "uv_version: '0.10.0'" in content or "uv_version: 0.10.0" in content
+    # uv_version is deliberately NOT recorded. It used to be an answer, which meant
+    # every repo stored the version a second time in a file Renovate cannot see; once
+    # Renovate advanced the real pin, the answers file asserted a uv nothing ran, and
+    # any file the template later delivered rendered from the stale value. uv is now a
+    # literal in the template's workflows, maintained like nox and git-cliff, so there
+    # is no second copy to go stale and nothing to record here.
+    assert "uv_version" not in content, "uv_version is a template literal now and must not be recorded as an answer"
 
 
 def test_max_python_version_in_classifiers(copie):


### PR DESCRIPTION
Fixes #256.
Fixes #258. 
Fixes #259.

Cutting one release in `sklearn-wrap` (v0.1.0-alpha.7) surfaced three defects in the generated release path. All three were shipped to seven repos, and none was visible until a publish was already in flight. Each fix here is derived from the corresponding merged downstream fix, so `sklearn-wrap`'s own update is a no-op rather than the one repo that conflicts.

## The three defects

| | what happened | fix |
|---|---|---|
| #256 | git-cliff's API calls were anonymous (60/hr, shared per runner IP). It panics on the resulting 403 instead of degrading, so the job exits 101, no changelog PR opens, and the pushed tag has no release behind it. Roughly 1 run in 10. | `GITHUB_TOKEN` on the generate step, `pull-requests: read` on the job. The scoped job token, not the App token: git-cliff only reads here. |
| #258 | The SBOM step passed `--outfile`, removed in cyclonedx-bom 7.x, and invoked the tool unpinned. It broke on the day 7.0 shipped, with no change in any consuming repo. | `--output-file` (valid in 6.x and 7.x, so correct regardless of the pin) plus an exact pin with a `# renovate:` annotation. |
| #259 | The `pypi` gate sat on the last job, so a public Release with wheels, sdist and SBOM went out *before* the approval was requested. Rejecting cost more than approving. | Release created `--draft`; a new `finalize-release` job undrafts it only after the upload succeeds. |

## Why #258 got through

`dependency-automation` already required that "every version the template pins is machine-updatable" — but that quantifies over versions **already pinned**, which says nothing about a tool that was never pinned at all. An unpinned invocation was not in the set the check measured.

The check now enumerates *invocations* (`uvx`, `uvx --from`, `uv tool install`) and requires an exact version plus an annotation on each, across both the template output and this repository's own workflows. It found the unpinned `uvx twine check` four lines from the cyclonedx bug. Verified to fail on the pre-fix template, naming both offenders.

It also encodes one real nuance: `uv tool run` reuses an installed tool unless `--isolated`, so `uvx nox -s fix` after `uv tool install nox==...` in the same job is pinned and is not flagged.

## `uv_version` becomes a template literal

All seven repos answered the default, and the default has never moved since #220 introduced it. Meanwhile `.copier-answers.yml` was about to start recording a uv version nothing runs, the moment Renovate advanced the real pin — and any new file rendered from that answer would be born stale.

Demoted **at the current value**, so no generated workflow changes; the only diff a repo sees is one line leaving its answers file. Rehearsed end to end: a project whose uv pin was advanced by hand kept all 12 advanced pins across `copier update` against an unchanged seed, with no `.rej`.

**BREAKING** for `copier.yml`'s question set; benign in output.

## Also fixed: the parity gate measured the wrong set

Found while running the suite for this change. `test_parity_manifest` derived "gates the template ships" by listing a generated project's root *at assertion time*. Session projects are shared, and the nox smoke test runs a full tool pass inside one, so `uv.lock`, `.coverage`, `coverage.xml` and `junit.*.xml` were read as shipped gates. The gate passed or failed purely on test order; `test_fast` deselects the polluting test, so merges stayed green while `test`/`test_slow` carried a live flake, with `-n auto` adding worker placement to the coin flip.

It now reads a snapshot taken at generation time. A denylist of artifact names would have reopened the moment a tool wrote a new one — the same "measures the wrong set" defect, which is the theme of this whole PR.

## Verification

- Fast suite as CI runs it (`-m "not slow and not integration" -n auto`): **422 passed**
- Previously-failing module order: **203 passed** (confirmed twice)
- `prek`: clean
- SBOM fix verified by execution, not inspection: `cyclonedx-bom==7.3.1` with `--output-file` exits 0 and emits valid CycloneDX 1.6
- Generated job graph confirmed: `build → create-release (draft) → [pypi approval] → pypi-publish → finalize-release`

## Not in scope

A build+SBOM smoke gate that exercises the release path outside a real release (filed separately — it matters more now that Renovate will start proposing bumps to release-path tools that nothing verifies); digest pinning in the template sources; and #257.