### PR TITLE
fix(docs): pin the uv version Read the Docs installs, and correct the ignored-path claim

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,9 @@ build:
   # config outright; every item below is a plain, unquoted scalar for that reason.
   commands:
     - asdf plugin add uv || true
-    - asdf install uv latest
-    - asdf global uv latest
+    # renovate: datasource=github-releases depName=astral-sh/uv
+    - asdf install uv 0.10.0
+    - asdf global uv 0.10.0
     # Docs deps only; this repo's docs do not import the project.
     - uv sync --group docs --no-install-project
     # Zensical has no site-dir flag: the site directory comes from `site_dir` in

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -73,9 +73,18 @@ docs/stylesheets/theme.css
 .github/PULL_REQUEST_TEMPLATE.md
 SECURITY.md
 .claude/skills/**                   # Skill files managed by template (the tracked copy)
-.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
-                                    # update never delivers it -- copier works through
-                                    # git and skips ignored paths. Edit .claude/skills.
+.github/skills/**                   # Byte-identical Copilot mirror. Gitignored, so an
+                                    # update writes it to disk UNTRACKED: the change is
+                                    # delivered, and no one reviews it because it never
+                                    # reaches a diff. Measured on the v0.43.0 fan-out,
+                                    # where copier updated this very file in all seven
+                                    # repos while `git status` stayed silent.
+                                    #
+                                    # This entry used to say copier "skips ignored
+                                    # paths" and that an update "never delivers it".
+                                    # Both halves are wrong. Do not rely on either:
+                                    # if you need to know what landed here, look at
+                                    # the file on disk, not at git. Edit .claude/skills.
 ```
 
 ---

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -73,9 +73,18 @@ docs/stylesheets/theme.css
 .github/PULL_REQUEST_TEMPLATE.md
 SECURITY.md
 .claude/skills/**                   # Skill files managed by template (the tracked copy)
-.github/skills/**                   # Byte-identical Copilot mirror; gitignored, so an
-                                    # update never delivers it -- copier works through
-                                    # git and skips ignored paths. Edit .claude/skills.
+.github/skills/**                   # Byte-identical Copilot mirror. Gitignored, so an
+                                    # update writes it to disk UNTRACKED: the change is
+                                    # delivered, and no one reviews it because it never
+                                    # reaches a diff. Measured on the v0.43.0 fan-out,
+                                    # where copier updated this very file in all seven
+                                    # repos while `git status` stayed silent.
+                                    #
+                                    # This entry used to say copier "skips ignored
+                                    # paths" and that an update "never delivers it".
+                                    # Both halves are wrong. Do not rely on either:
+                                    # if you need to know what landed here, look at
+                                    # the file on disk, not at git. Edit .claude/skills.
 ```
 
 ---

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -23,8 +23,9 @@ build:
     # on sys.path (via the wheel's `dev-mode-dirs`) so the build loads the
     # `docs_build` markdown extensions by module name. `uv run` uses that venv.
     - asdf plugin add uv || true
-    - asdf install uv latest
-    - asdf global uv latest
+    # renovate: datasource=github-releases depName=astral-sh/uv
+    - asdf install uv 0.10.0
+    - asdf global uv 0.10.0
     - uv sync --group docs
     # Generate the API pages and export the notebooks -- the explicit step that
     # replaced the deleted on_pre_build hook.


### PR DESCRIPTION
## Description

Corrects a factual error in the `update-from-template` skill's file-classification reference, which ships to every generated project.

It said the gitignored `.github/skills/` mirror is never delivered, because "copier works through git and skips ignored paths". Measured on the v0.43.0 fan-out: copier updated `.github/skills/update-from-template/references/file-classification.md` in **all seven repos**. The content landed on disk everywhere and `git status` mentioned it in none of them, because the path is ignored.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

The real behaviour is worse than the documented one, which is why the wording matters. A file copier genuinely skips is a file you know you have to sync by hand. A file that is delivered but never appears in any diff is one nobody reviews and nobody knows changed, and the note told readers to expect the first.

Both `template/.claude/` and `template/.github/` copies updated and verified byte-identical.

Fixes #

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [ ] Verified generated project works as expected
- [ ] Added/updated tests
- [x] All tests pass

`just test-fast`: 467 passed. `just fix`: clean. The two mirror copies `diff` clean.

The claim itself was measured rather than reasoned: seven `copier update` runs, the file's content compared on disk before and after, and `git status` checked separately in each repo.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

No test added: this is a claim about copier's behaviour in a reference document, and the existing `test_claude_skills_generated` compares skill names rather than contents. Asserting "copier writes to an ignored path" in the suite would pin third-party behaviour the template does not control.

## Additional Notes

Found while fanning out v0.43.0. The seven fan-out PRs are open and unaffected by this.
