### PR TITLE
fix(tests): leave the generated conftest byte-identical, it is effectively frozen

### DIFF
--- a/.claude/skills/fan-out-to-packages/SKILL.md
+++ b/.claude/skills/fan-out-to-packages/SKILL.md
@@ -184,6 +184,18 @@ earlier release did leave both copies, so **verify which happened** rather than 
 - It **overwrites binaries every run**, regardless of diff — no conflict, no `.rej`, only a
   `Bin NNNN -> NNNN` line. This ate project logos for months. Only `_skip_if_exists`
   stops it; "Tier 3" is a convention for whoever *resolves* an update and is never reached.
+- **The generated `tests/conftest.py` is effectively FROZEN. Any edit to it, including a
+  comment, can rewrite a project's own imports.** Measured in the v0.41.4 pre-flight
+  against real clones: inserting a comment block between the imports and the settings
+  call left `def`/fixture names untouched but **replaced kedro-dagster's entire import
+  header** -- its `# mypy: ignore-errors`, its `from __future__ import annotations`, and
+  all sixteen of its scenario imports -- with the template's five-line stub. The file
+  would not have imported. Reverting the conftest to byte-identical left it `UNCHANGED`
+  in all four repos tested, with no `.rej`.
+  Fleet conftests run 152 to 456 lines against the template's 25, so their import
+  sections have no common ancestry with it and the header hunk rejects wholesale. If the
+  template ever genuinely needs to change this file, pre-flight the update against every
+  repo first and expect to hand-carry it, not diff it.
 - **Moving a block within a template file is a whole-file rewrite, and it destroys
   divergent copies.** Measured in the v0.41.3 round: relocating a 15-line settings block
   from the middle of the template's `tests/conftest.py` to the end -- no content change,

--- a/.github/skills/fan-out-to-packages/SKILL.md
+++ b/.github/skills/fan-out-to-packages/SKILL.md
@@ -184,6 +184,18 @@ earlier release did leave both copies, so **verify which happened** rather than 
 - It **overwrites binaries every run**, regardless of diff — no conflict, no `.rej`, only a
   `Bin NNNN -> NNNN` line. This ate project logos for months. Only `_skip_if_exists`
   stops it; "Tier 3" is a convention for whoever *resolves* an update and is never reached.
+- **The generated `tests/conftest.py` is effectively FROZEN. Any edit to it, including a
+  comment, can rewrite a project's own imports.** Measured in the v0.41.4 pre-flight
+  against real clones: inserting a comment block between the imports and the settings
+  call left `def`/fixture names untouched but **replaced kedro-dagster's entire import
+  header** -- its `# mypy: ignore-errors`, its `from __future__ import annotations`, and
+  all sixteen of its scenario imports -- with the template's five-line stub. The file
+  would not have imported. Reverting the conftest to byte-identical left it `UNCHANGED`
+  in all four repos tested, with no `.rej`.
+  Fleet conftests run 152 to 456 lines against the template's 25, so their import
+  sections have no common ancestry with it and the header hunk rejects wholesale. If the
+  template ever genuinely needs to change this file, pre-flight the update against every
+  repo first and expect to hand-carry it, not diff it.
 - **Moving a block within a template file is a whole-file rewrite, and it destroys
   divergent copies.** Measured in the v0.41.3 round: relocating a 15-line settings block
   from the middle of the template's `tests/conftest.py` to the end -- no content change,

--- a/template/tests/conftest.py.jinja
+++ b/template/tests/conftest.py.jinja
@@ -4,14 +4,6 @@ import pytest
 from hypothesis import settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 
-# Deliberately here, between the imports and the fixtures, and NOT at the end of the
-# file. Moving it to the end was tried in v0.41.3 to avoid a ruff E402 in projects
-# whose conftest imports their own package below `import pytest`. Measured on a real
-# repo, that move made `copier update` reject the whole file and revert it to this
-# stub: 184 lines to 41, with 143 lines of local fixtures surviving only in a `.rej`.
-# The E402 is a lint error visible at staging and fixed in one line; the move silently
-# destroys a project's test infrastructure. Do not move this block again.
-#
 # Hypothesis remembers failing examples so a rerun replays them first. That example
 # database defaults to `.hypothesis/` at the repo root; this puts it under
 # `.artifacts/` with every other piece of throwaway output. It has no config-file


### PR DESCRIPTION
#290 reverted the block *move* but kept a comment explaining why it must not move. Pre-flighting v0.41.4 against real clones — the step v0.41.3 never got — showed **the comment alone is enough to do damage**.

## What the pre-flight found

| repo | with the comment | byte-identical to v0.41.2 |
|---|---|---|
| yohou-nixtla | 184 → 192 | **UNCHANGED** |
| kedro-dagster | 409 → **389**, `.rej` | **UNCHANGED** |
| yohou-optuna | 456 → **445**, `.rej` | **UNCHANGED** |
| sklearn-wrap | — | **UNCHANGED** |

kedro-dagster's fixtures survived, but its **entire import header was replaced**: `# mypy: ignore-errors`, `from __future__ import annotations`, and all sixteen scenario imports, swapped for the template's five-line stub. The file would not have imported.

## Why

Fleet conftests run 152–456 lines against the template's 25. Their import sections have no common ancestry with it, so any hunk touching that region rejects wholesale and falls back to the template's version. A comment inserted between the imports and the settings call sits in exactly that region.

**The generated `tests/conftest.py` is effectively frozen.** Not "edit carefully" — any edit, including a comment, can rewrite a project's own imports.

This PR makes it byte-identical to v0.41.2. The knowledge moves to the fan-out skill, where it costs nothing.

## The wider point

v0.41.3 shipped because I reasoned about a diff instead of running one. Two rounds of that reasoning were wrong in a row — first that moving the block was safe, then that a comment was safe. The pre-flight took four clones and about a minute, and it is now what the skill asks for before any change to a file projects customise.

## Verification

451 fast tests pass. The table above is real `copier update` runs against real clones of four fleet repos, twice each.

The one remaining `.rej` in the pre-flight is kedro-dagster's `nightly.yml` — the known digest-pin collision, and it carries that repo's `test-versions` job, which the skill records as previously lost to a bundled hunk. Its fan-out brief will call that out specifically.

Held for review — do not merge without a look.