### PR TITLE
fix(ci): let the drain workflow survive a missing workflows permission

### DIFF
--- a/.github/workflows/drain-automerge-queue.yml
+++ b/.github/workflows/drain-automerge-queue.yml
@@ -87,10 +87,40 @@ jobs:
 
             if [ "$state" = "behind" ]; then
               echo "Updating #${number} so its checks rerun against the current base."
-              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
-              echo "Done. Auto-merge lands it once the required checks pass, and that"
-              echo "merge triggers this workflow again for the next one."
-              exit 0
+
+              # Capture rather than let `set -e` kill the run: one specific failure here
+              # is a configuration gap, not a fault, and it must not paint the default
+              # branch red on every push until someone fixes it.
+              if response=$(gh api -X PUT "repos/$REPO/pulls/${number}/update-branch" 2>&1); then
+                echo "$response"
+                echo "Done. Auto-merge lands it once the required checks pass, and that"
+                echo "merge triggers this workflow again for the next one."
+                exit 0
+              fi
+
+              # The App needs `workflows: write` to push a branch whose diff touches
+              # `.github/workflows/*`. Most dependency updates in this fleet do exactly
+              # that -- action pins and tool versions live in the workflows -- so without
+              # that permission the drain works on the minority of PRs and refuses the
+              # rest. Nothing here can grant it: App permissions are changed by the App
+              # owner and then accepted on the installation.
+              if printf '%s' "$response" | grep -q 'without .workflows. permission'; then
+                echo "::warning title=Automerge queue is stalled::The GitHub App used by this workflow lacks the 'Workflows' write permission, so it cannot update #${number} (its diff touches .github/workflows/*). Grant that permission to the App and accept it on the installation. Until then the automerge queue will not drain."
+                {
+                  echo "### Automerge queue stalled"
+                  echo
+                  echo "Could not update **#${number}**: the GitHub App lacks **Workflows: write**."
+                  echo
+                  echo "Most dependency updates here touch \`.github/workflows/*\`, so the queue"
+                  echo "will not drain until that permission is granted to the App and accepted"
+                  echo "on the installation. No other action is needed in this repository."
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+
+              # Anything else is a real failure and should be loud.
+              echo "::error::Failed to update #${number}: ${response}"
+              exit 1
             fi
           done
 

--- a/template/.github/{% if include_actions %}workflows{% endif %}/drain-automerge-queue.yml.jinja
+++ b/template/.github/{% if include_actions %}workflows{% endif %}/drain-automerge-queue.yml.jinja
@@ -87,10 +87,40 @@ jobs:
 
             if [ "$state" = "behind" ]; then
               echo "Updating #${number} so its checks rerun against the current base."
-              gh api -X PUT "repos/$REPO/pulls/${number}/update-branch"
-              echo "Done. Auto-merge lands it once the required checks pass, and that"
-              echo "merge triggers this workflow again for the next one."
-              exit 0
+
+              # Capture rather than let `set -e` kill the run: one specific failure here
+              # is a configuration gap, not a fault, and it must not paint the default
+              # branch red on every push until someone fixes it.
+              if response=$(gh api -X PUT "repos/$REPO/pulls/${number}/update-branch" 2>&1); then
+                echo "$response"
+                echo "Done. Auto-merge lands it once the required checks pass, and that"
+                echo "merge triggers this workflow again for the next one."
+                exit 0
+              fi
+
+              # The App needs `workflows: write` to push a branch whose diff touches
+              # `.github/workflows/*`. Most dependency updates in this fleet do exactly
+              # that -- action pins and tool versions live in the workflows -- so without
+              # that permission the drain works on the minority of PRs and refuses the
+              # rest. Nothing here can grant it: App permissions are changed by the App
+              # owner and then accepted on the installation.
+              if printf '%s' "$response" | grep -q 'without .workflows. permission'; then
+                echo "::warning title=Automerge queue is stalled::The GitHub App used by this workflow lacks the 'Workflows' write permission, so it cannot update #${number} (its diff touches .github/workflows/*). Grant that permission to the App and accept it on the installation. Until then the automerge queue will not drain."
+                {
+                  echo "### Automerge queue stalled"
+                  echo
+                  echo "Could not update **#${number}**: the GitHub App lacks **Workflows: write**."
+                  echo
+                  echo "Most dependency updates here touch \`.github/workflows/*\`, so the queue"
+                  echo "will not drain until that permission is granted to the App and accepted"
+                  echo "on the installation. No other action is needed in this repository."
+                } >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+
+              # Anything else is a real failure and should be loud.
+              echo "::error::Failed to update #${number}: ${response}"
+              exit 1
             fi
           done
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -978,6 +978,41 @@ def test_drain_workflow_does_not_update_branches_with_github_token(copie_session
     )
 
 
+def test_drain_workflow_survives_a_missing_workflows_permission(copie_session_default):
+    """A missing `workflows: write` warns and exits 0; anything else still fails loudly.
+
+    Found in production, not in review. The App that updates the branch needs
+    `workflows: write` to push a diff touching `.github/workflows/*`, and in this fleet
+    that is most dependency updates -- action pins and tool versions live in the
+    workflows. Without it every such update returns:
+
+        refusing to allow a GitHub App to create or update workflow
+        `.github/workflows/nightly.yml` without `workflows` permission (HTTP 403)
+
+    That is a configuration gap, not a fault, and it recurs on *every* push until someone
+    grants the permission. Failing the run would paint the default branch red
+    indefinitely, and a permanently red main is worse than an amber one: it trains people
+    to ignore the colour, which is how a real failure gets missed.
+
+    So this one case warns and exits 0. Every other failure still exits 1, because the
+    alternative -- swallowing all errors -- is the silent green this fleet keeps getting
+    caught by. The distinction is the point of the test: verify BOTH branches exist, not
+    just that the workflow tolerates something.
+    """
+    workflow = copie_session_default.project_dir / ".github" / "workflows" / "drain-automerge-queue.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert "without .workflows. permission" in text, (
+        "the drain workflow does not detect the missing-workflows-permission 403, so it "
+        "will fail the run on every push until the permission is granted"
+    )
+    assert "::warning" in text, "the permission gap must surface as a warning annotation"
+    assert "::error" in text, (
+        "no ::error branch left: swallowing every failure turns this into a job that "
+        "reports success while advancing nothing"
+    )
+
+
 def test_drain_workflow_advances_exactly_one_pull_request(copie_session_default):
     """The drainer updates one PR per push, not every PR that is behind.
 


### PR DESCRIPTION
## Description

The drain workflow shipped in v0.44.0 failed on its **second** run in production. Its first run happened to pick a PR that did not touch workflow files and succeeded; the second picked one that did.

```
refusing to allow a GitHub App to create or update workflow
`.github/workflows/nightly.yml` without `workflows` permission (HTTP 403)
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation and Context

The App that updates the branch needs `workflows: write` to push a diff touching `.github/workflows/*`. In this fleet that is **most** dependency updates, because action pins and tool versions live in the workflows. Measured on the org's installations:

| App | permissions |
|---|---|
| `stateful-y-renovate` | contents:write, issues:write, pull_requests:write, vulnerability_alerts:read, **workflows:write** |
| `stateful-y-automation` | contents:write, metadata:read, pull_requests:write — **no workflows:write** |

The drain uses `stateful-y-automation` (the `APP_ID`/`APP_PRIVATE_KEY` that `changelog.yml` already uses). **Granting that permission is the actual fix and cannot be done from a PR** — App permissions are changed by the App owner and then accepted on the installation.

This is a case the tests structurally could not catch: the workflow only runs on `push` to `main`, so nothing on its own PR exercised it.

## What this changes

Until the permission is granted the 403 recurs on **every push**. Failing the run would paint `main` red indefinitely in all eight repos, and a permanently red default branch is worse than an amber one — it trains people to ignore the colour, which is how a real failure gets missed.

So the behaviour now splits three ways:

| outcome | result |
|---|---|
| update succeeds | exit 0, queue advances |
| 403, missing `workflows` permission | `::warning` annotation + job-summary block naming the remedy, **exit 0** |
| anything else | `::error`, **exit 1** |

Swallowing *every* failure would turn this into a job that reports success while advancing nothing — the silent green this fleet keeps getting caught by. `test_drain_workflow_survives_a_missing_workflows_permission` therefore asserts **both** branches exist and fails if the `::error` path is removed.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **470 passed**
- [x] Added/updated tests
- [x] All tests pass

**The detection was falsified against the exact 403 text GitHub produced**, not against a string I invented:

```
MATCHES the real 403 text
correctly ignores unrelated errors (404)
correctly ignores 422 merge conflict
```

The new test was falsified on a scratch copy by stripping the `::error` branch, which fails with the intended message and passes again when restored. The rendered YAML parses and the `run:` block passes `bash -n` with the `${{ }}` expressions placeholdered.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Held for review.

**Sequencing.** The v0.44.0 fan-out is in flight, so the seven generated repos do not have the drain workflow yet. If the App permission is granted before those PRs merge, this change is belt-and-braces and can ride along with any later release. If it is not, this wants to be in the fleet before v0.44.0's fan-out lands, or seven repos get a red `main` on their next push.