### PR TITLE
feat(ci): approve and automerge the dependency updates that CI clears

### DIFF
--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,76 @@
+name: Renovate Automerge
+
+# Renovate cannot approve its own pull request, so the branch ruleset's required
+# approving review blocks every unattended dependency update no matter what
+# `automerge` is set to in the shared preset. This workflow supplies that approval for
+# the update classes the preset already marked as safe to merge unattended, then hands
+# the PR to GitHub's own auto-merge queue. The required status checks still gate the
+# merge: auto-merge waits for them, so a red CI run means the PR sits unmerged.
+#
+# This is the template repository's own copy. The version generated into every project
+# is the renovate-automerge.yml.jinja source under the template's workflows directory;
+# keep the two in step.
+
+on:
+  pull_request:
+    # `labeled` matters as much as `opened`: Renovate creates the PR first and applies
+    # labels in a second API call, so the `opened` payload can arrive with an empty
+    # label list and the guard below would reject a PR that is in fact eligible.
+    types: [opened, reopened, synchronize, labeled]
+    branches: [main]
+
+# Least-privilege default: read-only token; the job below widens only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  automerge:
+    name: Approve and enable automerge
+    # Three independent conditions, all required.
+    #
+    # Deliberately NOT keyed on a literal bot login. The account name is the GitHub
+    # App's slug, which differs per installation: this fleet's self-hosted App is
+    # `stateful-y-renovate[bot]`, not the `renovate[bot]` of the hosted Mend app.
+    # Hardcoding either one gives a workflow that passes its own syntax checks and
+    # then silently never fires.
+    #
+    # The `automerge` label is the authorization signal. The preset applies it on
+    # exactly the rules that also set `automerge: true`, and nowhere else, so major
+    # bumps and the grouped runtime dependency PR carry no label and stay fully
+    # manual. Applying a label needs write access, so an outside contributor cannot
+    # forge the signal, and the branch-prefix and Bot-author checks keep a human PR
+    # from ever being auto-approved.
+    if: >-
+      github.event.pull_request.user.type == 'Bot'
+      && startsWith(github.event.pull_request.head.ref, 'renovate/')
+      && contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    permissions:
+      # `gh pr merge --auto` writes the auto-merge setting on the PR.
+      contents: write
+      # `gh pr review --approve` needs write, and the org or repository setting
+      # "Allow GitHub Actions to create and approve pull requests" must be enabled
+      # or this step fails with a 403.
+      pull-requests: write
+    steps:
+      - name: Approve the update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Idempotent: re-approving an already-approved PR is not an error, which
+          # matters because `synchronize` fires again on every Renovate rebase.
+          gh pr review --approve "$PR_URL" \
+            --body "Approved automatically: this update is in the automerge scope set by the shared Renovate preset. The required status checks still gate the merge."
+
+      - name: Hand the PR to GitHub auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # Renovate's `platformAutomerge` normally does this at creation time. Doing
+          # it here too covers the case where that call failed, and fails loudly if
+          # the repository has "Allow auto-merge" switched off, rather than leaving
+          # the PR to sit unexplained. Squash is the only merge method the ruleset
+          # permits.
+          gh pr merge --auto --squash "$PR_URL"

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -97,6 +97,11 @@ docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
+.github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is
+                                   # template-owned: it must keep requiring the
+                                   # `automerge` label, or the workflow starts approving
+                                   # updates nothing chose to automate. A project may add
+                                   # its own steps, so merge rather than overwrite.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/template/.github/renovate.json.jinja
+++ b/template/.github/renovate.json.jinja
@@ -8,9 +8,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "timezone": "Etc/UTC",
-  "schedule": ["before 9am on monday"],
+  "schedule": ["before 11am"],
   "labels": ["dependencies"],
   "dependencyDashboard": true,
+  "description": "The schedule is a wide daily window on purpose. A narrow one is a trap: whatever triggers Renovate is best-effort, so a window only slightly wider than the trigger is missed outright, and a missed window looks exactly like a healthy run that found nothing. `prHourlyLimit: 0` matters for the same reason: the default of 2 silently caps each run, so updates accumulate in the dashboard's Rate-Limited section faster than they drain.",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "platformAutomerge": true,
+  "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
       "description": "Batch runtime, test and docs dependencies into one low-noise PR.",
@@ -28,6 +33,20 @@
       "description": "Label GitHub Actions updates.",
       "matchManagers": ["github-actions"],
       "addLabels": ["ci"]
+    },
+    {
+      "description": "Automerge the CI and tooling updates: action digest refreshes and action patch/minor bumps, plus the pinned tool versions the custom manager reads (uv, nox, git-cliff, gitleaks, twine, cyclonedx-bom). The `automerge` label is not decoration: renovate-automerge.yml keys on it, so it must appear on exactly the rules that set `automerge: true` and nowhere else. Majors are excluded because an action major can change its inputs or outputs.",
+      "matchManagers": ["github-actions", "custom.regex"],
+      "matchUpdateTypes": ["digest", "pin", "pinDigest", "patch", "minor"],
+      "automerge": true,
+      "addLabels": ["automerge"]
+    },
+    {
+      "description": "Automerge patch/minor for the lint tools. These are dev-only, and a lint upgrade that breaks the build breaks it in CI, which blocks the merge by construction. Kept as its own rule rather than folded into the one above so the lockstep grouping set earlier still applies. The grouped `python-dependencies` PR is deliberately NOT automerged: it mixes runtime and dev dependencies into a single PR, so there is no safe half of it to merge unattended.",
+      "matchPackageNames": ["ruff", "rumdl", "ty", "interrogate", "prek"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "addLabels": ["automerge"]
     }
   ],
   "customManagers": [

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -97,6 +97,11 @@ docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
+.github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is
+                                   # template-owned: it must keep requiring the
+                                   # `automerge` label, or the workflow starts approving
+                                   # updates nothing chose to automate. A project may add
+                                   # its own steps, so merge rather than overwrite.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/template/.github/{% if include_actions %}workflows{% endif %}/renovate-automerge.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/renovate-automerge.yml.jinja
@@ -1,0 +1,72 @@
+name: Renovate Automerge
+
+# Renovate cannot approve its own pull request, so a branch ruleset that requires an
+# approving review blocks every unattended dependency update no matter what
+# `automerge` is set to in renovate.json. This workflow supplies that approval for the
+# update classes renovate.json already marked as safe to merge unattended, then hands
+# the PR to GitHub's own auto-merge queue. The required status checks still gate the
+# merge: auto-merge waits for them, so a red CI run means the PR sits unmerged.
+
+on:
+  pull_request:
+    # `labeled` matters as much as `opened`: Renovate creates the PR first and applies
+    # labels in a second API call, so the `opened` payload can arrive with an empty
+    # label list and the guard below would reject a PR that is in fact eligible.
+    types: [opened, reopened, synchronize, labeled]
+    branches: [main]
+
+# Least-privilege default: read-only token; the job below widens only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  automerge:
+    name: Approve and enable automerge
+    # Three independent conditions, all required.
+    #
+    # Deliberately NOT keyed on a literal bot login. The account name is the GitHub
+    # App's slug, which differs per installation: a self-hosted App shows up as
+    # `<app-slug>[bot]` (this fleet's is `stateful-y-renovate[bot]`), not the
+    # `renovate[bot]` of the hosted Mend app. Hardcoding either one gives a workflow
+    # that passes its own syntax checks and then silently never fires.
+    #
+    # The `automerge` label is the authorization signal. renovate.json applies it on
+    # exactly the rules that also set `automerge: true`, and nowhere else, so major
+    # bumps and the grouped runtime dependency PR carry no label and stay fully
+    # manual. Applying a label needs write access, so an outside contributor cannot
+    # forge the signal, and the branch-prefix and Bot-author checks keep a human PR
+    # from ever being auto-approved.
+    if: >-
+      github.event.pull_request.user.type == 'Bot'
+      && startsWith(github.event.pull_request.head.ref, 'renovate/')
+      && contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    permissions:
+      # `gh pr merge --auto` writes the auto-merge setting on the PR.
+      contents: write
+      # `gh pr review --approve` needs write, and the org or repository setting
+      # "Allow GitHub Actions to create and approve pull requests" must be enabled
+      # or this step fails with a 403.
+      pull-requests: write
+    steps:
+      - name: Approve the update
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          PR_URL: {% raw %}${{ github.event.pull_request.html_url }}{% endraw %}
+        run: |
+          # Idempotent: re-approving an already-approved PR is not an error, which
+          # matters because `synchronize` fires again on every Renovate rebase.
+          gh pr review --approve "$PR_URL" \
+            --body "Approved automatically: this update is in the automerge scope set by .github/renovate.json. The required status checks still gate the merge."
+
+      - name: Hand the PR to GitHub auto-merge
+        env:
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+          PR_URL: {% raw %}${{ github.event.pull_request.html_url }}{% endraw %}
+        run: |
+          # Renovate's `platformAutomerge` normally does this at creation time. Doing
+          # it here too covers the case where that call failed, and fails loudly if
+          # the repository has "Allow auto-merge" switched off, rather than leaving
+          # the PR to sit unexplained. Squash is the only merge method the ruleset
+          # permits.
+          gh pr merge --auto --squash "$PR_URL"

--- a/tests/parity_manifest.yml
+++ b/tests/parity_manifest.yml
@@ -109,6 +109,14 @@ file_gates:
     equivalent: pr-title.yml:validate-pr-title
     status: matched
     reason: same conventional pull request title check.
+  renovate-automerge.yml:automerge:
+    equivalent: renovate-automerge.yml:automerge
+    status: matched
+    reason: >-
+      Same approve-then-auto-merge job. This repo needs it most: it carried the largest
+      rate-limited backlog of the eight (18 items against a drain rate of two pull
+      requests per week), because it is the only one whose template/ tree Renovate also
+      scans.
 
   # --- CI: scheduled and security -----------------------------------------
   nightly.yml:test:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -875,6 +875,77 @@ def test_renovate_config_extends_preset_when_set(copie):
     assert "packageRules" not in config, "a preset subscription should not inline packageRules"
 
 
+def test_renovate_automerge_label_is_the_only_automerge_signal(copie_session_default):
+    """The `automerge` label sits on exactly the rules that set `automerge: true`.
+
+    renovate-automerge.yml approves a bot pull request only when it carries this label,
+    so the label is the authorization boundary and not a cosmetic tag. The two halves
+    fail in opposite directions and both fail quietly: a rule with `automerge: true` and
+    no label produces a pull request Renovate wants merged that nothing ever approves,
+    and a rule with the label but no `automerge: true` pre-approves an update nobody
+    chose to automate.
+    """
+    config = json.loads((copie_session_default.project_dir / ".github" / "renovate.json").read_text(encoding="utf-8"))
+    rules = config["packageRules"]
+
+    labelled = {i for i, rule in enumerate(rules) if "automerge" in rule.get("addLabels", [])}
+    automerged = {i for i, rule in enumerate(rules) if rule.get("automerge") is True}
+
+    assert automerged, "no rule enables automerge, so every dependency update needs a human merge"
+    assert labelled == automerged, (
+        f"rules setting automerge: {sorted(automerged)}, rules adding the label: {sorted(labelled)}. "
+        "The two must be the same set, or the approve-then-merge chain breaks with no error."
+    )
+
+
+def test_renovate_automerge_scope_excludes_majors_and_runtime_dependencies(copie_session_default):
+    """Nothing automerges a major, and the grouped runtime dependency PR never does.
+
+    A major can change an action's inputs or a library's API, and the `pep621` group is a
+    single pull request mixing runtime and dev dependencies, so there is no safe half of
+    it to merge unattended.
+    """
+    config = json.loads((copie_session_default.project_dir / ".github" / "renovate.json").read_text(encoding="utf-8"))
+
+    for rule in config["packageRules"]:
+        if rule.get("automerge") is not True:
+            continue
+        update_types = rule.get("matchUpdateTypes")
+        assert update_types, f"automerge rule with no matchUpdateTypes matches majors too: {rule!r}"
+        assert "major" not in update_types, f"automerge rule accepts majors: {rule!r}"
+        assert "pep621" not in rule.get("matchManagers", []), (
+            f"automerge rule covers the grouped runtime dependency PR: {rule!r}"
+        )
+
+
+def test_renovate_automerge_workflow_does_not_hardcode_a_bot_login(copie_session_default):
+    """The automerge guard keys on the label, never on a bot account name.
+
+    The account that opens the pull request is named after the GitHub App's slug, which
+    differs per installation: a self-hosted App is `<app-slug>[bot]` while the hosted
+    Mend app is `renovate[bot]`. A guard comparing against either literal is valid YAML
+    that evaluates false forever, so the workflow runs, reports success, and approves
+    nothing.
+    """
+    workflow = copie_session_default.project_dir / ".github" / "workflows" / "renovate-automerge.yml"
+    assert workflow.is_file(), "renovate-automerge.yml not generated"
+    text = workflow.read_text(encoding="utf-8")
+
+    guard = text.split("runs-on:")[0]
+    assert "[bot]'" not in guard and '[bot]"' not in guard, (
+        "the automerge guard compares against a literal bot login, which differs per "
+        "GitHub App installation and would make the guard silently always false"
+    )
+    assert "contains(github.event.pull_request.labels.*.name, 'automerge')" in guard, (
+        "the automerge guard does not require the `automerge` label, so it would approve "
+        "every bot pull request including majors"
+    )
+    assert "pull_request_target" not in text, (
+        "pull_request_target grants write access to code from forks; Renovate branches are "
+        "in-repo, so the plain pull_request trigger is both sufficient and safe"
+    )
+
+
 def test_workflows_pin_uv_nox_and_git_cliff(copie_session_default):
     """uv, nox and git-cliff are pinned to exact versions, not floating "latest".
 


### PR DESCRIPTION
## Description

Renovate's dependency dashboards accumulate updates without opening pull requests. Two settings multiply to explain it, and neither reports itself as a problem.

Measured drain rate: **two dependency PRs per repo per week**, against 61 queued updates fleet-wide (18 in this repo, the most of the eight, because it is the only one whose `template/` tree Renovate also scans). `yohou` opened exactly 2 on Mon 08-03 and exactly 2 on Mon 08-10; `kedro-dagster` the same. Cause: the shared runner fired Mondays only, times `prHourlyLimit: 2` capping that single run at two.

The throughput half is fixed in the shared preset (stateful-y/renovate-config#4). This PR is the half that has to ship from the template, because lifting the caps alone would only produce PRs nothing can merge.

**Why nothing could merge:** Renovate cannot approve its own pull request, and the org ruleset requires one approving review with only `OrganizationAdmin` as a bypass actor. So every unattended update was blocked regardless of any `automerge` setting. `renovate-automerge.yml` supplies that approval for the classes `renovate.json` marks as safe, then hands the PR to GitHub's auto-merge queue. The four required checks still gate the merge, so a red run leaves the PR sitting.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

The interesting part is the guard. It keys on an `automerge` label and deliberately **not** on a bot account name: the account is the GitHub App's slug, which differs per installation. This fleet's is `stateful-y-renovate[bot]`, not the hosted Mend app's `renovate[bot]`. A guard comparing against either literal is valid YAML that evaluates false forever, so the workflow would run, report success, and approve nothing. `test_renovate_automerge_workflow_does_not_hardcode_a_bot_login` forbids that shape.

That makes the label load-bearing rather than decorative, so a second test asserts the set of rules adding the label equals the set setting `automerge: true`. The two halves fail in opposite directions and both fail quietly:

- `automerge: true` with no label produces a PR Renovate wants merged that nothing ever approves.
- The label with no `automerge: true` pre-approves an update nobody chose to automate.

`schedule` widens from `before 9am on monday` to a wide daily window. A narrow window is a trap in the same way: whatever triggers Renovate is best-effort, so a window barely wider than the trigger is missed outright, and a missed window is indistinguishable from a healthy run that found nothing. The preset repo already learned this once (stateful-y/renovate-config#1 measured a run starting 3h29m late against a one-hour window).

## Automerge scope

In: action digests and patch/minor, the `# renovate:` annotated tool pins, the lint-tools group.

Out, deliberately, and asserted by `test_renovate_automerge_scope_excludes_majors_and_runtime_dependencies`:

- **Majors.** An action major can change its inputs or outputs.
- **The grouped `python-dependencies` PR.** It batches runtime and dev dependencies into one PR, so there is no safe half to merge unattended.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — 480 passed, 4 skipped (the pre-existing marimo export skips)
- [x] Added/updated tests
- [x] All tests pass

Also verified:

- `renovate-config-validator --strict` passes on the rendered self-contained config, in repository-config mode (not the global mode the validator defaults to when handed a path).
- The parity manifest entry is non-vacuous: removing it makes `test_every_shipped_gate_is_answered` fail with the new gate named.
- `uv run prek run --files ...` passes on every changed file. (`rumdl` fails on `diataxis-docs-planner/SKILL.md` on `main` already; untouched here.)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

**Already applied outside this PR** (both were hard blockers):

- `can_approve_pull_request_reviews` enabled org-wide, so a `GITHUB_TOKEN` approval satisfies the review rule. This is broader than Renovate: any workflow in the org could now approve PRs. `default_workflow_permissions` stays `read`.
- `allow_auto_merge` enabled on all eight repos; `gh pr merge --auto` errors without it.

**Merge ordering:** this PR and the fan-out must land before stateful-y/renovate-config#4, or the first daily run opens all 61 backlogged PRs with no approver.

**Known limitation:** the org ruleset sets `strict_required_status_checks_policy: true`, so each merge makes every other open Renovate branch out of date. Expect the backlog to drain serially over several days rather than at once.

**Still to do:** release, then fan the workflow out to the seven generated repos. Until it is on each repo's `main`, Renovate branches there will not carry it.