### PR TITLE
fix(docs): pin the uv version Read the Docs installs, and stop prescribing --conflict rej

### DIFF
--- a/template/.claude/skills/update-from-template/SKILL.md
+++ b/template/.claude/skills/update-from-template/SKILL.md
@@ -92,7 +92,7 @@ git checkout -b template-update/$VERSION
 ### Step 4: Run copier update
 
 ```bash
-copier update --trust --conflict rej --skip-answered
+copier update --trust --skip-answered
 ```
 
 If the template has new variables (added since `_commit`), copier will prompt for them. Provide answers by:

--- a/template/.claude/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.claude/skills/update-from-template/references/conflict-resolution.md
@@ -1,10 +1,10 @@
 # Conflict Resolution Patterns
 
-How to resolve conflicts produced by `copier update --conflict rej` for each file tier and type.
+How to resolve conflicts from `copier update` for each file tier and type.
 
 ## Table of Contents
 
-- [Why --conflict rej](#why---conflict-rej)
+- [Use the default inline merge](#use-the-default-inline-merge-not---conflict-rej)
 - [Resolution by Tier](#resolution-by-tier)
 - [.rej File Format](#rej-file-format)
 - [TOML Merge (pyproject.toml)](#toml-merge-pyprojecttoml)
@@ -16,56 +16,83 @@ How to resolve conflicts produced by `copier update --conflict rej` for each fil
 
 ---
 
-## Why --conflict rej
+## Use the default inline merge, NOT --conflict rej
 
-`copier update` supports two conflict modes:
+**Do not pass `--conflict rej`. Use copier's default, which is a three-way inline merge.**
 
-| Mode | Behavior | AI suitability |
-|------|----------|----------------|
-| `--conflict inline` | Inserts `<<<<<<<`/`=======`/`>>>>>>>` markers into files | Harder to parse — markers interleave with file content |
-| `--conflict rej` | Applies the hunks that apply, writes the rest to `<file>.rej` | Easier to parse — the `.rej` is a plain diff, not markers interleaved with content |
+This file used to prescribe `--conflict rej` on the grounds that a `.rej` is easier for an
+assistant to parse than markers interleaved with content. That reasoning is about *reading*
+the outcome and ignores what the two modes do to the file. They are not two presentations of
+the same result. Measured on one repository, one release, the same commit, only the flag
+differing:
 
-Use `--conflict rej`. This produces:
-- The **local file** with every hunk that applied cleanly already written to it — *not* the
-  untouched original. `git apply --reject` is all-or-nothing per hunk, not per file.
-- A **`.rej` file** containing only the hunks that could not be applied.
+| | `--conflict rej` | default (inline) |
+|---|---|---|
+| `.rej` files | 5 | **0** |
+| digest-pinned `uses:` lines | 49 → **26** | 49 → **49** |
+| local `exclude:` block in `tests.yml` | **destroyed** | intact |
+| tracked files changed | 7 | **2** |
 
-That distinction is load-bearing. For a Tier 3 file, deleting the `.rej` does not restore
-the project's version: the hunks that applied are still there. Use
-`git checkout HEAD -- <file>` to undo them. Check with `git diff HEAD -- <file>` whenever a
-`.rej` exists — a non-empty diff means the file was partially updated.
+`--conflict rej` applies hunks with `git apply --reject`, which is all-or-nothing **per hunk**
+and has no knowledge of the merge base. A hunk carrying the template's change plus context
+lines the project has legitimately edited fails as a unit, and what lands is the template's
+version of everything that did apply. The inline mode performs a real three-way merge, so
+where base, local and template agree it simply keeps the agreement, and it only marks genuine
+divergence.
+
+The damage is not limited to things you would think to recount. In one repository the reject
+mode also replaced a live `Compat tests` pin set with the template's **disabled** placeholder,
+and dropped `lfs: true` from a checkout step. A digest recount would have reported those files
+clean.
+
+If an inline conflict does appear, it is a real one. Resolve it in place: the markers sit
+exactly where the two sides genuinely disagree, which is far less than `--conflict rej`
+rejects.
+
+### If you inherit a --conflict rej run
+
+The **local file** already contains every hunk that applied — *not* the untouched original.
+So deleting the `.rej` does not restore the project's version. Use
+`git checkout HEAD -- <file>` to undo them, and check with `git diff HEAD -- <file>` whenever
+a `.rej` exists: a non-empty diff means the file was partially updated. Better still, discard
+the whole run and redo it without the flag.
 
 ---
 
 ## Resolution by Tier
 
+With the default inline merge a conflict appears as `<<<<<<<` / `=======` / `>>>>>>>` markers
+**in the file**, at exactly the lines where the two sides genuinely disagree. There is no
+`.rej` to read. The tier rules below decide which side of each marker block to keep. Where
+this section says "the template's side", read the block between `=======` and `>>>>>>>`.
+
+Sweep for markers with `^(<<<<<<<|>>>>>>>|=======)( |$)` before committing. The anchored form
+without that trailing group misses `<<<<<<< HEAD` and `>>>>>>> theirs`.
+
 ### Tier 1 — Template-managed (template wins)
 
-1. Read the `.rej` file to understand what the template wanted
-2. Apply those changes to the local file (the template version is correct)
-3. Delete the `.rej` file
+1. Keep the template's side of every marker block.
+2. If the file updated with no conflict, it is already correct — no action.
 
-If copier updated the file without conflict (no `.rej`), the update is already correct — no action needed.
+Verify by diffing against a fresh `copier copy` at the same ref: a Tier 1 file should end
+byte-identical to the pristine render.
 
 ### Tier 2 — Merge-required (intelligent merge)
 
-1. Read the **local file** (current project state with customizations)
-2. Read the **`.rej` file** (what the template wanted to change)
-3. Understand the intent of BOTH:
+1. Read both sides of each marker block, and understand the intent of each:
     - Template change: bug fix? dependency bump? structural improvement? new feature?
     - Local state: custom content? extended functionality? project-specific additions?
-4. Apply template changes while preserving local additions (see file-type patterns below)
-5. Delete the `.rej` file
+2. Apply the template's change while preserving the local addition (see file-type patterns
+   below). Both sides usually want to survive; that is what makes it Tier 2.
 
-If copier updated a Tier 2 file without conflict (no `.rej`) BUT the file was classified as customized in Step 2:
-- The update may have **overwritten local customizations**
-- Compare the updated file against the baseline diff from Step 2
-- Restore any lost local additions
+If a Tier 2 file updated with **no** conflict but you classified it as customized, do not
+assume it was left alone. Take a whole-file pre/post diff and confirm the only changes are the
+template's intended ones.
 
 ### Tier 3 — Local-owned (local wins)
 
-1. If a `.rej` file exists: delete it (ignore template changes)
-2. If copier modified the file without conflict: restore from git with `git checkout HEAD -- <file>`
+1. Keep the local side of every marker block.
+2. If copier modified the file with no conflict, restore it: `git checkout HEAD -- <file>`.
 
 ---
 

--- a/template/.github/skills/update-from-template/SKILL.md
+++ b/template/.github/skills/update-from-template/SKILL.md
@@ -92,7 +92,7 @@ git checkout -b template-update/$VERSION
 ### Step 4: Run copier update
 
 ```bash
-copier update --trust --conflict rej --skip-answered
+copier update --trust --skip-answered
 ```
 
 If the template has new variables (added since `_commit`), copier will prompt for them. Provide answers by:

--- a/template/.github/skills/update-from-template/references/conflict-resolution.md
+++ b/template/.github/skills/update-from-template/references/conflict-resolution.md
@@ -1,10 +1,10 @@
 # Conflict Resolution Patterns
 
-How to resolve conflicts produced by `copier update --conflict rej` for each file tier and type.
+How to resolve conflicts from `copier update` for each file tier and type.
 
 ## Table of Contents
 
-- [Why --conflict rej](#why---conflict-rej)
+- [Use the default inline merge](#use-the-default-inline-merge-not---conflict-rej)
 - [Resolution by Tier](#resolution-by-tier)
 - [.rej File Format](#rej-file-format)
 - [TOML Merge (pyproject.toml)](#toml-merge-pyprojecttoml)
@@ -16,56 +16,83 @@ How to resolve conflicts produced by `copier update --conflict rej` for each fil
 
 ---
 
-## Why --conflict rej
+## Use the default inline merge, NOT --conflict rej
 
-`copier update` supports two conflict modes:
+**Do not pass `--conflict rej`. Use copier's default, which is a three-way inline merge.**
 
-| Mode | Behavior | AI suitability |
-|------|----------|----------------|
-| `--conflict inline` | Inserts `<<<<<<<`/`=======`/`>>>>>>>` markers into files | Harder to parse — markers interleave with file content |
-| `--conflict rej` | Applies the hunks that apply, writes the rest to `<file>.rej` | Easier to parse — the `.rej` is a plain diff, not markers interleaved with content |
+This file used to prescribe `--conflict rej` on the grounds that a `.rej` is easier for an
+assistant to parse than markers interleaved with content. That reasoning is about *reading*
+the outcome and ignores what the two modes do to the file. They are not two presentations of
+the same result. Measured on one repository, one release, the same commit, only the flag
+differing:
 
-Use `--conflict rej`. This produces:
-- The **local file** with every hunk that applied cleanly already written to it — *not* the
-  untouched original. `git apply --reject` is all-or-nothing per hunk, not per file.
-- A **`.rej` file** containing only the hunks that could not be applied.
+| | `--conflict rej` | default (inline) |
+|---|---|---|
+| `.rej` files | 5 | **0** |
+| digest-pinned `uses:` lines | 49 → **26** | 49 → **49** |
+| local `exclude:` block in `tests.yml` | **destroyed** | intact |
+| tracked files changed | 7 | **2** |
 
-That distinction is load-bearing. For a Tier 3 file, deleting the `.rej` does not restore
-the project's version: the hunks that applied are still there. Use
-`git checkout HEAD -- <file>` to undo them. Check with `git diff HEAD -- <file>` whenever a
-`.rej` exists — a non-empty diff means the file was partially updated.
+`--conflict rej` applies hunks with `git apply --reject`, which is all-or-nothing **per hunk**
+and has no knowledge of the merge base. A hunk carrying the template's change plus context
+lines the project has legitimately edited fails as a unit, and what lands is the template's
+version of everything that did apply. The inline mode performs a real three-way merge, so
+where base, local and template agree it simply keeps the agreement, and it only marks genuine
+divergence.
+
+The damage is not limited to things you would think to recount. In one repository the reject
+mode also replaced a live `Compat tests` pin set with the template's **disabled** placeholder,
+and dropped `lfs: true` from a checkout step. A digest recount would have reported those files
+clean.
+
+If an inline conflict does appear, it is a real one. Resolve it in place: the markers sit
+exactly where the two sides genuinely disagree, which is far less than `--conflict rej`
+rejects.
+
+### If you inherit a --conflict rej run
+
+The **local file** already contains every hunk that applied — *not* the untouched original.
+So deleting the `.rej` does not restore the project's version. Use
+`git checkout HEAD -- <file>` to undo them, and check with `git diff HEAD -- <file>` whenever
+a `.rej` exists: a non-empty diff means the file was partially updated. Better still, discard
+the whole run and redo it without the flag.
 
 ---
 
 ## Resolution by Tier
 
+With the default inline merge a conflict appears as `<<<<<<<` / `=======` / `>>>>>>>` markers
+**in the file**, at exactly the lines where the two sides genuinely disagree. There is no
+`.rej` to read. The tier rules below decide which side of each marker block to keep. Where
+this section says "the template's side", read the block between `=======` and `>>>>>>>`.
+
+Sweep for markers with `^(<<<<<<<|>>>>>>>|=======)( |$)` before committing. The anchored form
+without that trailing group misses `<<<<<<< HEAD` and `>>>>>>> theirs`.
+
 ### Tier 1 — Template-managed (template wins)
 
-1. Read the `.rej` file to understand what the template wanted
-2. Apply those changes to the local file (the template version is correct)
-3. Delete the `.rej` file
+1. Keep the template's side of every marker block.
+2. If the file updated with no conflict, it is already correct — no action.
 
-If copier updated the file without conflict (no `.rej`), the update is already correct — no action needed.
+Verify by diffing against a fresh `copier copy` at the same ref: a Tier 1 file should end
+byte-identical to the pristine render.
 
 ### Tier 2 — Merge-required (intelligent merge)
 
-1. Read the **local file** (current project state with customizations)
-2. Read the **`.rej` file** (what the template wanted to change)
-3. Understand the intent of BOTH:
+1. Read both sides of each marker block, and understand the intent of each:
     - Template change: bug fix? dependency bump? structural improvement? new feature?
     - Local state: custom content? extended functionality? project-specific additions?
-4. Apply template changes while preserving local additions (see file-type patterns below)
-5. Delete the `.rej` file
+2. Apply the template's change while preserving the local addition (see file-type patterns
+   below). Both sides usually want to survive; that is what makes it Tier 2.
 
-If copier updated a Tier 2 file without conflict (no `.rej`) BUT the file was classified as customized in Step 2:
-- The update may have **overwritten local customizations**
-- Compare the updated file against the baseline diff from Step 2
-- Restore any lost local additions
+If a Tier 2 file updated with **no** conflict but you classified it as customized, do not
+assume it was left alone. Take a whole-file pre/post diff and confirm the only changes are the
+template's intended ones.
 
 ### Tier 3 — Local-owned (local wins)
 
-1. If a `.rej` file exists: delete it (ignore template changes)
-2. If copier modified the file without conflict: restore from git with `git checkout HEAD -- <file>`
+1. Keep the local side of every marker block.
+2. If copier modified the file with no conflict, restore it: `git checkout HEAD -- <file>`.
 
 ---
 

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -23,9 +23,16 @@ build:
     # on sys.path (via the wheel's `dev-mode-dirs`) so the build loads the
     # `docs_build` markdown extensions by module name. `uv run` uses that venv.
     - asdf plugin add uv || true
+    # Both lines carry an annotation, and both must. Renovate's regex manager matches
+    # per annotated occurrence, so a single annotation covering only `asdf install`
+    # would bump that line and leave `asdf global` behind -- selecting a uv version
+    # that was never installed, which fails the docs build in every generated project.
+    # Nothing would flag it first: the pin scans are scoped to workflow files and this
+    # is not one, so the half-bumped state would ship and only surface on Read the Docs.
     # renovate: datasource=github-releases depName=astral-sh/uv
-    - asdf install uv 0.10.0
-    - asdf global uv 0.10.0
+    - asdf install uv 0.12.3
+    # renovate: datasource=github-releases depName=astral-sh/uv
+    - asdf global uv 0.12.3
     - uv sync --group docs
     # Generate the API pages and export the notebooks -- the explicit step that
     # replaced the deleted on_pre_build hook.

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1011,6 +1011,65 @@ def test_drain_workflow_advances_exactly_one_pull_request(copie_session_default)
     assert "renovate/" in run, "the drainer does not filter on the renovate/ branch prefix"
 
 
+def test_every_uv_pin_agrees_and_carries_its_own_annotation(copie_session_default):
+    """Every uv pin in the project is the same version, and each one is annotated.
+
+    Two failures, one test, because they are the same mistake seen from either end.
+
+    The existing pin scans quantify over **workflow files**, so `.readthedocs.yml` was
+    outside the set being measured. v0.44.0 moved the uv seed to 0.12.3 in five workflows
+    and left Read the Docs installing 0.10.0, and nothing failed: CI and the docs build
+    ran different uv versions in every generated project.
+
+    Worse, that file pinned uv on two lines under a single `# renovate:` annotation.
+    Renovate's regex manager matches per annotated occurrence, so the next bump would
+    have produced `asdf install uv <new>` followed by `asdf global uv <old>` -- selecting
+    a version that was never installed, breaking the docs build fleet-wide. It was armed
+    and unfired: the annotation had simply not been reached by a Renovate run yet.
+
+    So this asserts over the rendered project, not over a list of files someone
+    remembered to include, and it checks the property that actually matters -- agreement
+    -- rather than the presence of a pin.
+    """
+    project = copie_session_default.project_dir
+
+    pin = re.compile(r'(?:uv["\s]+|version:\s*")(\d+\.\d+\.\d+)')
+    annotation = "# renovate:"
+
+    found: dict[str, list[str]] = {}
+    unannotated: list[str] = []
+
+    for path in sorted(project.rglob("*")):
+        if not path.is_file() or ".git" in path.parts or path.suffix not in {".yml", ".yaml"}:
+            continue
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if "uv" not in line and "setup-uv" not in line:
+                continue
+            match = pin.search(line)
+            if not match:
+                continue
+            rel = f"{path.relative_to(project)}:{i + 1}"
+            found.setdefault(match.group(1), []).append(rel)
+            # The annotation must be on the immediately preceding line, which is where
+            # Renovate's regex looks. A comment three lines up reads fine and is invisible.
+            if annotation not in (lines[i - 1] if i else ""):
+                unannotated.append(rel)
+
+    assert found, (
+        "found no uv pins in the rendered project, so this test measures nothing. The pin "
+        "syntax changed or the scan is reading the wrong tree; fix the check, do not delete it"
+    )
+    assert len(found) == 1, (
+        "the project pins more than one uv version, so CI and the docs build do not run the "
+        f"same toolchain: { ({v: sorted(p)[:4] for v, p in found.items()}) }"
+    )
+    assert not unannotated, (
+        "uv pins with no `# renovate:` annotation on the line immediately above, so a bot "
+        f"bump moves the annotated ones and strands these: {unannotated}"
+    )
+
+
 def test_workflows_pin_uv_nox_and_git_cliff(copie_session_default):
     """uv, nox and git-cliff are pinned to exact versions, not floating "latest".
 


### PR DESCRIPTION
## Description

Two template bugs found by the v0.44.0 fan-out. Both are the same shape: a control that quantified over the wrong set, so neither ever failed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## 1. Read the Docs installed a different uv than CI, and was one bot-bump from breaking

`template/.readthedocs.yml.jinja` pinned uv on **two** lines under **one** `# renovate:` annotation:

```yaml
# renovate: datasource=github-releases depName=astral-sh/uv
- asdf install uv 0.10.0
- asdf global uv 0.10.0
```

Renovate's regex manager matches per annotated occurrence. Proven directly against the preset's own pattern:

```
matches: 1   (depName=astral-sh/uv currentValue=0.10.0)
total 'uv 0.10.0' occurrences in file: 2
```

So the next bump writes `asdf install uv <new>` followed by `asdf global uv <old>` — selecting a version that was never installed, which breaks the docs build in **every generated project**. It was armed and unfired only by timing: the file arrived in v0.43.1 at 07:26Z, after that morning's 05:00Z Renovate run.

Separately, v0.44.0 moved the five workflows to `0.12.3` and left this file on `0.10.0`, so CI and the docs build ran different uv versions fleet-wide.

**Neither was catchable by the existing checks.** `test_every_invoked_tool_in_this_repo_is_pinned_and_annotated` and its generated-side twin quantify over **workflow paths**, and `.readthedocs.yml` is not a workflow.

Both lines are now annotated and both are on `0.12.3`. `test_every_uv_pin_agrees_and_carries_its_own_annotation` asserts over the **whole rendered project** rather than a remembered file list, and checks the property that matters — that the versions *agree* — rather than that a pin exists. It aborts if it finds zero pins, so it cannot pass over an empty set.

## 2. The update skill prescribed a destructive flag

`update-from-template` told every project to run `copier update --conflict rej`. Measured on one repository, one release, the same commit, only the flag differing:

| | `--conflict rej` | default (inline) |
|---|---|---|
| `.rej` files | 5 | **0** |
| digest-pinned `uses:` | 49 → **26** | 49 → **49** |
| local `exclude:` block | **destroyed** | intact |
| tracked files changed | 7 | **2** |

`git apply --reject` is all-or-nothing **per hunk** and knows nothing of the merge base, so a hunk carrying the template's change plus context lines the project legitimately edited fails as a unit — and the template's version of everything that *did* apply lands.

The damage is not limited to what you would think to recount. In one repo the reject mode also **replaced a live `Compat tests` pin set with the template's disabled placeholder** and dropped `lfs: true` from a checkout step. A digest recount reports those files clean.

The skill now prescribes the default three-way merge. The tier-resolution instructions are rewritten for inline markers instead of `.rej` files, with the inherited-`rej`-run recovery kept for anyone mid-flight, so the document is not left internally inconsistent.

## How Has This Been Tested?

- [x] Tested locally with `uv run pytest` — **470 passed**
- [x] Added/updated tests
- [x] All tests pass

The new test was falsified on scratch copies against **both** failure modes:

- original bug restored → fails naming `.readthedocs.yml:34` as unannotated
- half-bumped state → fails naming `0.12.3` and `0.10.0` as disagreeing

and passes when restored. `.claude/skills/` and `.github/skills/` under `template/` are byte-identical.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings
- [x] I have checked that my changes don't break the template generation

## Additional Notes

Held for review.

Credit where due: the uv/RTD mismatch was reported independently by the sklearn-optuna and yohou-optuna fan-out agents, and the `--conflict rej` difference was isolated by the yohou-nixtla agent, which ran both modes on the same clone rather than accepting either outcome.

**Not fixed here:** the six already-open v0.44.0 fan-out PRs were produced under mixed modes. I verified sklearn-wrap's (#107) landed a clean 3-file delta despite using the reject mode, and yohou-optuna's (#78) classified every changed line before resolving. yohou is being redone with the inline merge after its earlier attempt found real losses.