### PR TITLE
feat(release): allow retrying a failed publish against an existing tag

### DIFF
--- a/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/publish-release.yml.jinja
@@ -5,6 +5,20 @@ on:
     types: [closed]
     branches:
       - main
+  # A publish can fail for reasons that have nothing to do with the release: an
+  # upstream action shipping a broken dependency, a registry outage, a revoked
+  # token. Without this trigger the `pull_request: closed` event is spent the
+  # moment it fires, so the only way to retry was to delete the tag and cut a new
+  # version -- which also rewrites the changelog and burns a version number for a
+  # fault the release never had. Dispatch re-runs the same pipeline against an
+  # existing tag. The `pypi` environment gate still applies, so a retry is no
+  # less reviewed than the original.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing release tag to publish, e.g. v1.2.3"
+        required: true
+        type: string
 
 # Least-privilege default: read-only token unless a job widens it explicitly.
 permissions:
@@ -20,26 +34,36 @@ jobs:
   # build previously lived in changelog.yml and was fetched across workflows with a
   # third-party action; keeping it here removes that third party from the release path.
   build:
-    # Only run if PR was merged and has the changelog label
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'changelog')
+    # A merged, changelog-labelled PR, or an explicit dispatch naming a tag.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'changelog'))
     runs-on: ubuntu-latest
     outputs:
       version: {% raw %}${{ steps.find_tag.outputs.version }}{% endraw %}
     steps:
       - name: Find release tag
         id: find_tag
-        # The PR title reaches the shell through the environment, never through
-        # an expression inside `run:`. An expression is substituted into the
-        # script before bash parses it, so a title carrying shell metacharacters
-        # would execute here -- in a job that goes on to publish. An env var is data.
+        # Both the PR title and the dispatch input reach the shell through the
+        # environment, never through an expression inside `run:`. An expression is
+        # substituted into the script before bash parses it, so a value carrying
+        # shell metacharacters would execute here -- in a job that goes on to
+        # publish. An env var is data. The dispatch input is attacker-reachable by
+        # anyone who can run a workflow, so it gets the same treatment as the title.
         env:
           PR_TITLE: {% raw %}${{ github.event.pull_request.title }}{% endraw %}
+          INPUT_VERSION: {% raw %}${{ inputs.version }}{% endraw %}
         run: |
-          # Extract version from PR title (e.g., "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1")
-          VERSION=$(printf '%s' "$PR_TITLE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
+          # One extraction validates both paths, so a dispatch input that is not a
+          # version fails closed here rather than reaching `checkout` as a ref.
+          # Extract from the dispatch input, else the PR title (e.g.
+          # "chore(release): update CHANGELOG.md for v0.2.0" or "v0.1.0-alpha.1").
+          SOURCE="${INPUT_VERSION:-$PR_TITLE}"
+          VERSION=$(printf '%s' "$SOURCE" | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[0-9]+)?)?' || echo "")
 
           if [ -z "$VERSION" ]; then
-            echo "No version found in PR title"
+            echo "No version found in ${INPUT_VERSION:+the workflow_dispatch input}${INPUT_VERSION:-the PR title}"
             exit 1
           fi
 
@@ -154,16 +178,35 @@ jobs:
       # is public until the `pypi` environment gate has been approved and the upload
       # has succeeded. `finalize-release` undrafts it. If the gate is rejected or the
       # upload fails, the draft is all that exists and can simply be deleted.
-      - name: Create draft GitHub Release
+      - name: Create or refresh the draft GitHub Release
+        # RELEASE_NOTES is an env var, not an expression inside `run:`, for the same
+        # reason the PR title is: the notes are built from commit subjects, so a
+        # subject containing shell metacharacters would otherwise be pasted into this
+        # script and executed. VERSION is interpolated because it cannot be anything
+        # else -- it is whatever the `find_tag` regex matched, and nothing wider.
         env:
           GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          RELEASE_NOTES: {% raw %}${{ steps.release_notes.outputs.notes }}{% endraw %}
         run: |
           VERSION="{% raw %}${{ needs.build.outputs.version }}{% endraw %}"
-          gh release create "$VERSION" \
-            --draft \
-            --title "$VERSION" \
-            --notes "{% raw %}${{ steps.release_notes.outputs.notes }}{% endraw %}" \
-            dist/* sbom/sbom.cdx.json
+          # A retry reaches this job with the previous attempt's release already in
+          # place -- that is the normal case, since a publish that fails at the upload
+          # leaves its draft behind. `gh release create` exits non-zero on an existing
+          # tag, so without this branch the dispatch trigger could never serve the one
+          # situation it exists for. Refresh the existing release instead, and do not
+          # re-draft one that is already public: undrafting is `finalize-release`'s
+          # decision, taken only after a successful upload.
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists; refreshing its notes and artifacts"
+            gh release upload "$VERSION" dist/* sbom/sbom.cdx.json --clobber
+            gh release edit "$VERSION" --notes "$RELEASE_NOTES"
+          else
+            gh release create "$VERSION" \
+              --draft \
+              --title "$VERSION" \
+              --notes "$RELEASE_NOTES" \
+              dist/* sbom/sbom.cdx.json
+          fi
 
   pypi-publish:
     name: Publish to PyPI

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -738,6 +738,28 @@ graph LR
     - Only commits following conventional format are included
     - Breaking changes are highlighted
 
+### If the publish fails
+
+A publish can fail for reasons that have nothing to do with the release: an upstream
+action shipping a broken dependency, a registry outage, a revoked token. The merge that
+started it cannot be replayed, and re-running the failed job reuses the old workflow
+file, so fixing the cause on `main` is not enough on its own.
+
+Fix the cause, then re-run the pipeline against the **same tag**:
+
+```bash
+gh workflow run publish-release.yml -f version=v0.2.0
+```
+
+The retry rebuilds from the tag, refreshes the existing GitHub Release rather than
+failing on it, and still stops at the `pypi` approval gate. Do **not** delete the tag and
+cut a new version to work around a failed publish: that rewrites the changelog and spends
+a version number on a fault the release never had.
+
+One case this does not cover: if the previous attempt uploaded some files to PyPI before
+failing, the retry stops on the duplicates, because PyPI does not accept a re-upload of a
+file it already has. Bump to a new version for that.
+
 ### Version Numbering
 
 This project uses [Semantic Versioning](https://semver.org/):

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -183,6 +183,62 @@ class TestPublishWorkflow:
             "finalize-release carries its own environment gate, which would strand approved releases as drafts"
         )
 
+    def test_a_failed_publish_can_be_retried_without_burning_a_version(self, copie):
+        """A publish that fails for an external reason can be re-run against the same tag.
+
+        `pull_request: closed` fires once and is then spent. When yohou's v0.1.0-alpha.12
+        upload failed because the pinned publish action bundled a twine too old for the
+        metadata hatchling emits -- nothing to do with the release -- there was no way to
+        retry: re-running the job reuses the old workflow file, and the trigger cannot be
+        made to fire again. The recovery was to delete the tag, close the changelog PR and
+        recut, which rewrites the changelog and spends a version number on a fault the
+        release never had.
+
+        So this asserts the retry path end to end, because each piece is useless alone:
+        the trigger exists and takes a tag; the build job admits a dispatch as well as a
+        merged PR; and `create-release` tolerates the release the failed attempt left
+        behind. That last one is the easiest to omit and the one that would make the
+        feature fail in exactly the case it was built for -- a failed upload leaves its
+        draft in place, and `gh release create` exits non-zero on an existing tag.
+        """
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflow_path = result.project_dir / ".github" / "workflows" / "publish-release.yml"
+        content = workflow_path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        # PyYAML resolves a bare `on:` key to the boolean True.
+        triggers = parsed.get("on", parsed.get(True))
+
+        assert "workflow_dispatch" in triggers, (
+            "no workflow_dispatch trigger, so a publish that fails for an external reason "
+            "can only be retried by deleting the tag and cutting a new version"
+        )
+        assert "version" in (triggers["workflow_dispatch"]["inputs"] or {}), (
+            "the dispatch takes no version input, so it cannot say which existing tag to publish"
+        )
+
+        build_if = parsed["jobs"]["build"]["if"]
+        assert "workflow_dispatch" in build_if, (
+            f"the build job's condition does not admit a dispatch ({build_if!r}), so the "
+            "trigger fires and every job is skipped"
+        )
+        assert "changelog" in build_if, "the dispatch path dropped the changelog-label gate for merged PRs"
+
+        assert "gh release view" in content, (
+            "create-release does not check whether the release already exists, so a retry "
+            "dies on `gh release create` against the draft the failed attempt left behind"
+        )
+        assert "--clobber" in content, "a retry cannot replace the artifacts of the attempt it is retrying"
+
+        # The retry must not become a way around the human checkpoint.
+        gated = [name for name, body in parsed["jobs"].items() if (body.get("environment") or {})]
+        assert gated == ["pypi-publish"], (
+            f"the dispatch path changed which jobs are gated ({gated}), so a retry could publish unreviewed"
+        )
+
     def test_changelog_generation_is_authenticated(self, copie):
         """git-cliff's GitHub API calls carry a token.
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -212,11 +212,16 @@ def test_no_untrusted_expression_reaches_a_shell(copie):
 
 
 def test_release_tag_is_parsed_from_the_environment(copie):
-    """The release job reads the PR title from `env:`, and never re-interpolates it.
+    """Every source of the release tag reaches the job via `env:`, never re-interpolated.
 
     The generic scan above would stay green if someone "fixed" this by adding an `env:`
     block and leaving the `${{ }}` in the script, or by dropping the title parsing
     entirely. This pins the specific shape the release path depends on.
+
+    Both sources are covered. `workflow_dispatch.inputs.version` is if anything the more
+    exposed of the two: a PR title has to survive review to reach the merge that fires
+    the workflow, while a dispatch input is typed straight into a job that holds
+    `contents: write` and gates the PyPI upload.
     """
     result = copie.copy(extra_answers={"include_actions": True})
     publish = _read(result.project_dir, ".github/workflows/publish-release.yml")
@@ -224,8 +229,35 @@ def test_release_tag_is_parsed_from_the_environment(copie):
     assert "PR_TITLE: ${{ github.event.pull_request.title }}" in publish, (
         "the PR title no longer reaches the release job through the environment"
     )
+    assert "INPUT_VERSION: ${{ inputs.version }}" in publish, (
+        "the workflow_dispatch version no longer reaches the release job through the environment"
+    )
     assert 'PR_TITLE="${{' not in publish, "the PR title is still interpolated into the shell"
-    assert '"$PR_TITLE"' in publish, "nothing reads the PR title, so the version can no longer be found"
+    assert 'INPUT_VERSION="${{' not in publish, "the dispatch input is still interpolated into the shell"
+    # Both are read through parameter expansion (`${VAR:-default}`), so match that form
+    # rather than a bare `$VAR`, which the script never contains.
+    assert "$PR_TITLE" in publish, "nothing reads the PR title, so the version can no longer be found"
+    assert "${INPUT_VERSION" in publish, "nothing reads the dispatch input, so a retry cannot name its tag"
+
+
+def test_release_notes_are_not_pasted_into_the_shell(copie):
+    """The release notes reach `gh release` as data, not as a substituted expression.
+
+    The notes are built by git-cliff from commit subjects, so their content is decided
+    by whoever wrote the commits -- the same untrusted-input shape as the PR title, and
+    in the same job, which holds `contents: write` and precedes the PyPI upload. Passing
+    them as `--notes "${{ steps.release_notes.outputs.notes }}"` substitutes them into
+    the script before bash parses it, so a subject carrying a quote and a semicolon runs
+    as commands. Passing them through `env:` makes them data.
+    """
+    result = copie.copy(extra_answers={"include_actions": True})
+    publish = _read(result.project_dir, ".github/workflows/publish-release.yml")
+
+    assert "RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}" in publish, (
+        "the release notes no longer reach the release step through the environment"
+    )
+    assert '--notes "${{' not in publish, "the release notes are still interpolated into the shell"
+    assert '--notes "$RELEASE_NOTES"' in publish, "nothing passes the notes to gh release"
 
 
 def test_publish_action_is_not_a_branch_ref(copie):


### PR DESCRIPTION
## Description

Adds a `workflow_dispatch` trigger to `publish-release.yml` so a failed publish can be
re-run against the tag it already has, and makes `create-release` tolerate the release the
failed attempt left behind.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

`pull_request: closed` fires once and is then spent. When yohou's `v0.1.0-alpha.12` upload
failed because the pinned publish action bundled a twine too old for the metadata hatchling
emits — nothing to do with the release itself — there was no way to retry. Re-running the
failed job reuses the old workflow file, and the trigger cannot be made to fire again.

The recovery was to delete the tag, close the changelog PR and recut, which rewrites the
changelog and spends a version number on a fault the release never had. That happened to
five repos in one session.

Three parts, because each is useless alone:

1. **The trigger**, taking the tag to publish:
   `gh workflow run publish-release.yml -f version=v0.2.0`
2. **`build`'s condition** admits a dispatch as well as a merged, changelog-labelled PR.
3. **`create-release` is idempotent.** This is the easy one to omit and the one that would
   make the feature fail in exactly the case it exists for: a failed upload leaves its draft
   behind, and `gh release create` exits non-zero on an existing tag. It now refreshes the
   existing release instead, and does not re-draft one that is already public — undrafting
   stays `finalize-release`'s decision, taken only after a successful upload.

The `pypi` environment gate still applies, so a retry is no less reviewed than the original.

### Also: the release notes were being pasted into the shell

Not the reason for this PR, but it is the step being rewritten, so it is fixed here.
`--notes "${{ steps.release_notes.outputs.notes }}"` substitutes the notes into the script
before bash parses it. The notes are built by git-cliff from **commit subjects**, so their
content is chosen by whoever wrote the commits — the same untrusted-input shape v0.40.1
fixed for the PR title, in the same job, which holds `contents: write` and precedes the
PyPI upload. They now reach `gh release` through `env:`.

The dispatch input gets the same treatment, and is validated by the same regex as the PR
title, so an input that is not a version fails closed rather than reaching `checkout` as a
ref.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

**Known limit, documented rather than papered over:** if a previous attempt uploaded some
files to PyPI before failing, the retry stops on the duplicates, because PyPI does not
accept a re-upload of a file it already has. `skip-existing` would hide that, but it would
equally hide a genuine attempt to republish an existing version, so the docs say to bump
instead.

**Tests were falsified, not just written.** `test_a_failed_publish_can_be_retried_without_
burning_a_version` was run against three mutations — trigger removed, `create-release`
reverted to a plain `gh release create`, changelog-label gate dropped — and failed on each,
passing only unmutated. `test_release_notes_are_not_pasted_into_the_shell` fails when the
`${{ }}` is put back. Full fast suite: 456 passed.

All verification ran in a clean clone rather than this working copy, which currently holds
another session's in-progress Renovate work; nothing here touches it.
