### PR TITLE
fix(ci): close the second coverage upload, and anchor the Hypothesis block

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -55,7 +55,14 @@ jobs:
         with:
 {% if repo_visibility == 'public' %}          use_oidc: true
 {% else %}          token: {% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}
-{% endif %}{% endif %}
+{% endif %}          # Named explicitly, with the uploader's search off. This step had
+          # neither for several releases: it uploaded whatever the fallback happened to
+          # find, which is the exact pattern the tests.yml upload was fixed to remove --
+          # and it survived that fix because the check only looked at tests.yml.
+          files: {% raw %}'${{ github.workspace }}/.artifacts/coverage.xml'{% endraw %}
+          disable_search: true
+          fail_ci_if_error: true
+{% endif %}
   # The release path's tools, exercised where a failure is cheap.
   #
   # `publish-release.yml` only ever runs on a merged, `changelog`-labelled PR, so

--- a/template/tests/conftest.py.jinja
+++ b/template/tests/conftest.py.jinja
@@ -4,6 +4,19 @@ import pytest
 from hypothesis import settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
+
+@pytest.fixture
+def sample_data():
+    """Provide sample data for tests."""
+    return {"key": "value", "number": 42}
+
+
+# Deliberately at the end of the file, not up with the imports. `copier update`
+# applies this as a diff, and a project whose conftest imports its own package below
+# `import pytest` had these module-level statements inserted ABOVE that import --
+# ruff E402, lint red, only visible after staging. Anchored here, the hunk lands after
+# whatever the project has.
+#
 # Hypothesis remembers failing examples so a rerun replays them first. That example
 # database defaults to `.hypothesis/` at the repo root; this puts it under
 # `.artifacts/` with every other piece of throwaway output. It has no config-file
@@ -17,9 +30,3 @@ from hypothesis.database import DirectoryBasedExampleDatabase
 # version resolved.
 settings.register_profile("default", database=DirectoryBasedExampleDatabase(".artifacts/hypothesis"))
 settings.load_profile("default")
-
-
-@pytest.fixture
-def sample_data():
-    """Provide sample data for tests."""
-    return {"key": "value", "number": 42}

--- a/template/tests/test_artifact_paths.py.jinja
+++ b/template/tests/test_artifact_paths.py.jinja
@@ -208,36 +208,61 @@ def test_every_reader_of_the_built_site_agrees_with_mkdocs():
         assert site_dir in text, f"{name} reads the built site but not at {site_dir!r} from mkdocs.yml `site_dir`"
 {% if include_codecov %}
 
-def test_coverage_upload_names_the_file_coverage_writes():
-    """The Codecov `files:` input must name the file the coverage config produces.
+def _workflows_uploading_coverage():
+    """Every workflow file containing a Codecov upload step.
+
+    Deliberately discovered, not listed. The first version of these checks named
+    `tests.yml` and nothing else, so a second upload in `nightly.yml` -- with no
+    `files:` and no `disable_search:`, relying entirely on the fallback -- sat
+    unnoticed through the release that removed exactly that pattern from `tests.yml`.
+    A check that names its own scope cannot see the instance it was not told about.
+    """
+    workflows = _PROJECT / ".github/workflows"
+    if not workflows.is_dir():
+        return []
+
+    return [
+        path for path in sorted(workflows.glob("*.yml")) if "codecov/codecov-action" in path.read_text(encoding="utf-8")
+    ]
+
+
+def test_a_coverage_upload_exists_to_check():
+    """Guard the input set, so the two checks below cannot pass over nothing."""
+    assert _workflows_uploading_coverage(), (
+        "no workflow uploads coverage, so the assertions about upload paths measure nothing"
+    )
+
+
+def test_every_coverage_upload_names_the_file_coverage_writes():
+    """Each Codecov `files:` input must name the file the coverage config produces.
 
     These drifted apart once before and nothing noticed, because the uploader's
-    fallback search found the real report and reported success.
+    fallback search found the real report and reported success anyway.
     """
     pyproject = (_PROJECT / "pyproject.toml").read_text(encoding="utf-8")
     written = re.search(r"\[tool\.coverage\.xml\][^\[]*?output\s*=\s*\"([^\"]+)\"", pyproject, re.S)
     assert written, "pyproject.toml does not set [tool.coverage.xml] output; the report path is undefined"
 
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-    uploaded = re.search(r"files:\s*'\$\{\{ github\.workspace \}\}/([^']+)'", workflow)
-    assert uploaded, "the coverage upload step does not name a file"
+    for path in _workflows_uploading_coverage():
+        text = path.read_text(encoding="utf-8")
+        uploaded = re.search(r"files:\s*'?\$\{\{ github\.workspace \}\}/([^'\s]+)'?", text)
 
-    assert uploaded.group(1) == written.group(1), (
-        f"coverage upload reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
-    )
+        assert uploaded, f"{path.name} uploads coverage without naming a file, so it relies on the fallback search"
+        assert uploaded.group(1) == written.group(1), (
+            f"{path.name} reads {uploaded.group(1)!r} but the coverage config writes {written.group(1)!r}"
+        )
 
 
-def test_coverage_upload_does_not_fall_back_to_searching():
+def test_no_coverage_upload_falls_back_to_searching():
     """`fail_ci_if_error` only means something with the uploader's search disabled.
 
     With search on, a `files:` input naming nothing is not an error: the CLI scans
     the workspace, uploads whatever it finds, and the step passes.
     """
-    workflow = (_PROJECT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
-
-    assert "disable_search: true" in workflow, (
-        "the coverage upload leaves search enabled, so a wrong `files:` path cannot fail the build"
-    )
+    for path in _workflows_uploading_coverage():
+        assert "disable_search: true" in path.read_text(encoding="utf-8"), (
+            f"{path.name} leaves the uploader's search enabled, so a wrong `files:` path cannot fail the build"
+        )
 {% endif %}{% endif %}
 
 def test_the_scan_can_fail(tmp_path):


### PR DESCRIPTION
The two items deferred out of v0.41.x, both reported by fan-out agents.

## The gate could not see the second upload

`nightly.yml` uploads coverage with **neither `files:` nor `disable_search:`** — it takes whatever the fallback search finds. That is precisely the pattern v0.41.0 removed from `tests.yml`.

It survived that release because the check I wrote to catch it read `.github/workflows/tests.yml` by name. A check that names its own scope cannot see the instance nobody told it about — the same defect this line of work exists to remove, reproduced inside the fix for it.

The gate no longer takes a filename. It **discovers** every workflow containing a Codecov step and asserts over all of them, plus a guard test so the discovered set cannot silently become empty:

```
=== which workflows upload coverage? ===
.github/workflows/nightly.yml
.github/workflows/tests.yml
```

Falsified in a container — reverting `nightly.yml` to its old shape fails both assertions **by name**:

```
FAILED test_every_coverage_upload_names_the_file_coverage_writes
  - nightly.yml uploads coverage without naming a file...
FAILED test_no_coverage_upload_falls_back_to_searching
  - nightly.yml leaves the uploader's search enabled...
```

`nightly.yml` now carries `files:`, `disable_search: true` and `fail_ci_if_error: true`. It is a canary; being noisy when the path is wrong is its job.

## The Hypothesis block is anchored at the end of the conftest

`copier update` applies it as a diff. A project whose conftest imports its own package below `import pytest` had these module-level statements inserted **above** that import — ruff E402, lint red, and only visible after `git add -A` + prek. sklearn-wrap hit it and fixed it by hand.

The template's own render was clean, which is why it took a fan-out to find: the defect is in where the *hunk lands* in a divergent file, not in the file the template ships. Anchoring the block at the end means the hunk lands after whatever the project has.

## Verification

451 fast tests pass. Both `include_actions` values render ruff-check and ruff-format clean. Container run confirms the gate sees both workflows, the falsification fails by name, and the conftest block sits after the fixture.

Held for review — do not merge without a look.