### PR TITLE
fix(ci): verify the release tag is signed before the release proceeds

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,7 +14,67 @@ permissions:
   pull-requests: read
 
 jobs:
+  # A human creates the release tag, and that push is what triggers this workflow, so
+  # no automation exists at the moment the tag comes into being: by the time anything
+  # can object, the tag is already public. This job is the first automated thing to see
+  # it, and it runs before the changelog pull request opens and long before anything is
+  # published, so a rejected release costs a force-deleted tag rather than a withdrawn
+  # artifact.
+  #
+  # It exists because "release tags are signed" was written in the contributing guide
+  # and in the security posture, believed, and measured by nothing -- v0.34.0 through
+  # v0.38.0 carried no signature at all and no one found out until someone went
+  # looking. A control nothing measures is a claim, so this is deliberately the
+  # cheapest possible job: no checkout, no actions, no third party in the release path.
+  verify-tag-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the release tag carries a verifiable signature
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Read from the environment, never through an Actions expression: those are
+          # substituted into the script body before bash parses it, and a tag name is
+          # attacker-influenced text.
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          # A lightweight tag is a ref pointing straight at a commit, with no tag object
+          # to carry a signature. Report it separately from an unsigned annotated tag,
+          # because "you forgot -s" and "you forgot -a" read identically in the failure
+          # and are fixed the same way only by accident.
+          REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" \
+            --jq '.object.type + " " + .object.sha')
+          OBJECT_TYPE="${REF%% *}"
+          OBJECT_SHA="${REF##* }"
+
+          if [ "$OBJECT_TYPE" != "tag" ]; then
+            echo "::error::${TAG_NAME} is a lightweight tag, so there is no tag object to sign." \
+              "Delete it (git push --delete origin ${TAG_NAME}) and recreate it with" \
+              "'git tag -s ${TAG_NAME} -m \"Release ${TAG_NAME}\"'."
+            exit 1
+          fi
+
+          # Ask the forge whether the signature verifies, rather than grepping the tag
+          # body for a PGP block. A malformed or unknown-key signature contains the
+          # block and proves nothing, so a grep would be a check that passes on exactly
+          # the input it exists to reject.
+          TAG_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJECT_SHA}")
+          VERIFIED=$(printf '%s' "$TAG_JSON" | jq -r '.verification.verified')
+          REASON=$(printf '%s' "$TAG_JSON" | jq -r '.verification.reason')
+
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::${TAG_NAME} has no verifiable signature (reason: ${REASON})." \
+              "Sign release tags with 'git tag -s', and make sure the public half of the" \
+              "signing key is registered on the tagger's account so the signature can be" \
+              "checked by someone who is not you. See docs/pages/explanation/release-process.md."
+            exit 1
+          fi
+
+          echo "${TAG_NAME} is signed and the signature verifies."
+
   changelog:
+    needs: verify-tag-signature
     runs-on: ubuntu-latest
     steps:
       # Mint a short-lived, scoped token from the fleet automation GitHub App. A PR

--- a/docs/pages/explanation/release-process.md
+++ b/docs/pages/explanation/release-process.md
@@ -62,12 +62,36 @@ The version is determined by the Git tag - there is no version file to manually 
 
 ## The Complete Flow in Practice
 
-1. Developer pushes a **signed** version tag: `git tag -s v0.2.0 -m "Release v0.2.0" && git push origin v0.2.0` (tags are signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing, so the tag is verifiable with no long-lived GPG key; this complements the artifact-level PEP 740 attestations)
-2. `changelog.yml` generates the changelog, builds the package, creates a PR
-3. Maintainer reviews and merges the PR
-4. `publish-release.yml` creates a GitHub Release with artifacts
-5. Designated reviewer receives a notification and approves the PyPI deployment
-6. Package is published to PyPI via Trusted Publishing
+1. Developer pushes a **signed** version tag: `git tag -s v0.2.0 -m "Release v0.2.0" && git push origin v0.2.0`. The signature complements the artifact-level PEP 740 attestations: those cover what was published, and the tag signature covers what it was published from.
+2. `changelog.yml`'s `verify-tag-signature` job rejects the release if that tag is unsigned, or if its signature cannot be verified against a key registered on the tagger's account. Nothing runs before this job, because the tag push is what starts the workflow. See [Why the signature check runs where it does](#why-the-signature-check-runs-where-it-does) below.
+3. `changelog.yml` generates the changelog, builds the package, creates a PR
+4. Maintainer reviews and merges the PR
+5. `publish-release.yml` creates a GitHub Release with artifacts
+6. Designated reviewer receives a notification and approves the PyPI deployment
+7. Package is published to PyPI via Trusted Publishing
+
+## Why the signature check runs where it does
+
+A person creates the release tag, and pushing it is what starts `changelog.yml`. There
+is therefore no moment at which automation can inspect the tag before it exists: by the
+time any workflow runs, the tag is already public. Verification is detection, not
+prevention, and the honest thing is to say so rather than to imply the check stops a bad
+tag from being created.
+
+What it does buy is cost. `verify-tag-signature` is the first automated thing to see the
+tag and gates every other job through `needs`, so an unsigned tag is rejected before the
+changelog PR opens, before a GitHub Release exists and before anything reaches PyPI. The
+recovery is `git push --delete origin vX.Y.Z` and a re-tag, which spends a version number
+and nothing else.
+
+The job asks the GitHub API whether the signature verifies rather than grepping the tag
+body for a PGP block. A tag carrying a malformed signature, or one made with a key nobody
+can look up, contains the block and proves nothing, so a grep would pass on exactly the
+input the check exists to reject.
+
+Prevention would need a tag ruleset with the `required_signatures` rule, which is
+repository configuration rather than anything the template can ship. That remains open;
+this check is the half that travels with the code.
 
 ## Connections
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/changelog.yml.jinja
@@ -15,7 +15,69 @@ permissions:
   pull-requests: read
 
 jobs:
+  # A human creates the release tag, and that push is what triggers this workflow, so
+  # no automation exists at the moment the tag comes into being: by the time anything
+  # can object, the tag is already public. This job is the first automated thing to see
+  # it, and it runs before the changelog pull request opens and long before anything is
+  # published, so a rejected release costs a force-deleted tag rather than a withdrawn
+  # artifact.
+  #
+  # It exists because "release tags are signed" was written in the contributing guide
+  # and in the security posture, believed, and measured by nothing -- five consecutive
+  # releases of the template that generates this workflow carried no signature at all
+  # and no one found out until someone went looking. A control nothing measures is a
+  # claim, so this is deliberately the cheapest possible job: no checkout, no actions,
+  # no third party in the release path.
+  verify-tag-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify the release tag carries a verifiable signature
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+        run: |
+          set -euo pipefail
+          # Read from the environment, never through an Actions expression: those are
+          # substituted into the script body before bash parses it, and a tag name is
+          # attacker-influenced text.
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+          # A lightweight tag is a ref pointing straight at a commit, with no tag object
+          # to carry a signature. Report it separately from an unsigned annotated tag,
+          # because "you forgot -s" and "you forgot -a" read identically in the failure
+          # and are fixed the same way only by accident.
+          REF=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}" \
+            --jq '.object.type + " " + .object.sha')
+          OBJECT_TYPE="${REF%% *}"
+          OBJECT_SHA="${REF##* }"
+
+          if [ "$OBJECT_TYPE" != "tag" ]; then
+            echo "::error::${TAG_NAME} is a lightweight tag, so there is no tag object to sign." \
+              "Delete it (git push --delete origin ${TAG_NAME}) and recreate it with" \
+              "'git tag -s ${TAG_NAME} -m \"Release ${TAG_NAME}\"'."
+            exit 1
+          fi
+
+          # Ask the forge whether the signature verifies, rather than grepping the tag
+          # body for a PGP block. A malformed or unknown-key signature contains the
+          # block and proves nothing, so a grep would be a check that passes on exactly
+          # the input it exists to reject.
+          TAG_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJECT_SHA}")
+          VERIFIED=$(printf '%s' "$TAG_JSON" | jq -r '.verification.verified')
+          REASON=$(printf '%s' "$TAG_JSON" | jq -r '.verification.reason')
+
+          if [ "$VERIFIED" != "true" ]; then
+            echo "::error::${TAG_NAME} has no verifiable signature (reason: ${REASON})." \
+              "Sign release tags with 'git tag -s', and make sure the public half of the" \
+              "signing key is registered on the tagger's account so the signature can be" \
+              "checked by someone who is not you. See the release section of the" \
+              "contributing guide."
+            exit 1
+          fi
+
+          echo "${TAG_NAME} is signed and the signature verifies."
+
   changelog:
+    needs: verify-tag-signature
     runs-on: ubuntu-latest
     steps:
       # Mint a short-lived, scoped token from the fleet automation GitHub App. A PR

--- a/template/docs/pages/how-to/contribute.md.jinja
+++ b/template/docs/pages/how-to/contribute.md.jinja
@@ -694,45 +694,49 @@ graph LR
 
 ### How It Works
 
-1. **Tag a release** (signed with [gitsign](https://github.com/sigstore/gitsign) keyless Sigstore signing):
+1. **Tag a release** (the tag must be signed, and CI rejects it if it is not):
 
     ```bash
    git tag -s v0.2.0 -m "Release v0.2.0"
    git push origin v0.2.0
     ```
 
-    One-time gitsign setup so `git tag -s` signs via Sigstore, with no long-lived GPG key to manage:
+    One-time setup so `git tag -s` works, and so the signature is verifiable by someone who is not you:
 
     ```bash
-   git config --local gpg.x509.program gitsign
-   git config --local gpg.format x509
+   git config --local user.signingkey <your-key-id>
    git config --local tag.gpgSign true
     ```
 
-    The first signing authenticates via your identity provider in a browser; verify a tag with `gitsign verify-tag`. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
+    Upload the public half of that key to your account's SSH and GPG keys settings. This is not optional bookkeeping: the release check asks the forge whether the signature verifies, and a signature made with a key nobody can look up fails exactly like no signature at all. Signed tags complement the PEP 740 artifact attestations the publish workflow already produces, so both the tag and the published artifacts are verifiable.
 
-2. **Automated changelog workflow** (`changelog.yml`):
+2. **Signature check** (`changelog.yml`, job `verify-tag-signature`):
+    - Runs before every other job, and gates them through `needs`
+    - Rejects a lightweight tag (there is no tag object to sign) and an unverifiable signature, with a different message for each
+    - Pushing the tag is what starts the workflow, so this is detection rather than prevention: the tag is already public when the check runs. It fires before the changelog PR opens and long before anything reaches PyPI, so recovery is `git push --delete origin v0.2.0` and a re-tag
+
+3. **Automated changelog workflow** (`changelog.yml`):
     - Generates changelog from conventional commits using git-cliff
     - Creates a **Pull Request** with the updated CHANGELOG.md
     - Builds the package distributions (wheels and sdist) for **immediate validation**
     - Stores distributions as workflow artifacts (reused later to avoid rebuilding)
 
-3. **Review and merge the changelog PR:**
+4. **Review and merge the changelog PR:**
     - A maintainer reviews the generated changelog
     - Once approved, merge the PR to main
 
-4. **Automated release workflow** (`publish-release.yml`):
+5. **Automated release workflow** (`publish-release.yml`):
     - Creates a GitHub Release with generated release notes
     - Attaches distribution files to the release
     - **Waits for manual approval** before proceeding to PyPI
 
-5. **Manual approval for PyPI publishing:**
+6. **Manual approval for PyPI publishing:**
     - Designated reviewers receive a notification
     - Review the GitHub Release to verify everything is correct
     - Approve the deployment to publish to PyPI
     - Package is published using Trusted Publishing (OIDC, no tokens needed)
 
-6. **Release notes generation:**
+7. **Release notes generation:**
     - All commits since the last tag are analyzed
     - Commits are grouped by type (Added, Fixed, Documentation, etc.)
     - Only commits following conventional format are included

--- a/tests/parity_manifest.yml
+++ b/tests/parity_manifest.yml
@@ -80,6 +80,15 @@ file_gates:
     equivalent: changelog.yml:changelog
     status: matched
     reason: same git-cliff changelog PR flow, on the same tag trigger.
+  changelog.yml:verify-tag-signature:
+    equivalent: changelog.yml:verify-tag-signature
+    status: matched
+    reason: >-
+      Same job, gating the same `changelog` job through `needs`. Deliberately a job
+      rather than a step inside `changelog`: this manifest derives what the template
+      ships from workflow JOB ids, so a step would be invisible to it and this repo
+      could drop the check with nothing failing. The gate that measures a claim has to
+      be shaped so its own absence is measurable, which is the whole premise here.
   publish-release.yml:create-release:
     equivalent: publish-release.yml:create-release
     status: matched

--- a/tests/test_github_workflows.py
+++ b/tests/test_github_workflows.py
@@ -384,6 +384,72 @@ class TestChangelogWorkflow:
         assert "push:" in workflow_content
         assert "tags:" in workflow_content
 
+    def test_the_release_tag_signature_is_verified_before_anything_else_runs(self, copie):
+        """An unsigned release tag stops the release, and stops it first.
+
+        The contributing guide and the security posture both state that release tags
+        are signed. For five consecutive releases of this template they were not, and
+        nothing noticed: the requirement was written down and measured nowhere, which
+        is the same shape as every other control that turned out to be a claim.
+
+        A person creates the tag and that push starts the workflow, so no check can run
+        before the tag exists. What is available is order: this job must gate the rest
+        rather than race them, or the changelog PR opens for a release that is about to
+        be rejected.
+        """
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflow_path = result.project_dir / ".github" / "workflows" / "changelog.yml"
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        jobs = workflow.get("jobs") or {}
+
+        assert "verify-tag-signature" in jobs, (
+            "changelog.yml has no verify-tag-signature job, so an unsigned tag would reach "
+            f"a changelog PR and a release unchallenged; jobs are {sorted(jobs)}"
+        )
+        assert "verify-tag-signature" in (jobs["changelog"].get("needs") or []), (
+            "the changelog job does not depend on verify-tag-signature, so the two run in "
+            "parallel and the changelog PR opens for a release the check is about to reject"
+        )
+
+    def test_the_signature_check_rejects_a_signature_it_cannot_verify(self, copie):
+        """The check reads a verification verdict, not the presence of a PGP block.
+
+        A tag signed with a key nobody can look up, or with a corrupted signature,
+        still contains `BEGIN PGP SIGNATURE`. A grep for that block therefore passes on
+        exactly the input the check exists to reject, which would make this another
+        control that reports success without measuring anything. Assert on the
+        mechanism, because the difference between the two implementations is invisible
+        in a passing run.
+        """
+        import yaml
+
+        result = copie.copy(extra_answers={"include_actions": True})
+        assert result.exit_code == 0
+
+        workflow_path = result.project_dir / ".github" / "workflows" / "changelog.yml"
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        script = "\n".join(
+            str(step.get("run", "")) for step in (workflow["jobs"]["verify-tag-signature"].get("steps") or [])
+        )
+
+        assert script.strip(), "the verify-tag-signature job runs no script at all"
+        assert ".verification.verified" in script, (
+            "the signature check does not read the forge's verification verdict; a check that "
+            "greps the tag body for a signature block passes on a malformed or unknown-key "
+            "signature, which is the case it exists to catch"
+        )
+        assert "'.object.type" in script or ".object.type" in script, (
+            "the check does not distinguish a lightweight tag, which has no tag object to "
+            "sign and so fails for a reason the operator cannot act on from the message alone"
+        )
+        # `${{ }}` is substituted before bash parses the line, so a tag name must reach the
+        # shell as an environment variable. GITHUB_REF is the runner's own, not an expression.
+        assert "GITHUB_REF" in script, "the tag name is not read from the environment"
+
 
 class TestNightlyWorkflow:
     """Test the nightly.yml workflow."""

--- a/tests/test_repo_workflows.py
+++ b/tests/test_repo_workflows.py
@@ -418,6 +418,33 @@ def test_this_repo_authenticates_git_cliff():
         )
 
 
+def test_this_repo_verifies_its_own_release_tag_signatures():
+    """The signature gate shipped to seven projects also guards this repo's releases.
+
+    v0.34.0 through v0.38.0 were tagged here with no signature at all while the
+    contributing guide this repo hands out said tags are signed. Shipping the check
+    downstream and not running it here would reproduce the original defect one level
+    up, which is the specific failure this whole test module exists to prevent.
+    """
+    changelog = _WORKFLOWS / "changelog.yml"
+    workflow = yaml.safe_load(changelog.read_text(encoding="utf-8"))
+    jobs = workflow.get("jobs") or {}
+
+    assert "verify-tag-signature" in jobs, (
+        f"this repo's changelog.yml has no verify-tag-signature job; jobs are {sorted(jobs)}"
+    )
+    assert "verify-tag-signature" in (jobs["changelog"].get("needs") or []), (
+        "the changelog job does not depend on verify-tag-signature, so an unsigned tag still "
+        "opens a changelog PR before anything objects"
+    )
+
+    script = "\n".join(str(step.get("run", "")) for step in (jobs["verify-tag-signature"].get("steps") or []))
+    assert ".verification.verified" in script, (
+        "the check does not read the forge's verification verdict, so a signature made with "
+        "an unknown key would pass it"
+    )
+
+
 def test_repo_coverage_upload_names_the_file_it_writes():
     """This repo's own Codecov step must name the path its coverage config produces.
 


### PR DESCRIPTION
## Description

Adds a `verify-tag-signature` job to `changelog.yml`, in the template and in this repository's own copy, which rejects a release whose tag is unsigned or whose signature cannot be verified. Also corrects the signing mechanism the docs describe: both guides specified gitsign keyless Sigstore signing, and every signed tag in the fleet is in fact GPG.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Fixes #268

The docs and the `generated-project-security` spec both say release tags are signed. For five consecutive releases they were not, and nothing noticed. Current practice is correct, so the defect is not the signing: it is that the requirement was written down and measured nowhere, and the next unsigned tag would be exactly as invisible as the five before it. Same shape as the defects fixed in v0.39.0 and v0.39.1.

**Option 1 from the issue.** A person creates the tag and that push is what starts `changelog.yml`, so nothing can inspect the tag before it exists: this is detection, not prevention, and the docs now say so rather than implying otherwise. What it buys is cost. The job gates every other job through `needs`, so an unsigned tag is rejected before the changelog PR opens and long before anything reaches PyPI. Recovery is `git push --delete origin vX.Y.Z` and a re-tag.

Two design points worth review:

- **It asks the forge for a verification verdict rather than grepping for a PGP block.** A tag signed with an unknown key, or carrying a corrupted signature, still contains `BEGIN PGP SIGNATURE`. A grep would pass on exactly the input the check exists to reject, which would make this another control that reports success while measuring nothing.
- **It is a job, not a step inside `changelog`.** `tests/parity_manifest.yml` derives what the template ships from workflow *job ids*. A step would be invisible to that derivation, so this repo could later drop the check with nothing failing. The gate that measures a claim has to be shaped so its own absence is measurable.

Option 3 (a tag ruleset with `required_signatures`) is the only preventive fix and remains open. It is repository configuration, so the template cannot ship it and the seven generated projects would inherit nothing; this is the half that travels with the code. Worth noting no repo in the fleet currently has any ruleset with `target: tag`.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

`454 passed` on the fast suite; `prek` clean on every changed file.

The three new tests were verified non-vacuous by mutation rather than assumed: swapping `.verification.verified` for `.verification.reason` and `needs: verify-tag-signature` for `needs: []` in the template makes both new generated-project tests fail with their intended messages. Reverting restores green.

Empirically checked while writing this, across all eight repos: the latest tag in each is signed and returns `verification.verified: true`, and every tag before it is unsigned. So the check passes on today's practice and would have caught v0.34.0 through v0.38.0.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

**Fan-out**: not done here. Per the issue, the template ships this requirement to seven generated projects, so `changelog.yml` and the contributing guide both change downstream. Landing this alongside other pending template work in one release, as arranged.

**Not in this PR**, both flagged in the same investigation:

- `openspec/specs/generated-project-security/spec.md` states the requirement as "WHEN the release workflow creates a version tag", an event that never occurs, since a human creates it. The OpenSpec tree is gitignored and untracked, so it cannot be part of any PR; updated locally.
- `tests/parity_manifest.yml` describes the merge gate's mechanism as ruleset `protect-main`; the ruleset is actually named `main`. Harmless (the test keys on the check name, not the ruleset name) and left alone to keep this diff to one concern.
