### PR TITLE
refactor(tests): derive the action-pin checks instead of listing them

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -179,7 +179,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        # renovate: datasource=github-releases depName=pypa/gh-action-pypi-publish
         uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           attestations: true

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -4195,24 +4195,6 @@ def test_docs_use_no_em_or_en_dashes(copie_session_default):
 # What the fleet actually runs, verified against all seven generated repos. A pin the
 # fleet does not run is not a stale version number, it is a permanent local delta in
 # every repo that copier must replay on every release -- see the test below.
-EXPECTED_ACTION_PINS = {
-    "actions/checkout": "v7",
-    "actions/create-github-app-token": "v2",
-    "actions/download-artifact": "v7",
-    "actions/github-script": "v9",
-    "actions/upload-artifact": "v7",
-    "amannn/action-semantic-pull-request": "v6",
-    "astral-sh/setup-uv": "v7",
-    "codecov/codecov-action": "v7",
-    "codecov/test-results-action": "v1",
-    "github/codeql-action/analyze": "v3",
-    "github/codeql-action/init": "v3",
-    "github/codeql-action/upload-sarif": "v3",
-    "ossf/scorecard-action": "v2.4.4",
-    "peter-evans/create-pull-request": "v8",
-    "pypa/gh-action-pypi-publish": "v1.13.0",
-    "taiki-e/install-action": "v2",
-}
 
 
 def test_action_pins_are_consistent_and_current(copie_session_default):
@@ -4248,22 +4230,21 @@ def test_action_pins_are_consistent_and_current(copie_session_default):
     split = {a: {v: sorted(f) for v, f in vs.items()} for a, vs in pins.items() if len(vs) > 1}
     assert not split, f"these actions are pinned at more than one version: {split}"
 
-    actual = {action: next(iter(versions)) for action, versions in pins.items()}
-    unknown = sorted(set(actual) - set(EXPECTED_ACTION_PINS))
-    assert not unknown, (
-        f"new actions {unknown} are pinned but absent from EXPECTED_ACTION_PINS; check what the "
-        f"fleet runs and record it, rather than letting a fresh pin drift from day one"
-    )
-    wrong = {a: (v, EXPECTED_ACTION_PINS[a]) for a, v in actual.items() if EXPECTED_ACTION_PINS[a] != v}
-    assert not wrong, f"pins disagree with what the fleet runs (action: template -> expected): {wrong}"
+    # Currency is no longer asserted here. It used to be checked against a hand-written
+    # map of sixteen actions in this file, which is a second source of truth that can
+    # only drift: it went stale once with four pins matching no repo alive, and the test
+    # stayed green throughout. The shared Renovate preset now reads the template's own
+    # `uses:` refs directly, so a stale pin arrives as a pull request instead of as a
+    # silently-passing assertion. What remains here is the part that is derived from the
+    # rendered project and cannot go stale: one version per action.
 
 
 @pytest.mark.slow
-def test_expected_action_pins_actually_resolve_on_github():
-    """Every pin in EXPECTED_ACTION_PINS resolves to a real ref on GitHub.
+def test_action_pins_actually_resolve_on_github(copie_session_default):
+    """Every action ref the template ships resolves to a real ref on GitHub.
 
-    ``test_action_pins_are_consistent_and_current`` only checks the template's pins are
-    self-consistent and match this map -- it cannot tell whether a tag *exists*. That
+    ``test_action_pins_are_consistent_and_current`` checks the template's pins are
+    self-consistent -- it cannot tell whether a tag *exists*. That
     gap shipped ``ossf/scorecard-action@v2`` (no such tag; the action publishes only
     ``vX.Y.Z`` tags), which passed every test and then failed at runtime on every
     generated repo with "unable to find version v2". This closes it by resolving each
@@ -4278,7 +4259,13 @@ def test_expected_action_pins_actually_resolve_on_github():
         pytest.skip("gh CLI not available")
     missing = {}
     uncheckable = []
-    for action, ref in EXPECTED_ACTION_PINS.items():
+    pins = {}
+    for wf in sorted((copie_session_default.project_dir / ".github" / "workflows").glob("*.yml")):
+        for match in re.finditer(r"uses:\s*([\w./-]+)@(\S+)", wf.read_text(encoding="utf-8")):
+            pins[match.group(1)] = match.group(2)
+    assert pins, "no action refs found in the rendered project; this test would verify nothing"
+
+    for action, ref in pins.items():
         repo = "/".join(action.split("/")[:2])  # github/codeql-action/init -> github/codeql-action
         result = subprocess.run(
             [gh, "api", f"repos/{repo}/commits/{ref}", "--jq", ".sha"],
@@ -4304,7 +4291,7 @@ def test_expected_action_pins_actually_resolve_on_github():
     )
     if uncheckable:
         pytest.skip(
-            f"could not verify {len(uncheckable)}/{len(EXPECTED_ACTION_PINS)} pins "
+            f"could not verify {len(uncheckable)}/{len(pins)} pins "
             f"(gh unauthenticated or network unavailable); e.g. {uncheckable[0]}"
         )
 


### PR DESCRIPTION
Follow-up to renovate-config#2, which made the shared preset read the template's own `uses:` refs.

## The map goes

`EXPECTED_ACTION_PINS` was a hand-written map of sixteen actions asserting what the template should pin. It is a second source of truth, and it drifted — four pins once matched no repo alive while its test stayed green. Renovate now reads those refs directly, so a stale pin arrives as a pull request instead of a silently-passing assertion.

The dashboard proves the drift was live at the moment of removal. Every one of these was a value the map asserted as current:

```
actions/checkout                v7      → v7.0.1
actions/upload-artifact         v7      → v7.0.1
actions/create-github-app-token v2      → v2.2.2
astral-sh/setup-uv              v7      → v7.6
github/codeql-action/*          v3      → v3.37.4
peter-evans/create-pull-request v8      → v8.1.1
pypa/gh-action-pypi-publish     v1.13.0 → v1.14.2
```

## Both checks survive, derived

| check | before | after |
|---|---|---|
| one version per action across workflows | derived | unchanged |
| pins match what the fleet runs | the map | Renovate |
| every ref exists on GitHub | iterated the map | iterates the **rendered project's** refs |

That last row is why this is not a straight deletion. The check exists because `ossf/scorecard-action@v2` once shipped as a tag that does not exist — it passed every test and then failed at runtime in every generated repo with "unable to find version v2". Renovate would not have caught it either. Removing the map without rehoming that check would have reopened it; now it derives its input, so a newly added action is covered without anyone remembering to list it.

## The redundant annotation

`pypa/gh-action-pypi-publish` carried a `# renovate:` comment, which after renovate-config#2 made it the one dependency claimed by **two** managers under different datasources (`github-releases` at `1.13.0`, `github-tags` at `v1.13.0`) — duplicate update PRs for that action.

Removed. Verified by running both managers' regexes from the **live merged preset fetched from GitHub**, not a local copy, since what matters is what Renovate actually runs: no dependency is claimed twice.

## Verification

```
fast suite   (-m "not slow and not integration" -n auto)   424 passed
slow suite   (-m "slow or integration")                     26 passed, 4 skipped
prek                                                        clean
```

Both tiers, deliberately. The previous PR in this sequence failed CI because I ran only the fast tier and pushed on it; the failure was in the slow tier, which is the one that renders the template and runs the generated project's own checks.

## Fan-out

No urgency. The only fleet-visible change is the dropped annotation, whose sole effect is duplicate PRs for one action. Monday's Renovate run will open template PRs for the version bumps listed above, which force a release within days — this rides that rather than spending a release cycle now.