### PR TITLE
fix(tests): stop the shipped path gate failing a project that reads no site

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -355,9 +355,14 @@ checked.
 - **`gh pr checks` also exits NON-ZERO while checks are still pending.** A poll loop that
   guards on exit status breaks out immediately and reports the partial state as final; mine
   did, on this release. Guard on the *output* (`grep -q pending`), not the exit code.
-- **`Validate Commit Message` skips on a multi-commit PR** — it carries
-  `if: github.event.pull_request.commits == 1`. Folding a second release into an open PR
-  flips it from pass to skip, which is correct, not a regression: with two commits GitHub
+- **`Validate Commit Message` does NOT skip on a multi-commit PR — it PASSES vacuously.**
+  The `if: github.event.pull_request.commits == 1` is at **step** level, not job level, so
+  the job reports `success` with all its real steps skipped. In `gh pr checks` that is
+  indistinguishable from a real pass, and an agent watching for `skipping` to confirm the
+  handoff will never see it. Verified on yohou #142 after folding a second release in.
+  This entry said "flips from pass to skip, which is correct" — a green tick over an empty
+  set, recorded as benign, which is this fleet's dominant failure shape. The substantive
+  point is unchanged: with two commits GitHub
   takes the squash title from the **PR title**, which `pr-title.yml` validates instead.
   **This makes the PR title load-bearing for the changelog** — update it when you fold.
 - **RTD 403s urllib's user-agent** — use `curl`. And in **yohou**, a green RTD preview is

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -355,9 +355,14 @@ checked.
 - **`gh pr checks` also exits NON-ZERO while checks are still pending.** A poll loop that
   guards on exit status breaks out immediately and reports the partial state as final; mine
   did, on this release. Guard on the *output* (`grep -q pending`), not the exit code.
-- **`Validate Commit Message` skips on a multi-commit PR** — it carries
-  `if: github.event.pull_request.commits == 1`. Folding a second release into an open PR
-  flips it from pass to skip, which is correct, not a regression: with two commits GitHub
+- **`Validate Commit Message` does NOT skip on a multi-commit PR — it PASSES vacuously.**
+  The `if: github.event.pull_request.commits == 1` is at **step** level, not job level, so
+  the job reports `success` with all its real steps skipped. In `gh pr checks` that is
+  indistinguishable from a real pass, and an agent watching for `skipping` to confirm the
+  handoff will never see it. Verified on yohou #142 after folding a second release in.
+  This entry said "flips from pass to skip, which is correct" — a green tick over an empty
+  set, recorded as benign, which is this fleet's dominant failure shape. The substantive
+  point is unchanged: with two commits GitHub
   takes the squash title from the **PR title**, which `pr-title.yml` validates instead.
   **This makes the PR title load-bearing for the changelog** — update it when you fold.
 - **RTD 403s urllib's user-agent** — use `curl`. And in **yohou**, a green RTD preview is

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -72,6 +72,18 @@ examples/__marimo__/
 .env
 .env.local
 
+# Hypothesis writes a `.hypothesis/` storage directory for its own constants and
+# unicode caches. No setting relocates it -- `database=` moves only the example
+# database, which the generated conftest.py points under `.artifacts/`.
+#
+# Recent Hypothesis drops a self-ignoring `.gitignore` inside it, and this entry was
+# removed on the strength of that. It is version-dependent: 6.165.2 writes the file,
+# 6.151.9 does not, and the project floors at `hypothesis>=6.100`. A repo resolving
+# below the cutoff gets ~26 untracked files at its root -- the exact mess the
+# `.artifacts/` layout exists to prevent, reintroduced by trusting a library's
+# internal behaviour across a range it does not promise.
+.hypothesis/
+
 # Markdown linter cache. rumdl has no cache-path option, so unlike the caches
 # above this one cannot be moved under `.artifacts/`.
 .rumdl_cache/

--- a/template/tests/conftest.py.jinja
+++ b/template/tests/conftest.py.jinja
@@ -12,7 +12,9 @@ from hypothesis.database import DirectoryBasedExampleDatabase
 #
 # This moves the example database ONLY. Hypothesis also writes a `.hypothesis/`
 # storage directory for its own constants and unicode caches, which no setting
-# relocates; it self-ignores via a `.gitignore` Hypothesis writes inside it.
+# relocates. Newer versions drop a self-ignoring `.gitignore` inside it and older
+# ones do not, so `.gitignore` lists it explicitly rather than depending on which
+# version resolved.
 settings.register_profile("default", database=DirectoryBasedExampleDatabase(".artifacts/hypothesis"))
 settings.load_profile("default")
 

--- a/template/tests/test_artifact_paths.py.jinja
+++ b/template/tests/test_artifact_paths.py.jinja
@@ -186,9 +186,25 @@ def test_every_reader_of_the_built_site_agrees_with_mkdocs():
         path = _PROJECT / name
         if not path.is_file():
             continue
+
         text = path.read_text(encoding="utf-8")
-        if "site" not in text:
+
+        # Judge a file only if it reads the built site at all -- either correctly (it
+        # names `site_dir`) or stalely (it names a bare `site/` path). A project may
+        # publish some other way and legitimately reference neither.
+        #
+        # Both halves are load-bearing. The guard was `if "site" not in text`, and a
+        # real project failed on it: its `.readthedocs.yml` downloads a prebuilt tarball
+        # rather than building, so it genuinely does not read the built site, but the
+        # word "site" appears in its prose and in a release name. `_RELOCATED` carries a
+        # trailing slash for exactly that reason, six lines above where the guard did not.
+        # Testing only for the stale form would be worse still: a correct file names
+        # `.artifacts/site/`, which the path pattern deliberately does not match, so the
+        # assertion would never once run on a healthy repo.
+        reads_built_site = site_dir in text or re.search(_pattern_for("site/"), text)
+        if not reads_built_site:
             continue
+
         assert site_dir in text, f"{name} reads the built site but not at {site_dir!r} from mkdocs.yml `site_dir`"
 {% if include_codecov %}
 


### PR DESCRIPTION
Two defects the v0.41.1 fan-out found in the release it was rolling out. Both are mine, and the fan-out is what caught them.

## The gate fails a correct repo

`test_every_reader_of_the_built_site_agrees_with_mkdocs` decided whether to judge a file with `if "site" not in text`.

yohou's `.readthedocs.yml` downloads a prebuilt tarball rather than building (Zensical OOMs on RTD's memory limit), so it genuinely reads no built site. But the bare word "site" appears six times in its prose and in the `docs-site` release name, so the guard admitted the file and the assertion fired on something it was never meant to judge. **yohou #142 went red on a correct repo**, 12 of 24 checks failing on that one assertion.

The module already explains why the bare word is wrong — `_RELOCATED` carries a trailing slash for exactly this reason, six lines above where the guard did not.

**The obvious fix would have been worse.** Testing only for a stale `site/` skips a *correct* file too, because it names `.artifacts/site/` and the path pattern deliberately does not match a `site/` preceded by a slash. The assertion would then never once have run on a healthy repo: a green check over an empty set, which is the exact shape this release exists to remove.

The guard now judges a file that reads the built site in **either** form and skips only one that reads it in neither. Verified in a container against all three cases:

| case | expected | result |
|---|---|---|
| tarball-style `.readthedocs.yml` | skip | skipped, test passes |
| correct `.artifacts/site/` reader | judge, pass | passes |
| stale `site/` reader | judge, fail | fails with the path named |

## `.hypothesis/` is ignored again

I removed it from `.gitignore` because Hypothesis writes a self-ignoring `.gitignore` inside that directory. That is **version-dependent**: 6.165.2 writes it, 6.151.9 does not, and the template floors at `hypothesis>=6.100`.

A repo resolving below the cutoff gets ~26 untracked files at its root — precisely the mess the `.artifacts/` layout exists to prevent, reintroduced by trusting a library's internal behaviour across a range it does not promise. Two agents reported opposite results; both were right about their own environment, which is what made it worth pinning down rather than picking a side.

## Verification

451 fast tests pass. Container run confirms the gate behaves correctly in all three cases under the tests-only dependency group, and that `.hypothesis/` is ignored again.

Held for review — do not merge without a look.