### PR TITLE
feat(ci): drain the automerge queue one pull request at a time

### DIFF
--- a/.github/workflows/drain-automerge-queue.yml
+++ b/.github/workflows/drain-automerge-queue.yml
@@ -1,0 +1,99 @@
+name: Drain Automerge Queue
+
+# A branch protection rule that requires branches to be up to date deadlocks
+# unattended dependency updates. GitHub's auto-merge refuses to merge a PR whose
+# branch is behind its base, and it does NOT update the branch itself. Renovate does
+# rebase stale branches, but only when it next runs, and the moment one PR merges every
+# other open branch is behind again. The result is roughly one merge per run: the queue
+# never drains, while every PR in it looks approved, green and ready.
+#
+# This workflow closes that gap. On every push to the default branch it advances exactly
+# ONE pull request: the oldest automerge-labelled bot PR that is behind. Updating the
+# branch reruns its checks, auto-merge then lands it, and that merge pushes the default
+# branch again, which runs this workflow for the next one. The queue drains itself, one
+# CI run per merge, with no schedule and nothing to maintain.
+#
+# It does nothing at all when no PR is waiting, and it stops on its own once the queue is
+# empty, so there is no loop to break.
+
+on:
+  push:
+    branches: [main]
+
+# Least-privilege default. This job needs no GITHUB_TOKEN scopes at all, because every
+# API call is made with the App token minted below.
+permissions: {}
+
+# One at a time. Several merges landing together would otherwise each pick a PR, and a
+# burst of branch updates is the CI storm this design exists to avoid.
+concurrency:
+  group: drain-automerge-queue
+  cancel-in-progress: false
+
+jobs:
+  advance-one:
+    name: Advance the automerge queue
+    runs-on: ubuntu-latest
+    steps:
+      # The App token is not decoration. A branch updated with the default GITHUB_TOKEN
+      # does NOT trigger a new workflow run: GitHub suppresses that to prevent recursion.
+      # The updated head commit would therefore carry none of the required checks, they
+      # would sit "Expected -- waiting for status to be reported" forever, and auto-merge
+      # would never fire. The PR would look freshly updated and be more stuck than before.
+      # An App token is a different identity, so its push does trigger the checks.
+      - name: Generate a token from the fleet automation GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2.2.2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Update the oldest automerge PR that is behind
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Oldest first, so the queue is FIFO and a PR cannot be starved by newer ones.
+          # The same three conditions as renovate-automerge.yml, for the same reasons:
+          # a Bot author, a `renovate/` branch, and the `automerge` label that the
+          # Renovate config applies only to rules it also marks `automerge: true`.
+          candidates=$(gh api \
+            "repos/$REPO/pulls?state=open&sort=created&direction=asc&per_page=100" \
+            --jq '.[]
+                  | select(.user.type == "Bot")
+                  | select(.head.ref | startswith("renovate/"))
+                  | select([.labels[].name] | index("automerge"))
+                  | .number')
+
+          if [ -z "$candidates" ]; then
+            echo "No automerge-labelled bot pull requests are open. Nothing to do."
+            exit 0
+          fi
+
+          for number in $candidates; do
+            # `mergeable_state` is computed lazily: the first read can legitimately
+            # return "unknown" and resolve on a retry. Treating that as "not behind"
+            # would skip a PR that is in fact waiting, so ask again before giving up.
+            state=""
+            for _ in 1 2 3; do
+              state=$(gh api "repos/$REPO/pulls/$number" --jq '.mergeable_state')
+              [ "$state" != "unknown" ] && break
+              sleep 5
+            done
+
+            echo "PR #${number}: mergeable_state=${state}"
+
+            if [ "$state" = "behind" ]; then
+              echo "Updating #${number} so its checks rerun against the current base."
+              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
+              echo "Done. Auto-merge lands it once the required checks pass, and that"
+              echo "merge triggers this workflow again for the next one."
+              exit 0
+            fi
+          done
+
+          # Everything else is already current, or blocked on its own checks, or has a
+          # real conflict. None of those is something a branch update can fix.
+          echo "No automerge pull request is behind its base. Nothing to advance."

--- a/template/.claude/skills/update-from-template/references/file-classification.md
+++ b/template/.claude/skills/update-from-template/references/file-classification.md
@@ -119,6 +119,12 @@ CITATION.cff                       # renders entirely from copier answers, which
                                    # `automerge` label, or the workflow starts approving
                                    # updates nothing chose to automate. A project may add
                                    # its own steps, so merge rather than overwrite.
+.github/workflows/drain-automerge-queue.yml  # conditional: include_actions. Advances one
+                                   # automerge PR per push to the default branch. The
+                                   # App-token step is load-bearing, not boilerplate: a
+                                   # branch updated with GITHUB_TOKEN triggers no checks,
+                                   # so the PR would stall with its required checks never
+                                   # reported. Do not "simplify" it to GITHUB_TOKEN.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/template/.github/skills/update-from-template/references/file-classification.md
+++ b/template/.github/skills/update-from-template/references/file-classification.md
@@ -119,6 +119,12 @@ CITATION.cff                       # renders entirely from copier answers, which
                                    # `automerge` label, or the workflow starts approving
                                    # updates nothing chose to automate. A project may add
                                    # its own steps, so merge rather than overwrite.
+.github/workflows/drain-automerge-queue.yml  # conditional: include_actions. Advances one
+                                   # automerge PR per push to the default branch. The
+                                   # App-token step is load-bearing, not boilerplate: a
+                                   # branch updated with GITHUB_TOKEN triggers no checks,
+                                   # so the PR would stall with its required checks never
+                                   # reported. Do not "simplify" it to GITHUB_TOKEN.
 .github/workflows/publish-release.yml  # conditional: include_actions
 .github/workflows/nightly.yml      # conditional: include_actions
 .github/workflows/changelog.yml    # conditional: include_actions

--- a/template/.github/{% if include_actions %}workflows{% endif %}/drain-automerge-queue.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/drain-automerge-queue.yml.jinja
@@ -1,0 +1,99 @@
+name: Drain Automerge Queue
+
+# A branch protection rule that requires branches to be up to date deadlocks
+# unattended dependency updates. GitHub's auto-merge refuses to merge a PR whose
+# branch is behind its base, and it does NOT update the branch itself. Renovate does
+# rebase stale branches, but only when it next runs, and the moment one PR merges every
+# other open branch is behind again. The result is roughly one merge per run: the queue
+# never drains, while every PR in it looks approved, green and ready.
+#
+# This workflow closes that gap. On every push to the default branch it advances exactly
+# ONE pull request: the oldest automerge-labelled bot PR that is behind. Updating the
+# branch reruns its checks, auto-merge then lands it, and that merge pushes the default
+# branch again, which runs this workflow for the next one. The queue drains itself, one
+# CI run per merge, with no schedule and nothing to maintain.
+#
+# It does nothing at all when no PR is waiting, and it stops on its own once the queue is
+# empty, so there is no loop to break.
+
+on:
+  push:
+    branches: [main]
+
+# Least-privilege default. This job needs no GITHUB_TOKEN scopes at all, because every
+# API call is made with the App token minted below.
+permissions: {}
+
+# One at a time. Several merges landing together would otherwise each pick a PR, and a
+# burst of branch updates is the CI storm this design exists to avoid.
+concurrency:
+  group: drain-automerge-queue
+  cancel-in-progress: false
+
+jobs:
+  advance-one:
+    name: Advance the automerge queue
+    runs-on: ubuntu-latest
+    steps:
+      # The App token is not decoration. A branch updated with the default GITHUB_TOKEN
+      # does NOT trigger a new workflow run: GitHub suppresses that to prevent recursion.
+      # The updated head commit would therefore carry none of the required checks, they
+      # would sit "Expected -- waiting for status to be reported" forever, and auto-merge
+      # would never fire. The PR would look freshly updated and be more stuck than before.
+      # An App token is a different identity, so its push does trigger the checks.
+      - name: Generate a token from the fleet automation GitHub App
+        id: app-token
+        uses: actions/create-github-app-token@v2.2.2
+        with:
+          app-id: {% raw %}${{ secrets.APP_ID }}{% endraw %}
+          private-key: {% raw %}${{ secrets.APP_PRIVATE_KEY }}{% endraw %}
+
+      - name: Update the oldest automerge PR that is behind
+        env:
+          GH_TOKEN: {% raw %}${{ steps.app-token.outputs.token }}{% endraw %}
+          REPO: {% raw %}${{ github.repository }}{% endraw %}
+        run: |
+          set -euo pipefail
+
+          # Oldest first, so the queue is FIFO and a PR cannot be starved by newer ones.
+          # The same three conditions as renovate-automerge.yml, for the same reasons:
+          # a Bot author, a `renovate/` branch, and the `automerge` label that the
+          # Renovate config applies only to rules it also marks `automerge: true`.
+          candidates=$(gh api \
+            "repos/$REPO/pulls?state=open&sort=created&direction=asc&per_page=100" \
+            --jq '.[]
+                  | select(.user.type == "Bot")
+                  | select(.head.ref | startswith("renovate/"))
+                  | select([.labels[].name] | index("automerge"))
+                  | .number')
+
+          if [ -z "$candidates" ]; then
+            echo "No automerge-labelled bot pull requests are open. Nothing to do."
+            exit 0
+          fi
+
+          for number in $candidates; do
+            # `mergeable_state` is computed lazily: the first read can legitimately
+            # return "unknown" and resolve on a retry. Treating that as "not behind"
+            # would skip a PR that is in fact waiting, so ask again before giving up.
+            state=""
+            for _ in 1 2 3; do
+              state=$(gh api "repos/$REPO/pulls/$number" --jq '.mergeable_state')
+              [ "$state" != "unknown" ] && break
+              sleep 5
+            done
+
+            echo "PR #${number}: mergeable_state=${state}"
+
+            if [ "$state" = "behind" ]; then
+              echo "Updating #${number} so its checks rerun against the current base."
+              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
+              echo "Done. Auto-merge lands it once the required checks pass, and that"
+              echo "merge triggers this workflow again for the next one."
+              exit 0
+            fi
+          done
+
+          # Everything else is already current, or blocked on its own checks, or has a
+          # real conflict. None of those is something a branch update can fix.
+          echo "No automerge pull request is behind its base. Nothing to advance."

--- a/tests/parity_manifest.yml
+++ b/tests/parity_manifest.yml
@@ -126,6 +126,15 @@ file_gates:
       rate-limited backlog of the eight (18 items against a drain rate of two pull
       requests per week), because it is the only one whose template/ tree Renovate also
       scans.
+  drain-automerge-queue.yml:advance-one:
+    equivalent: drain-automerge-queue.yml:advance-one
+    status: matched
+    reason: >-
+      Same queue-advancing job, and this repo is subject to the same org ruleset that
+      makes it necessary: `strict_required_status_checks_policy` means auto-merge will
+      not land a branch that is behind, and GitHub does not update the branch itself.
+      Measured on the first live automerge run: 24 of 24 approved, auto-merge-enabled
+      pull requests across the fleet sat in `behind` state, none in `clean`.
 
   # --- CI: scheduled and security -----------------------------------------
   nightly.yml:test:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -947,6 +947,70 @@ def test_renovate_automerge_workflow_does_not_hardcode_a_bot_login(copie_session
     )
 
 
+def test_drain_workflow_does_not_update_branches_with_github_token(copie_session_default):
+    """The queue drainer mints an App token, and never falls back to `GITHUB_TOKEN`.
+
+    This is the whole reason the workflow has a token step at all, and it looks exactly
+    like boilerplate worth deleting. A branch updated using the default `GITHUB_TOKEN`
+    does **not** trigger a new workflow run: GitHub suppresses that to prevent recursion.
+    The updated head commit would then carry none of the required checks, they would sit
+    "Expected -- waiting for status to be reported" forever, and auto-merge would never
+    fire. The pull request would look freshly updated and be more stuck than before, with
+    nothing failing anywhere to say so.
+
+    So a "simplification" to `secrets.GITHUB_TOKEN` produces a workflow that runs, reports
+    success, updates the branch, and deadlocks the queue it exists to drain.
+    """
+    workflow = copie_session_default.project_dir / ".github" / "workflows" / "drain-automerge-queue.yml"
+    assert workflow.is_file(), "drain-automerge-queue.yml not generated"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "create-github-app-token" in text, (
+        "the drain workflow does not mint an App token; a GITHUB_TOKEN branch update "
+        "triggers no checks and deadlocks the pull request it just updated"
+    )
+    assert "secrets.GITHUB_TOKEN" not in text, (
+        "the drain workflow uses GITHUB_TOKEN somewhere; a branch updated with it reports "
+        "no checks, so auto-merge can never fire"
+    )
+    assert "steps.app-token.outputs.token" in text, (
+        "the App token is minted but not used; the API calls must run as the App"
+    )
+
+
+def test_drain_workflow_advances_exactly_one_pull_request(copie_session_default):
+    """The drainer updates one PR per push, not every PR that is behind.
+
+    Updating them all is the obvious implementation and it wastes most of the work: only
+    one can merge, and that merge puts every other branch behind again, so the remaining
+    CI runs are thrown away. One per push is what makes the queue self-draining at a cost
+    of one CI run per merge, because each merge pushes the default branch and starts the
+    next round.
+    """
+    import yaml
+
+    workflow = copie_session_default.project_dir / ".github" / "workflows" / "drain-automerge-queue.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    body = yaml.safe_load(text)
+    triggers = body.get("on", body.get(True))
+    assert "push" in triggers, "the drainer must run on push to the default branch"
+    assert "concurrency" in body, (
+        "without a concurrency group, simultaneous merges each pick a pull request and "
+        "produce the burst of branch updates this design exists to avoid"
+    )
+
+    run = body["jobs"]["advance-one"]["steps"][-1]["run"]
+    assert "exit 0" in run, "the loop must stop after advancing one pull request"
+    # The guard must be the same three conditions the approve workflow uses, or the
+    # drainer would advance pull requests nothing has authorised for automerge.
+    assert '"automerge"' in run or "'automerge'" in run, (
+        "the drainer does not filter on the automerge label, so it would advance updates "
+        "that were deliberately left for manual review"
+    )
+    assert "renovate/" in run, "the drainer does not filter on the renovate/ branch prefix"
+
+
 def test_workflows_pin_uv_nox_and_git_cliff(copie_session_default):
     """uv, nox and git-cliff are pinned to exact versions, not floating "latest".
 


### PR DESCRIPTION
## Description

The automerge chain shipped in v0.42.0 works: on the first live run, **24 of 24** labelled bot PRs across the eight repos were approved by `renovate-automerge.yml` and had auto-merge enabled.

**None of them merged.** All 24 sat in `mergeable_state: behind`, and zero were `clean`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

The org ruleset sets `strict_required_status_checks_policy: true`. Two facts combine badly:

1. GitHub's auto-merge **refuses to merge a branch that is behind its base**.
2. GitHub auto-merge **does not update the branch itself**.

Renovate does rebase stale branches via `rebaseWhen: behind-base-branch`, but only when it next runs — daily here. And the instant one PR merges, every other open branch in that repo is behind again. Net throughput is roughly one merge per repo per run, which is barely better than the two-per-week the whole initiative set out to fix. Every PR in the queue meanwhile looks approved, green and ready.

I flagged this as a risk when the initiative started and understated it: I said the backlog would "drain serially over several days". With a once-daily rebase it does not meaningfully drain at all.

## How it works

On every push to `main`, advance exactly **one** pull request: the oldest automerge-labelled bot PR that is `behind`. Updating its branch reruns its checks, auto-merge lands it, and that merge pushes `main` again, which starts the next round.

```
push main -> update oldest behind PR -> checks rerun -> auto-merge fires
          -> merge pushes main -> workflow runs again -> next PR
```

Self-draining, **one CI run per merge**, no schedule, and it exits doing nothing when the queue is empty. Updating every behind PR instead is the obvious implementation and wastes most of the work: only one can win, and that merge puts the rest behind again.

It reuses the same three guards as `renovate-automerge.yml` — Bot author, `renovate/` branch, `automerge` label — so it can never advance an update that was deliberately left for manual review.

## The App token is load-bearing, not boilerplate

This is the part most likely to be "simplified" later, so it has a test.

A branch updated with the default `GITHUB_TOKEN` **does not trigger a new workflow run** — GitHub suppresses that to prevent recursion. The updated head commit would then carry none of the required checks, they would sit "Expected — waiting for status to be reported" indefinitely, and auto-merge could never fire. The PR would look freshly updated and be *more* stuck than before, with nothing failing anywhere to say so.

`test_drain_workflow_does_not_update_branches_with_github_token` rejects exactly that substitution. It reuses the org-level `APP_ID` / `APP_PRIVATE_KEY` that `changelog.yml` already uses in every generated repo, so there is no new secret.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **469 passed**
- [x] Added/updated tests
- [x] All tests pass

Both new tests were falsified on a scratch copy: swapping the App token for `secrets.GITHUB_TOKEN` fails with the intended message, and it passes again when restored. The parity manifest entry is non-vacuous — removing it fails `test_every_shipped_gate_is_answered` naming the new gate.

The workflow's `run:` block was checked with `bash -n` after placeholdering the `${{ }}` expressions, and the rendered YAML parses.

**Not verified, and cannot be from a PR:** this workflow triggers on `push` to `main`, so nothing on this PR exercises it. Its first real execution will be its own merge. That is also its cheapest possible test, since a failure there advances nothing rather than breaking anything.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Held for review. Needs a release and fan-out to reach the seven generated repos.

I have already drained the current backlog by hand, one PR per repo per round, to confirm the mechanism end to end before automating it: kedro-dagster#170 merged on the first round exactly as designed.

Related: stateful-y/renovate-config#5 fixes a separate leak found in the same run, where a bump touching both `.github/workflows/**` and `template/**` landed in one PR and got labelled for automerge despite `template/**` being deliberately excluded.