### PR TITLE
fix(tests): put the Hypothesis block back, it was destroying local fixtures

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -184,6 +184,17 @@ earlier release did leave both copies, so **verify which happened** rather than 
 - It **overwrites binaries every run**, regardless of diff — no conflict, no `.rej`, only a
   `Bin NNNN -> NNNN` line. This ate project logos for months. Only `_skip_if_exists`
   stops it; "Tier 3" is a convention for whoever *resolves* an update and is never reached.
+- **Moving a block within a template file is a whole-file rewrite, and it destroys
+  divergent copies.** Measured in the v0.41.3 round: relocating a 15-line settings block
+  from the middle of the template's `tests/conftest.py` to the end -- no content change,
+  just position -- made `copier update` reject the entire file on a repo whose conftest
+  had grown to 184 lines, reverting it to the 41-line template stub with 143 lines of
+  local fixtures surviving only in a `.rej`. Reverting the move made the same update
+  apply cleanly with no `.rej` at all, which is what identified the cause.
+  This is the whitespace-tutorial hazard below with a different trigger, and it was
+  introduced *by a fix for a lint warning*. Weigh the two failure modes before moving
+  anything in a file projects customise: a lint error surfaces at staging and costs one
+  line, a rejected hunk costs whatever the project had written.
 - It applies an update as **a diff against the template's version**. Once a local file no
   longer resembles it, one shifted line rejects the whole hunk and the page reverts to the
   stub, content surviving only in a `.rej` nobody reads. A **whitespace-only** template

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -184,6 +184,17 @@ earlier release did leave both copies, so **verify which happened** rather than 
 - It **overwrites binaries every run**, regardless of diff — no conflict, no `.rej`, only a
   `Bin NNNN -> NNNN` line. This ate project logos for months. Only `_skip_if_exists`
   stops it; "Tier 3" is a convention for whoever *resolves* an update and is never reached.
+- **Moving a block within a template file is a whole-file rewrite, and it destroys
+  divergent copies.** Measured in the v0.41.3 round: relocating a 15-line settings block
+  from the middle of the template's `tests/conftest.py` to the end -- no content change,
+  just position -- made `copier update` reject the entire file on a repo whose conftest
+  had grown to 184 lines, reverting it to the 41-line template stub with 143 lines of
+  local fixtures surviving only in a `.rej`. Reverting the move made the same update
+  apply cleanly with no `.rej` at all, which is what identified the cause.
+  This is the whitespace-tutorial hazard below with a different trigger, and it was
+  introduced *by a fix for a lint warning*. Weigh the two failure modes before moving
+  anything in a file projects customise: a lint error surfaces at staging and costs one
+  line, a rejected hunk costs whatever the project had written.
 - It applies an update as **a diff against the template's version**. Once a local file no
   longer resembles it, one shifted line rejects the whole hunk and the page reverts to the
   stub, content surviving only in a `.rej` nobody reads. A **whitespace-only** template

--- a/template/tests/conftest.py.jinja
+++ b/template/tests/conftest.py.jinja
@@ -4,18 +4,13 @@ import pytest
 from hypothesis import settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
-
-@pytest.fixture
-def sample_data():
-    """Provide sample data for tests."""
-    return {"key": "value", "number": 42}
-
-
-# Deliberately at the end of the file, not up with the imports. `copier update`
-# applies this as a diff, and a project whose conftest imports its own package below
-# `import pytest` had these module-level statements inserted ABOVE that import --
-# ruff E402, lint red, only visible after staging. Anchored here, the hunk lands after
-# whatever the project has.
+# Deliberately here, between the imports and the fixtures, and NOT at the end of the
+# file. Moving it to the end was tried in v0.41.3 to avoid a ruff E402 in projects
+# whose conftest imports their own package below `import pytest`. Measured on a real
+# repo, that move made `copier update` reject the whole file and revert it to this
+# stub: 184 lines to 41, with 143 lines of local fixtures surviving only in a `.rej`.
+# The E402 is a lint error visible at staging and fixed in one line; the move silently
+# destroys a project's test infrastructure. Do not move this block again.
 #
 # Hypothesis remembers failing examples so a rerun replays them first. That example
 # database defaults to `.hypothesis/` at the repo root; this puts it under
@@ -30,3 +25,9 @@ def sample_data():
 # version resolved.
 settings.register_profile("default", database=DirectoryBasedExampleDatabase(".artifacts/hypothesis"))
 settings.load_profile("default")
+
+
+@pytest.fixture
+def sample_data():
+    """Provide sample data for tests."""
+    return {"key": "value", "number": 42}


### PR DESCRIPTION
**v0.41.3 must not be fanned out.** It destroys customised `tests/conftest.py` files, and every repo in the fleet has one.

## What it does

v0.41.3 moved the Hypothesis settings block from the middle of the generated conftest to the end, to avoid a ruff E402 in projects whose conftest imports their own package below `import pytest`. No content change — position only.

Measured on a real clone of yohou-nixtla, whose conftest has grown to 184 lines:

| | conftest | `_isolated_cwd` | `run_checks` | `daily_y_X_factory` | `.rej` |
|---|---|---|---|---|---|
| v0.41.3 as released | **41 lines** | gone | gone | gone | 143 lines |
| with the move reverted | **184 lines** | intact | intact | intact | **none** |

The whole file is rejected and reverted to the template stub. The project's test infrastructure survives only in a `.rej` — the exact hazard the fan-out skill documents, triggered by a fix for a lint warning.

Fleet conftest drift runs 135 to 437 lines, so this would have fired seven times.

## Method note

My first attempt to test this was **invalid**: I reverted the file in the working tree and ran `copier update --vcs-ref HEAD`, which renders the committed ref, not the working tree — so it re-tested the unreverted template and I briefly concluded the move was not the cause. Committing and pushing the revert first gave the clean result above. Recording it because the wrong answer was convincing.

## The trade, stated plainly

The E402 stays unfixed. It is a lint error that surfaces at staging and costs one line to fix; the move silently rewrites a file the project owns. One repo hit the E402 and fixed it by hand in a minute.

The conftest comment now says the block must not move and why. The fan-out skill gains the general form: **moving a block within a template file projects customise is a whole-file rewrite**, regardless of whether the content changed.

## What stays from v0.41.3

Nothing else is reverted. The generalised coverage-upload gate and the `nightly.yml` `files:`/`disable_search:` fix are untouched and still correct.

## Verification

451 fast tests pass. Both `include_actions` renders lint clean. The measurement above is a real `copier update` against a real clone, run twice — once with the move, once without.

Held for review — do not merge without a look.