### PR TITLE
fix(docs): put the description in the citation title, and drop the abstract

### DIFF
--- a/template/CITATION.cff.jinja
+++ b/template/CITATION.cff.jinja
@@ -13,8 +13,12 @@
 # docs/pages/reference/citation.md. All three render from the same answers.
 cff-version: 1.2.0
 message: "If you use {{ project_name }} in your work, please cite it as below."
-title: "{{ project_name }}"
-abstract: "{{ description }}"
+# Name and description in one field, because that is what a citation renders. A
+# reference list shows the title and nothing else, so a bare package name tells a
+# reader who has not met the project what it was called and not what it is. There
+# is deliberately no separate `abstract`: it duplicated this text, and the field a
+# citation actually prints is this one.
+title: "{{ project_name }}: {{ description }}"
 type: software
 authors:
   # Recorded as a single `name`, which the format treats as an entity rather than a

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -149,14 +149,14 @@ This project is licensed under the terms of the [{{ license }} License](https://
 
 If you use {{ project_name }} in work you publish, please cite it:
 
-{{ author_name }}. {{ project_name }}. https://github.com/{{ github_username }}/{{ project_slug }}
+{{ author_name }}. {{ project_name }}: {{ description }}. https://github.com/{{ github_username }}/{{ project_slug }}
 
 Or in BibTeX:
 
 ```bibtex
 @software{{ '{' }}{{ package_name }},
   author  = "{{ author_name }}",
-  title   = "{{ '{' }}{{ project_name }}}",
+  title   = "{{ '{' }}{{ project_name }}: {{ description }}}",
   url     = "https://github.com/{{ github_username }}/{{ project_slug }}",
   license = "{{ license }}"
 }

--- a/template/docs/pages/reference/citation.md.jinja
+++ b/template/docs/pages/reference/citation.md.jinja
@@ -8,14 +8,14 @@ If you use {{ project_name }} in work you publish, please cite it.
 
 ## Plain text
 
-{{ author_name }}. {{ project_name }}. https://github.com/{{ github_username }}/{{ project_slug }}
+{{ author_name }}. {{ project_name }}: {{ description }}. https://github.com/{{ github_username }}/{{ project_slug }}
 
 ## BibTeX
 
 ```bibtex
 @software{{ '{' }}{{ package_name }},
   author  = "{{ author_name }}",
-  title   = "{{ '{' }}{{ project_name }}}",
+  title   = "{{ '{' }}{{ project_name }}: {{ description }}}",
   url     = "https://github.com/{{ github_username }}/{{ project_slug }}",
   license = "{{ license }}"
 }

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5370,7 +5370,7 @@ def test_citation_file_is_generated_at_the_root(copie_session_default):
     project_dir = copie_session_default.project_dir
     _, citation = _citation_file(project_dir)
 
-    for key in ("cff-version", "message", "title", "abstract", "type", "authors", "repository-code"):
+    for key in ("cff-version", "message", "title", "type", "authors", "repository-code"):
         assert key in citation, f"CITATION.cff is missing the required `{key}` field"
     assert citation["authors"], "CITATION.cff lists no authors; the format requires at least one"
 
@@ -5428,7 +5428,12 @@ def test_citation_fields_agree_with_package_metadata(copie_session_default):
     answers = yaml.safe_load((project_dir / ".copier-answers.yml").read_text(encoding="utf-8"))
     expected_repo = f"https://github.com/{answers['github_username']}/{answers['project_slug']}"
     assert citation["repository-code"] == expected_repo, "the citation points at the wrong repository"
-    assert citation["title"] == answers["project_name"], "the citation cites something other than this project"
+    # Name and description in one field: a reference list prints the title and nothing
+    # else, so the description has to live there or it is never seen. There is no
+    # separate `abstract` for the same reason.
+    expected_title = f"{answers['project_name']}: {answers['description']}"
+    assert citation["title"] == expected_title, "the citation title is not `<name>: <description>`"
+    assert "abstract" not in citation, "CITATION.cff carries an abstract duplicating the title"
 
 
 def test_readme_citation_section_sits_between_licence_and_acknowledgements(copie_session_default):


### PR DESCRIPTION
## Description

Changes the citation title from the bare project name to `<name>: <description>`, and removes the now-redundant `abstract` field.

Before:

```bibtex
title   = "{Sklearn-Optuna}",
```

After:

```bibtex
title   = "{Sklearn-Optuna: An Optuna integration for hyperparameter tuning in Scikit-Learn}",
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

A reference list prints the title and nothing else. A bare package name tells a reader who has not met the project what it was called, not what it is, which makes the citation less informative than the line it appears on.

The `abstract` held exactly the description text, in a field no citation renders. With the description in the title it is a second home for the same fact, so it is gone rather than left to drift.

Applied to all three surfaces the equality test keeps in step: the `CITATION.cff` title, the BibTeX title in the README and on the docs page, and the plain-text citation on both.

Fixes #

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest`
- [x] Tested template generation with `copier copy . /tmp/test-project`
- [x] Verified generated project works as expected
- [x] Added/updated tests
- [x] All tests pass

`just test-fast`: 467 passed. `just fix`: clean.

Rendered with a real project's answers (sklearn-optuna's) rather than the test fixture's, and the result validated with `cffconvert --validate` against schema 1.2.0. The assertion now checks the composed title and that no `abstract` key is present.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

This supersedes the format shipped in v0.43.0. The seven fan-out PRs for v0.43.0 are still open and unmerged, so they will be updated to this format rather than landing the old one and correcting it afterwards.
