### PR TITLE
fix(ci): make the cyclonedx-bom renovate annotation readable

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -65,9 +65,14 @@ jobs:
       # Software bill of materials (CycloneDX) for the release, generated from the
       # locked dependency set so it enumerates exactly what this release resolves.
       - name: Generate SBOM (CycloneDX)
-        # renovate: datasource=pypi depName=cyclonedx-bom
         run: |
           uv export --frozen --no-emit-project --format requirements-txt -o sbom-requirements.txt
+          # The annotation must sit directly above the line carrying the version. The
+          # custom manager matches `depName=<x>` then scans forward within ONE line, so
+          # an annotation above `run: |` lands on that key and can never reach a version
+          # two lines below -- it parses as a comment, is silently read by nothing, and
+          # the pin rots at whatever it was set to.
+          # renovate: datasource=pypi depName=cyclonedx-bom
           uvx --from cyclonedx-bom==7.3.1 cyclonedx-py requirements sbom-requirements.txt \
             --output-format JSON --output-file sbom.cdx.json
 

--- a/tests/_tool_invocations.py
+++ b/tests/_tool_invocations.py
@@ -115,3 +115,34 @@ def unpinned(invocations, lines_by_path):
         if inv.name not in installed:
             offenders.append(inv)
     return offenders
+
+
+# The exact pattern the shared Renovate preset (`stateful-y/renovate-config`) uses to
+# read `# renovate:` annotations, transcribed from `default.json`. Renovate runs RE2,
+# which spells named groups `(?<name>)`; Python needs `(?P<name>)`. That is the only
+# difference, and it is why testing this pattern locally raises rather than silently
+# matching nothing.
+PRESET_ANNOTATION = re.compile(
+    r"# renovate: datasource=(?P<datasource>\S+) depName=(?P<depName>\S+)"
+    r"\s+[^\n]*?(?P<currentValue>\d[^\"\s]*)"
+)
+
+_ANNOTATION = re.compile(r"# renovate: datasource=\S+ depName=(\S+)")
+
+
+def unreadable_annotations(path):
+    """Annotations the preset's manager cannot actually read, with their depName.
+
+    Presence is not readability. The pattern scans forward from `depName=` within a
+    SINGLE line, so an annotation placed above a `run: |` key lands on that key and can
+    never reach a version two lines below. It looks correct, reviews as correct, and is
+    read by nothing -- the pin then rots at whatever it was set to while every check
+    that merely greps for the comment stays green.
+
+    That is not hypothetical: v0.39.0 shipped exactly this for `cyclonedx-bom`, to the
+    template and all seven generated repos, and a test asserting the annotation was
+    *present* passed over it in 214 CI checks.
+    """
+    text = path.read_text(encoding="utf-8")
+    readable = {m.group("depName") for m in PRESET_ANNOTATION.finditer(text)}
+    return [dep for dep in _ANNOTATION.findall(text) if dep not in readable]

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -593,7 +593,7 @@ class TestWorkflowConsistency:
         a `# renovate:` annotation. Without the version it floats; without the
         annotation nothing can bump it and it rots wherever it was last set.
         """
-        from _tool_invocations import find_invocations, unpinned
+        from _tool_invocations import find_invocations, unpinned, unreadable_annotations
 
         result = copie.copy(extra_answers={"include_actions": True})
         assert result.exit_code == 0
@@ -612,6 +612,14 @@ class TestWorkflowConsistency:
         assert not floating, (
             "tools invoked with no exact version (they resolve to whatever is newest on the day): "
             + ", ".join(f"{i.path}:{i.line} `{i.text}`" for i in floating)
+        )
+
+        unreadable = []
+        for workflow_path in sorted(workflows_dir.glob("*.yml")):
+            unreadable += [f"{workflow_path.name}:{d}" for d in unreadable_annotations(workflow_path)]
+        assert not unreadable, (
+            "`# renovate:` annotations the preset's manager cannot read (present, but placed where "
+            "its forward scan cannot reach the version, so nothing will ever bump them): " + ", ".join(unreadable)
         )
 
         unannotated = [i for i in invocations if i.pinned and not i.annotated]

--- a/tests/test_repo_workflows.py
+++ b/tests/test_repo_workflows.py
@@ -16,7 +16,7 @@ import subprocess
 from pathlib import Path
 
 import yaml
-from _tool_invocations import find_invocations
+from _tool_invocations import find_invocations, unreadable_annotations
 from _tool_invocations import unpinned as unpinned_invocations
 
 _REPO = Path(__file__).resolve().parent.parent
@@ -296,6 +296,11 @@ def test_every_invoked_tool_in_this_repo_is_pinned_and_annotated():
         "tools invoked with no exact version (they resolve to whatever is newest on the day): "
         + ", ".join(f"{i.path}:{i.line} `{i.text}`" for i in floating)
     )
+
+    unreadable = []
+    for path in _repo_workflow_paths():
+        unreadable += [f"{path.name}:{d}" for d in unreadable_annotations(path)]
+    assert not unreadable, "`# renovate:` annotations the preset's manager cannot read: " + ", ".join(unreadable)
 
     unannotated = [i for i in invocations if i.pinned and not i.annotated]
     assert not unannotated, (


### PR DESCRIPTION
Follow-up to #260. The `cyclonedx-bom` annotation that release shipped is **unreadable by Renovate**, in the template and in all seven generated repos.

## Evidence

A full debug run of the fleet Renovate job contains the word `cyclonedx` **zero times**. `twine`, pinned in the same job four lines away, appears eight times with `twine==7.0.0`.

The difference is placement, not content:

```yaml
# renovate: datasource=pypi depName=twine
run: uvx twine==7.0.0 check dist/*          # version on the next line -> MATCHES

# renovate: datasource=pypi depName=cyclonedx-bom
run: |
  uv export ...
  uvx --from cyclonedx-bom==7.3.1 ...       # version two lines down -> NO MATCH
```

The preset's pattern is `depName=(\S+)\s+[^\n]*?(\d[^"\s]*)`. `\s+` consumes the whitespace and lands on `run: |`; `[^\n]*?` cannot cross a newline to reach the version. Confirmed by running the preset's own regex against both shapes.

Measured across the fleet before this fix: **218 annotations, 210 readable, 8 dead** — this one, in `template/` and in each of the seven repos. Nothing else is affected.

## Impact

Narrow but real. The **pin works**, so #258 stays fixed: releases use 7.3.1 with the supported `--output-file` flag. What was lost is the other half of the requirement #260 strengthened — *"expressed so that Renovate can update it."* When cyclonedx-bom 8.0 ships, nothing proposes the bump and the pin rots at 7.3.1.

## Why the new check missed it

`test_every_invoked_tool_is_pinned_and_annotated` asserted the annotation was **present** within six lines of the invocation. Presence is not readability, so it passed — through 214 CI checks across seven PRs, and through my own verification.

That is the same defect #260 was written to eliminate: a rule that quantifies over the wrong thing. #260 fixed a check that measured *already-pinned versions* instead of *invocations*; it then shipped a check that measured *comment presence* instead of *manager readability*.

## The fix

1. Move the annotation inside the block, directly above the line carrying the version.
2. Both halves of the pin check (generated output and this repo's own workflows) now assert every annotation is matched by the **preset's own regex**, transcribed from `stateful-y/renovate-config`'s `default.json`.

Falsified against the shipped defect: restoring the v0.39.0 placement fails the new check, naming `publish-release.yml:cyclonedx-bom`.

One transcription note worth keeping: Renovate runs RE2, which spells named groups `(?<name>)`, while Python needs `(?P<name>)`. Testing the pattern locally without translating it raises rather than silently matching nothing — which is the good failure mode, and is how the placement bug was found.

## Verification

```
fast suite (-m "not slow and not integration" -n auto)   422 passed
prek                                                     clean
new check vs the shipped defect                          fails, names it
fleet re-scan after fix                                  0 dead annotations
```

Needs a v0.39.1 release and a fan-out to the seven repos, which carry the dead annotation today.