### PR TITLE
fix(ci): gate the nightly coverage upload on the version that produces it

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/nightly.yml.jinja
@@ -14,6 +14,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      # A nightly exists to report, not to fail fast. Cancelling the other
+      # interpreters on the first failure turns one bad minute into a run that
+      # says nothing about the versions it never reached.
+      fail-fast: false
       matrix:
         python-version: [{%- set versions = ["3.11", "3.12", "3.13", "3.14"] -%}
           {%- for v in versions if v >= min_python_version and v <= max_python_version -%}
@@ -43,15 +47,28 @@ jobs:
         # renovate: datasource=pypi depName=nox
         run: uv tool install nox==2026.7.11
 
+      # `test_coverage` is pinned to the minimum Python, so `nox -s test_coverage`
+      # runs that interpreter whatever the matrix entry says. Asking for it on every
+      # entry ran the same suite once per version and exercised no other interpreter;
+      # the split mirrors the full/coverage split in tests.yml.
       - name: Run tests with coverage
+        if: {% raw %}matrix.python-version == '{% endraw %}{{ min_python_version }}{% raw %}'{% endraw %}
         run: nox -s test_coverage
+
+      - name: Run tests
+        if: {% raw %}matrix.python-version != '{% endraw %}{{ min_python_version }}{% raw %}'{% endraw %}
+        run: nox -s test --python {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Run docstring tests
         run: nox -s test_docstrings
 
 {% if include_codecov %}      - name: Upload coverage reports
         uses: codecov/codecov-action@v7
-        if: {% raw %}${{ matrix.python-version == '3.12'{% endraw %}{% if repo_visibility != 'public' %}{% raw %} && env.CODECOV_TOKEN != ''{% endraw %}{% endif %}{% raw %} }}{% endraw %}
+        # Gated on the entry that PRODUCES the report. This was a hardcoded '3.12'
+        # while `test_coverage` is pinned to the minimum Python, so it uploaded that
+        # run's coverage under a 3.12 label -- and in a project whose matrix has no
+        # 3.12 entry at all it uploaded nothing, silently and forever.
+        if: {% raw %}${{ matrix.python-version == '{% endraw %}{{ min_python_version }}{% raw %}'{% endraw %}{% if repo_visibility != 'public' %}{% raw %} && env.CODECOV_TOKEN != ''{% endraw %}{% endif %}{% raw %} }}{% endraw %}
         with:
 {% if repo_visibility == 'public' %}          use_oidc: true
 {% else %}          token: {% raw %}${{ env.CODECOV_TOKEN }}{% endraw %}


### PR DESCRIPTION
Adopts the `nightly.yml` fix yohou had made locally, which the v0.41.4 round surfaced and I deferred rather than folding into a release that was already a correction to a correction.

## The gate was a latent silent failure

It was a hardcoded `'3.12'`, while `test_coverage` is pinned to `PYTHON_VERSIONS[0]`.

- On a project whose minimum is 3.11 — all seven today — it uploaded **that** run's coverage under a 3.12 label.
- On a project whose matrix has **no 3.12 entry at all** (any `min_python_version` above it), the step never ran. The nightly uploaded nothing, silently and forever.

Verified on both renders: with `min_python_version: 3.13` the matrix is `["3.13", "3.14"]` and the gate now reads `'3.13'` rather than an entry that does not exist.

## Two smaller wins

`nox -s test_coverage` ran on **every** matrix entry although the session is pinned to one interpreter — the same suite once per version, no other interpreter exercised. Now split: minimum runs coverage, the rest run `test --python`, mirroring `tests.yml`.

`fail-fast: false`, because a nightly exists to report and cancelling the remaining interpreters on the first failure produces a run that says nothing about the versions it never reached.

**Deliberately not adopted:** yohou's `test_docstrings-${{ matrix.python-version }}`. The template's session takes no `python=`, so that would not resolve. yohou parametrised its own noxfile; the template has not.

## Pre-flight — and one thing the rollout must lead with

Run against all seven repos before opening this.

**Conftests untouched everywhere** (1069, 456, 409, 374, 184, 164, 152 — all unchanged).

**But all seven reject their own `codecov/codecov-action` digest.** The `if:` line sits directly below the `uses:` line, so changing it invalidates the project's pin hunk; the `.rej` holds the digest and the working tree is left with the template's `@v7`.

That is **unavoidable for any fix to this gate**, and it is precisely the resolution the fan-out skill forbids — accepting the working tree silently un-pins the action in seven repos and drops their Scorecard `PinnedDependenciesID`. Renovate would re-pin eventually, but the window is real. The rollout brief has to lead with *restore the local digest*.

Given that, this is worth **bundling with the next substantive change** rather than shipping as its own release and fan-out. Nothing here is urgent: the gate bug is latent for every current repo, and the redundancy costs nightly minutes, not correctness.

## Verification

451 fast tests pass. Both `min_python_version` renders produce valid YAML with the correct gate. Pre-flight table above is real `copier update` runs against real clones.

## Disclosure

I force-pushed this branch once, to replace a `wip:` commit with a proper message. It was my own branch, pushed minutes earlier and never reviewed — but I have told seven agents never to force-push, so I am noting it rather than letting the standard apply only to them.

Held for review — do not merge without a look.