### PR TITLE
feat(docs): tell every generated project how to cite itself

### DIFF
--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -95,6 +95,14 @@ docs/index.md
 docs/pages/reference/api.md
 docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
+docs/pages/reference/citation.md   # prose copy of the citation; a project may add a
+                                   # paper or a DOI to it
+CITATION.cff                       # renders entirely from copier answers, which argues
+                                   # for Tier 1. Against that: the commented `doi:` line
+                                   # exists precisely so a project can fill it in, and a
+                                   # Tier 1 overwrite would delete that DOI with no
+                                   # conflict, no .rej and no output, the same silent
+                                   # loss as the logos.
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
 .github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -95,6 +95,14 @@ docs/index.md
 docs/pages/reference/api.md
 docs/pages/how-to/contribute.md
 docs/pages/explanation/security.md
+docs/pages/reference/citation.md   # prose copy of the citation; a project may add a
+                                   # paper or a DOI to it
+CITATION.cff                       # renders entirely from copier answers, which argues
+                                   # for Tier 1. Against that: the commented `doi:` line
+                                   # exists precisely so a project can fill it in, and a
+                                   # Tier 1 overwrite would delete that DOI with no
+                                   # conflict, no .rej and no output, the same silent
+                                   # loss as the logos.
 .github/workflows/tests.yml        # conditional: include_actions
 .github/workflows/pr-title.yml     # conditional: include_actions
 .github/workflows/renovate-automerge.yml  # conditional: include_actions. The guard is

--- a/template/CITATION.cff.jinja
+++ b/template/CITATION.cff.jinja
@@ -1,0 +1,34 @@
+# How to cite {{ project_name }}, in the one form machines read. GitHub renders the
+# "Cite this repository" button from this file, and reads it from the default
+# branch's ROOT only: moving it under `.github/` or `docs/` does not relocate the
+# consumer, it removes the only one. Same reason `LICENSE` stays at the root.
+#
+# There is deliberately no `version:` and no `date-released:` here. Both are optional
+# in the format, GitHub's button works without them, and both are wrong the day after
+# the next release. Keeping them right would mean a step in the release workflow, and
+# what it would buy is a version number a reader can already get from PyPI. Add them
+# yourself if you need version-specific citation.
+#
+# The prose copies of this citation live in README.md and
+# docs/pages/reference/citation.md. All three render from the same answers.
+cff-version: 1.2.0
+message: "If you use {{ project_name }} in your work, please cite it as below."
+title: "{{ project_name }}"
+abstract: "{{ description }}"
+type: software
+authors:
+  # Recorded as a single `name`, which the format treats as an entity rather than a
+  # person. That is deliberate: splitting "{{ author_name }}" into given and family
+  # names means guessing where one ends and the other begins, and a template that
+  # guesses wrong ships a misattributed citation. If the author is a person, replace
+  # `name` with `given-names` and `family-names` here. This file is merge-required,
+  # not template-managed, so that edit survives template updates.
+  - name: "{{ author_name }}"
+    email: "{{ author_email }}"
+repository-code: "https://github.com/{{ github_username }}/{{ project_slug }}"
+url: "https://{{ project_slug }}.readthedocs.io/"
+{% if license in ["Apache-2.0", "MIT", "BSD-3-Clause", "GPL-3.0"] %}license: {{ license }}
+{% endif %}# No DOI is assigned to this project. If you deposit a release (Zenodo, for
+# example), uncomment the line below and paste the CONCEPT DOI, the one that always
+# resolves to the latest version, rather than a single release's DOI.
+# doi: 10.5281/zenodo.XXXXXXX

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -145,6 +145,25 @@ For questions and discussions, you can also open a [discussion](https://github.c
 
 This project is licensed under the terms of the [{{ license }} License](https://github.com/{{ github_username }}/{{ project_slug }}/blob/main/LICENSE).
 
+## How do I cite {{ project_name }}?
+
+If you use {{ project_name }} in work you publish, please cite it:
+
+{{ author_name }}. {{ project_name }}. https://github.com/{{ github_username }}/{{ project_slug }}
+
+Or in BibTeX:
+
+```bibtex
+@software{{ '{' }}{{ package_name }},
+  author  = "{{ author_name }}",
+  title   = "{{ '{' }}{{ project_name }}}",
+  url     = "https://github.com/{{ github_username }}/{{ project_slug }}",
+  license = "{{ license }}"
+}
+```
+
+Reference managers can read [CITATION.cff](https://github.com/{{ github_username }}/{{ project_slug }}/blob/main/CITATION.cff) directly. To cite a specific version, see the [citation page](https://{{ project_slug }}.readthedocs.io/en/latest/pages/reference/citation/).
+
 ## Acknowledgements
 
 This project is maintained by [stateful-y](https://stateful-y.io), an ML consultancy specializing in MLOps and data science & engineering. If you're interested in collaborating or learning more about our services, please visit our website.

--- a/template/docs/pages/reference/citation.md.jinja
+++ b/template/docs/pages/reference/citation.md.jinja
@@ -26,7 +26,7 @@ machine-readable file below carries no release date: either one is wrong as soon
 the next version ships. If your citation style needs them, add the year and the
 version you actually used:
 
-```
+```text
   year    = "2026",
   version = "1.2.3",
 ```

--- a/template/docs/pages/reference/citation.md.jinja
+++ b/template/docs/pages/reference/citation.md.jinja
@@ -1,0 +1,49 @@
+---
+description: How to cite {{ project_name }}, in plain text and in BibTeX.
+---
+
+# Citation
+
+If you use {{ project_name }} in work you publish, please cite it.
+
+## Plain text
+
+{{ author_name }}. {{ project_name }}. https://github.com/{{ github_username }}/{{ project_slug }}
+
+## BibTeX
+
+```bibtex
+@software{{ '{' }}{{ package_name }},
+  author  = "{{ author_name }}",
+  title   = "{{ '{' }}{{ project_name }}}",
+  url     = "https://github.com/{{ github_username }}/{{ project_slug }}",
+  license = "{{ license }}"
+}
+```
+
+The entry carries no `year` and no `version` on purpose, for the same reason the
+machine-readable file below carries no release date: either one is wrong as soon as
+the next version ships. If your citation style needs them, add the year and the
+version you actually used:
+
+```
+  year    = "2026",
+  version = "1.2.3",
+```
+
+The version you used is the one `pip show {{ package_name }}` reports.
+
+## Machine-readable metadata
+
+The repository root carries a
+[`CITATION.cff`](https://github.com/{{ github_username }}/{{ project_slug }}/blob/main/CITATION.cff)
+file. It is the same citation in the Citation File Format, which is what GitHub's
+"Cite this repository" button, Zenodo, and most reference managers read. If your tool
+can import that file, prefer it over copying from this page: it cannot fall out of
+step with the repository.
+
+## There is no DOI
+
+No release of {{ project_name }} has been deposited with a DOI-issuing archive, so
+there is no DOI to cite. Cite the repository URL above instead. If that changes, the
+`doi` field in `CITATION.cff` is where it will appear first.

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -262,6 +262,7 @@ nav:
     - pages/reference/index.md
     - API: pages/reference/api.md
     - Changelog: pages/reference/changelog.md
+    - Citation: pages/reference/citation.md
 
 extra:
   social:

--- a/tests/parity_manifest.yml
+++ b/tests/parity_manifest.yml
@@ -222,6 +222,17 @@ file_gates:
       Adopted, with wording corrected for what this repo is: a fix reaches a generated
       project only when that project runs `copier update`, so there is no patched
       release to consume. Also satisfies an OpenSSF Scorecard check.
+  file:CITATION.cff:
+    status: excluded
+    reason: >-
+      This repo is a Copier template, not software anyone cites: it is not on PyPI, it
+      has no importable package, and a paper that used it would cite the seven packages
+      it generated rather than the generator. It ships citation metadata (the file, a
+      README section and docs/pages/reference/citation.md) to every generated project
+      and deliberately carries none of the three itself. This entry is what makes that
+      a reviewed decision rather than an omission, which is the whole point of the
+      derivation: the file arrived here as an unanswered gate the moment the template
+      began shipping it.
 
   # --- pre-commit / prek hooks --------------------------------------------
   hook:trailing-whitespace: {status: matched, reason: same builtin hook.}

--- a/tests/test_docs_content.py
+++ b/tests/test_docs_content.py
@@ -476,6 +476,25 @@ class TestMkdocsConfiguration:
         # Should include examples in navigation
         assert "example" in nav_str
 
+    def test_mkdocs_yml_navigation_lists_the_citation_page_under_reference(self, copie_session_default):
+        """Citing is a lookup, so the page belongs in Reference and must be in the nav.
+
+        The nav entry is not only placement: the Reference index resolves its own
+        contents from `<!-- SUBPAGES -->`, which reads the nav. A page missing from the
+        nav is a page nothing links to.
+        """
+        mkdocs_file = copie_session_default.project_dir / "mkdocs.yml"
+        mkdocs_data = yaml.load(mkdocs_file.read_text(encoding="utf-8"), Loader=SafeMkdocsLoader)
+
+        reference = next((section["Reference"] for section in mkdocs_data["nav"] if "Reference" in section), None)
+        assert reference is not None, "the nav has no Reference section"
+
+        titles = [title for entry in reference if isinstance(entry, dict) for title in entry]
+        assert "Citation" in titles, f"the Reference section does not list the citation page: {titles}"
+
+        pages = [page for entry in reference if isinstance(entry, dict) for page in entry.values()]
+        assert "pages/reference/citation.md" in pages, "the Citation nav entry points somewhere else"
+
     def test_mkdocs_yml_navigation_excludes_examples_when_disabled(self, copie):
         """Test that navigation excludes examples when disabled."""
         result = copie.copy(extra_answers={"include_examples": False})

--- a/tests/test_option_combinations.py
+++ b/tests/test_option_combinations.py
@@ -1,6 +1,7 @@
 """Tests for template option combinations and integration scenarios."""
 
 import pytest
+import yaml
 from _build_layout import BUILD_DIR
 
 
@@ -111,6 +112,19 @@ def test_all_licenses(copie, license_type):
     # Verify pyproject.toml has correct license (uses table format)
     pyproject_content = (result.project_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert f'license = {{ text = "{license_type}" }}' in pyproject_content
+
+    # CITATION.cff validates its `license` against the SPDX list, and "Proprietary" is
+    # not an SPDX identifier. The field is optional, so it is emitted only for the four
+    # answers that are identifiers; emitting it for the fifth would ship a file that
+    # fails schema validation in every tool that reads it.
+    citation = yaml.safe_load((result.project_dir / "CITATION.cff").read_text(encoding="utf-8"))
+    assert citation, f"CITATION.cff did not parse for {license_type}"
+    if license_type == "Proprietary":
+        assert "license" not in citation, (
+            "CITATION.cff carries a non-SPDX license identifier, which fails schema validation"
+        )
+    else:
+        assert citation["license"] == license_type, f"CITATION.cff states the wrong licence for {license_type}"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -5343,3 +5344,169 @@ def test_claude_md_survives_a_later_template_run(tmp_path):
     assert claude_md.read_text(encoding="utf-8") == owned, (
         "the template overwrote the project's own CLAUDE.md; _skip_if_exists is not holding"
     )
+
+
+# --- Citation metadata ------------------------------------------------------
+
+_BIBTEX_BLOCK = re.compile(r"^```bibtex\n(.*?)^```", re.MULTILINE | re.DOTALL)
+
+
+def _citation_file(project_dir):
+    """Return the generated CITATION.cff as (raw text, parsed mapping)."""
+    path = project_dir / "CITATION.cff"
+    assert path.is_file(), "the template ships no CITATION.cff at the project root"
+    raw = path.read_text(encoding="utf-8")
+    return raw, yaml.safe_load(raw)
+
+
+def test_citation_file_is_generated_at_the_root(copie_session_default):
+    """A generated project carries machine-readable citation metadata, at the root.
+
+    GitHub renders its "Cite this repository" button from this file and reads it from
+    the default branch's root only. Under `.github/` or `docs/` the file is not
+    relocated, it is unread, so the location is the requirement rather than a tidiness
+    preference.
+    """
+    project_dir = copie_session_default.project_dir
+    _, citation = _citation_file(project_dir)
+
+    for key in ("cff-version", "message", "title", "abstract", "type", "authors", "repository-code"):
+        assert key in citation, f"CITATION.cff is missing the required `{key}` field"
+    assert citation["authors"], "CITATION.cff lists no authors; the format requires at least one"
+
+    assert not (project_dir / ".github" / "CITATION.cff").exists(), (
+        "a CITATION.cff under .github/ is a file GitHub's citation widget never reads"
+    )
+    assert not (project_dir / "docs" / "CITATION.cff").exists(), (
+        "a CITATION.cff under docs/ is a file GitHub's citation widget never reads"
+    )
+
+
+def test_citation_file_carries_nothing_that_goes_stale(copie_session_default):
+    """No `version`, no `date-released`, and the DOI ships commented out.
+
+    Both fields are optional and the citation button works without them. Present, they
+    are wrong the day after the next release, in every generated project at once, and
+    keeping them right would mean a step in the release workflow. The `doi:` line is
+    the opposite case: it must be visible enough for a project to fill in, and inert
+    until one does.
+    """
+    raw, citation = _citation_file(copie_session_default.project_dir)
+
+    assert "version" not in citation, (
+        "CITATION.cff pins a version, which is wrong the day after the next release and has nothing keeping it right"
+    )
+    assert "date-released" not in citation, "CITATION.cff pins a release date with nothing keeping it right"
+
+    assert "doi" not in citation, "CITATION.cff ships an active doi field; no project in the fleet has a DOI"
+    assert re.search(r"^# doi:", raw, re.MULTILINE), (
+        "the commented `# doi:` placeholder is gone, so a project that deposits one has nowhere obvious to put it"
+    )
+
+
+def test_citation_fields_agree_with_package_metadata(copie_session_default):
+    """The citation and `pyproject.toml` cannot name different authors or licences.
+
+    Both render from the same answers, so a disagreement means one of the two stopped
+    reading the answer it is supposed to. That is worth catching here rather than in a
+    citation somebody publishes.
+    """
+    project_dir = copie_session_default.project_dir
+    _, citation = _citation_file(project_dir)
+    pyproject = tomllib.loads((project_dir / "pyproject.toml").read_text(encoding="utf-8"))
+
+    author = pyproject["project"]["authors"][0]
+    assert citation["authors"][0]["name"] == author["name"], "the citation names a different author than the package"
+    assert citation["authors"][0]["email"] == author["email"], (
+        "the citation carries a different author email than the package"
+    )
+
+    assert citation["license"] == pyproject["project"]["license"]["text"], (
+        "the citation states a different licence than the package"
+    )
+
+    answers = yaml.safe_load((project_dir / ".copier-answers.yml").read_text(encoding="utf-8"))
+    expected_repo = f"https://github.com/{answers['github_username']}/{answers['project_slug']}"
+    assert citation["repository-code"] == expected_repo, "the citation points at the wrong repository"
+    assert citation["title"] == answers["project_name"], "the citation cites something other than this project"
+
+
+def test_readme_citation_section_sits_between_licence_and_acknowledgements(copie_session_default):
+    """Placement is the requirement, not decoration.
+
+    The seven generated projects have rewritten most of their README but all seven
+    still carry the template's exact `## License` paragraph immediately followed by
+    `## Acknowledgements`. A section anchored between those two has matching context on
+    both sides everywhere, which is what decides whether a `copier update` hunk applies
+    or lands in a `.rej` nobody reads. Move it elsewhere and the fan-out stops being
+    automatic.
+    """
+    readme = (copie_session_default.project_dir / "README.md").read_text(encoding="utf-8")
+
+    licence_at = readme.find("\n## License")
+    citation_at = readme.find("\n## How do I cite")
+    acknowledgements_at = readme.find("\n## Acknowledgements")
+
+    assert citation_at != -1, "the README never tells a reader how to cite the project"
+    assert licence_at != -1 and acknowledgements_at != -1, (
+        "the README anchors this section is placed between are gone; the fan-out hunk has no context"
+    )
+    assert licence_at < citation_at < acknowledgements_at, (
+        "the citation section moved out from between License and Acknowledgements, so the "
+        "update hunk no longer has matching context in the generated projects"
+    )
+
+    section = readme[citation_at:acknowledgements_at]
+    assert "CITATION.cff" in section, "the README section never points at the machine-readable file"
+    assert "pages/reference/citation/" in section, "the README section never points at the docs citation page"
+
+
+def test_readme_and_docs_cite_the_project_identically(copie_session_default):
+    """Two copies of a citation that can disagree eventually do.
+
+    The README and the docs page both carry a copy-pasteable BibTeX entry, because
+    sending a README reader elsewhere for the one thing they came for is worse than a
+    second copy. What makes the second copy safe is this test: both are rendered from
+    the same expressions, and an edit to one template file and not the other fails
+    here instead of shipping two answers to the same question.
+    """
+    project_dir = copie_session_default.project_dir
+    readme = (project_dir / "README.md").read_text(encoding="utf-8")
+    docs_page = (project_dir / "docs" / "pages" / "reference" / "citation.md").read_text(encoding="utf-8")
+
+    in_readme = _BIBTEX_BLOCK.search(readme)
+    in_docs = _BIBTEX_BLOCK.search(docs_page)
+
+    # Assert both were found before comparing. Two failed searches compare equal as
+    # "not found", and this test would then pass by measuring nothing.
+    assert in_readme, "the README carries no ```bibtex block"
+    assert in_docs, "the docs citation page carries no ```bibtex block"
+
+    assert in_readme.group(1) == in_docs.group(1), (
+        "the README and the docs citation page ship different BibTeX entries:\n"
+        f"README:\n{in_readme.group(1)}\ndocs:\n{in_docs.group(1)}"
+    )
+
+
+def test_seeded_reference_index_lists_the_citation_page(copie_session_default):
+    """The citation page is reachable, not merely present.
+
+    Driven through the real marker extension and the real mkdocs.yml nav rather than
+    the source markdown, because `<!-- SUBPAGES -->` renders nothing and warns nothing
+    when a project has replaced its index by hand. That is how `security.md` reached
+    four projects unlinked: the file was there, the page was built, and nothing linked
+    to it.
+    """
+    project_dir = copie_session_default.project_dir
+    citation_page = project_dir / "docs" / "pages" / "reference" / "citation.md"
+    assert citation_page.is_file(), "the template ships no docs citation page"
+
+    markers = _load_markers(project_dir, "reference_index_citation")
+    page = _FakePage("pages/reference/index.md", "pages/reference/index.html")
+    source = (project_dir / "docs" / "pages" / "reference" / "index.md").read_text(encoding="utf-8")
+
+    with caplog_at_warning() as records:
+        out = markers._inject(source, page)
+
+    assert "(citation.md)" in out, "the reference index does not link the citation page, so nothing reaches it"
+    assert not records, f"resolving the reference index warns, which fails --strict: {records}"

--- a/tests/test_template_options.py
+++ b/tests/test_template_options.py
@@ -3,6 +3,7 @@
 import subprocess
 
 import pytest
+import yaml
 from _build_layout import BUILD_DIR
 
 
@@ -113,6 +114,19 @@ def test_all_licenses(copie, license_type):
     # Verify pyproject.toml has correct license (uses table format)
     pyproject_content = (result.project_dir / "pyproject.toml").read_text(encoding="utf-8")
     assert f'license = {{ text = "{license_type}" }}' in pyproject_content
+
+    # CITATION.cff validates its `license` against the SPDX list, and "Proprietary" is
+    # not an SPDX identifier. The field is optional, so it is emitted only for the four
+    # answers that are identifiers; emitting it for the fifth would ship a file that
+    # fails schema validation in every tool that reads it.
+    citation = yaml.safe_load((result.project_dir / "CITATION.cff").read_text(encoding="utf-8"))
+    assert citation, f"CITATION.cff did not parse for {license_type}"
+    if license_type == "Proprietary":
+        assert "license" not in citation, (
+            "CITATION.cff carries a non-SPDX license identifier, which fails schema validation"
+        )
+    else:
+        assert citation["license"] == license_type, f"CITATION.cff states the wrong licence for {license_type}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Ships citation metadata to every generated project in the three places a reader looks: a `CITATION.cff` at the project root, a `## How do I cite ...?` section in the README, and `docs/pages/reference/citation.md` in the Reference nav. This repository ships all three and carries none of them itself.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

None of the seven generated packages says how to cite it. There is no `CITATION.cff` anywhere in the fleet, so GitHub renders no "Cite this repository" button, no README carries a citation section, and nothing appears in the published documentation. These are research-adjacent libraries whose users are the kind of people who cite software, and today each of them has to invent an entry by hand.

The fleet is uniform (one author, one licence, one organisation, one template commit), so this is something the template can render from answers it already collects rather than seven hand-written files that immediately drift.

Three decisions worth reviewing:

**Root placement is the requirement, not tidiness.** `repo-root-layout` sends machine-read metadata into `.github/` because both consumers resolve that path identically. GitHub reads `CITATION.cff` from the default branch's root only, so the same move would not relocate a consumer, it would remove the only one. This is the `LICENSE` case.

**No `version`, no `date-released`.** Both are optional, the citation button works without them, and both are wrong the day after the next release in seven repositories at once. Keeping them right means a step in `publish-release.yml`, to buy a version number PyPI already reports. The `doi:` line ships commented out; no repository has a deposit.

**Tier 2, not Tier 1.** `CITATION.cff` renders entirely from answers, which argues for Tier 1. Against that: the commented `doi:` exists precisely so a project can fill it in, and a Tier 1 overwrite would delete that DOI with no conflict, no `.rej` and no output, the same silent loss as the logos.

The README section sits between `## License` and `## Acknowledgements` deliberately. All seven projects have rewritten most of their README but all seven still carry the template's exact License paragraph followed by Acknowledgements, so the fan-out hunk has matching context on both sides everywhere. `test_readme_citation_section_sits_between_licence_and_acknowledgements` pins that.

Fixes #

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

`just test-fast`: 467 passed. `just fix`: clean.

Checks that were verified in both directions rather than assumed:

- `cffconvert --validate` passes on the rendered file for an SPDX licence answer and for `Proprietary` (which omits `license`, since it is not an SPDX identifier and CFF validates that field).
- Removing the `file:CITATION.cff` entry from `tests/parity_manifest.yml` makes `test_every_shipped_gate_is_answered` fail naming it. The entry is what encodes "every generated repo, not this one".
- Editing the BibTeX block in one of the two template files and not the other makes `test_readme_and_docs_cite_the_project_identically` fail.

Not verified: the generated project's docs build emits one HTML file locally, which is the known local Zensical no-op rather than anything this change causes. The render-level check that does run is `test_seeded_reference_index_lists_the_citation_page`, which drives the real marker extension against the real nav and asserts the citation page appears in the resolved Reference index.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Follow-up, not in this PR: this needs a release before the seven repositories can receive it, then a `copier update` fan-out. Per-repository verification should check the file on disk and `git check-ignore` rather than `git status`, and should grep the resolved Reference index rather than trusting `copier update`'s exit code.

`test_all_licenses` exists twice, in `tests/test_option_combinations.py` and `tests/test_template_options.py`, which are near-duplicate files. The new assertion was added to both rather than leaving one copy weaker; deduplicating them is separate work.
